### PR TITLE
[auto-maintainer] fix: PORT env var ignored + readBody callback fires after 413

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ const BASE_DIR = path.join(__dirname, "..");
 
 const args = process.argv.slice(2);
 const portIdx = args.indexOf("--port");
-const PORT = portIdx >= 0 ? parseInt(args[portIdx + 1]) || 8888 : 8888;
+const PORT = parseInt(process.env.PORT || (portIdx >= 0 ? args[portIdx + 1] : '')) || 8888;
 const musicIdx = args.indexOf("--music-dir");
 
 let MUSIC_DIR = musicIdx >= 0

--- a/server/utils.js
+++ b/server/utils.js
@@ -68,12 +68,20 @@ function getSPA(spaPath) {
 function readBody(req, res, callback) {
   let body = "";
   let size = 0;
+  let rejected = false;
   req.on("data", d => {
+    if (rejected) return;
     size += d.length;
-    if (size > MAX_BODY) { req.destroy(); res.writeHead(413); res.end("Payload too large"); return; }
+    if (size > MAX_BODY) {
+      rejected = true;
+      req.destroy();
+      res.writeHead(413);
+      res.end("Payload too large");
+      return;
+    }
     body += d;
   });
-  req.on("end", () => callback(body));
+  req.on("end", () => { if (!rejected) callback(body); });
 }
 
 // ── Fuzzy audio file matching ──────────────────────────────


### PR DESCRIPTION
## What changed

Two defensive bug fixes in two files; no behaviour change on the happy path.

### Fix 1 — `server/index.js`: `PORT` env var completely ignored (line 52)

**Before:**
```js
const PORT = portIdx >= 0 ? parseInt(args[portIdx + 1]) || 8888 : 8888;
```

**After:**
```js
const PORT = parseInt(process.env.PORT || (portIdx >= 0 ? args[portIdx + 1] : '')) || 8888;
```

`process.env.PORT` was never consulted. Every other configurable port in this file (`ICECAST_PORT`, `NATS_PORT`, `OBSERVATORY_PORT`) is read from the environment; the main server port was the lone exception. Running `PORT=3000 node server/index.js` silently started the server on 8888 instead of 3000.

Resolution priority is now: `PORT` env var → `--port` flag → default `8888`.

---

### Fix 2 — `server/utils.js` `readBody`: callback invoked after 413 is sent

**Before:**
```js
function readBody(req, res, callback) {
  let body = "";
  let size = 0;
  req.on("data", d => {
    size += d.length;
    if (size > MAX_BODY) { req.destroy(); res.writeHead(413); res.end("Payload too large"); return; }
    body += d;
  });
  req.on("end", () => callback(body));
}
```

**After** (abbreviated):
```js
  let rejected = false;
  req.on("data", d => {
    if (rejected) return;
    size += d.length;
    if (size > MAX_BODY) {
      rejected = true;
      req.destroy(); res.writeHead(413); res.end("Payload too large");
      return;
    }
    body += d;
  });
  req.on("end", () => { if (!rejected) callback(body); });
```

`MAX_BODY` is 64 KB. When a request body exceeds that limit, `req.destroy()` is called and the 413 response is sent. However, Node.js can still emit `"end"` on the request after `destroy()` returns (the socket teardown is async). The previous code called `callback(body)` unconditionally on `"end"`, so any route handler that then attempted `res.writeHead` or `res.end` threw **"ERR_HTTP_HEADERS_SENT / Cannot set headers after they are sent to the client"**.

The `rejected` flag gates the `"end"` handler so the callback is never called once the oversized-body path has fired.

## Why it's safe

- Fix 1: no code path changes on the happy path; `process.env.PORT` simply wasn't checked before. The fallback chain (env → flag → default) is the conventional Node.js ordering.
- Fix 2: the callback is only suppressed when the 413 response has already been sent. Normal requests (body ≤ 64 KB) are unaffected — `rejected` stays `false`, `"end"` calls `callback(body)` exactly as before.

## Verification

```
npm test   ✓  all 55+ assertions pass across 7 test files (same as baseline)
git diff --stat   2 files changed, 11 insertions(+), 3 deletions(-)
```

No test script exercises the >64 KB body path, so the readBody fix was verified by code review only — the invariant is straightforward (flag prevents double-response).

## Runtime

~22 minutes wall-clock (jitter + in-flight check + repo survey + fix + test + PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_0152qNEj3KrgQUtQdcYbFvmB)_