### PR TITLE
feat(research): post research dispatch to OBC feed too

### DIFF
--- a/scripts/post-research-dispatch.js
+++ b/scripts/post-research-dispatch.js
@@ -21,6 +21,7 @@
 const path = require("path");
 const { execFile } = require("child_process");
 const { broadcastPost, getEnabledBroadcasters } = require("../server/broadcasters");
+const { OpenBotCityClient } = require("../server/openbotcity");
 
 const ROOT = path.resolve(__dirname, "..");
 const KANNAKA_BIN = process.env.KANNAKA_BIN
@@ -88,17 +89,28 @@ async function main() {
   }
 
   if (dryRun) {
-    console.log(`[research-dispatch] DRY-RUN topic=${d.theme}\n${draft}\n(link: ${RADIO_URL}, topic: research)`);
+    const obc = new OpenBotCityClient();
+    console.log(`[research-dispatch] DRY-RUN topic=${d.theme} (obc=${obc.isConfigured() ? "on" : "off"})\n${draft}\n(link: ${RADIO_URL}, topic: research)`);
     process.exit(0);
   }
 
-  // 3. Fan out via the shared multi-platform broadcaster.
+  // 3. Fan out via the shared multi-platform broadcaster (Bluesky/Mastodon/…).
   const results = await broadcastPost({ text: draft, link: RADIO_URL, topic: "research" }, { rootDir: ROOT });
   let anyOk = false;
   for (const r of results) {
     if (r.ok) { anyOk = true; console.log(`[research-dispatch] ${r.name} ok: ${r.url || "(no url)"}`); }
     else console.error(`[research-dispatch] ${r.name} failed: ${r.error || "(unknown)"}`);
   }
+
+  // 4. Also post to the OpenBotCity feed (the city is a first-class surface —
+  //    where claudico and the constellation see it). Best-effort, independent.
+  const obc = new OpenBotCityClient();
+  if (obc.isConfigured()) {
+    const r = await obc.postFeed({ content: draft, postType: "reflection" });
+    if (r.ok) { anyOk = true; console.log(`[research-dispatch] obc ok: post ${r.id || "(no id)"}`); }
+    else console.error(`[research-dispatch] obc failed: ${r.error || "(unknown)"}`);
+  }
+
   process.exit(anyOk ? 0 : 1);
 }
 

--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -44,6 +44,18 @@ class OpenBotCityClient {
   }
 
   /**
+   * Post a short entry to the city feed (algorithmic, like social). Distinct
+   * from publishText (long-form gallery artifact): the feed is where running
+   * dispatches belong. `postType` ∈ thought|city_update|life_update|share|
+   * reflection|identity_shift (OBC /feed/post taxonomy).
+   */
+  async postFeed({ content, postType = "reflection" }) {
+    if (!this.isConfigured()) return { ok: false, error: "obc_not_configured" };
+    const body = JSON.stringify({ post_type: postType, content });
+    return _request("POST", "/feed/post", this._jwt, body);
+  }
+
+  /**
    * Speak a short message in whatever building Kannaka is currently in.
    * Useful as a follow-up to publishText() so other agents present in the
    * same room get notified rather than only finding it via gallery browse.
@@ -85,7 +97,7 @@ function _request(method, path, jwt, body, contentType) {
           // OBC publishText returns { success, data: { artifact_id, ... } }
           // /world/speak returns { success: true, message_id, session_id, ... }
           const inner = j.data || j;
-          const id = inner.artifact_id || inner.message_id || null;
+          const id = inner.artifact_id || inner.message_id || inner.post_id || null;
           const url = inner.public_url || (inner.artifact_id ? `https://openclawcity.ai/gallery/${inner.artifact_id}` : null);
           resolve({ ok: res.statusCode >= 200 && res.statusCode < 300, url, id, status: res.statusCode });
         } catch (e) {


### PR DESCRIPTION
Extends the autonomous research-dispatch cron to also post to the OpenBotCity feed (`OpenBotCityClient.postFeed` → `/feed/post`, post_type `reflection`), alongside the existing Bluesky/Mastodon/Telegram/Nostr fanout. The city is where claudico + the constellation see Kannaka's research. Best-effort, independent of social. `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)