### PR TITLE
feat(research): research-from-city — external-signal-driven research loop

### DIFF
--- a/scripts/research-from-city.js
+++ b/scripts/research-from-city.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * research-from-city.js — external-signal-driven research (the partnership loop).
+ *
+ * Senses what the OpenBotCity constellation is curious about (recent feed),
+ * distils ONE research question from it, grounds that question in real
+ * literature (`kannaka research --ingest`, dedupe-safe), and reports back a
+ * grounded finding to the city feed + social. This is the half of the divergence
+ * where the city steers what Kannaka studies — not just internal gap-rotation.
+ *
+ * Usage: research-from-city.js [--dry-run]
+ * Soft-skips (exit 0) when the feed is empty / OBC unconfigured / no broadcasters.
+ */
+
+"use strict";
+
+const path = require("path");
+const { execFile } = require("child_process");
+const { broadcastPost, getEnabledBroadcasters } = require("../server/broadcasters");
+const { OpenBotCityClient } = require("../server/openbotcity");
+
+const ROOT = path.resolve(__dirname, "..");
+const KANNAKA_BIN = process.env.KANNAKA_BIN
+  || "/home/opc/kannaka-memory/target/release/kannaka";
+const RADIO_URL = process.env.RADIO_PUBLIC_URL || "https://radio.ninja-portal.com";
+const dryRun = process.argv.includes("--dry-run");
+
+function runKannaka(cliArgs, timeout = 60000) {
+  return new Promise((resolve) => {
+    execFile(KANNAKA_BIN, cliArgs, {
+      timeout, maxBuffer: 1024 * 1024,
+      env: { ...process.env, KANNAKA_QUIET: "1" },
+    }, (err, stdout) => resolve(err ? null : (stdout || "").trim()));
+  });
+}
+
+// A search query is short; strip quotes/punctuation/preamble the LLM may add.
+function cleanQuery(s) {
+  if (!s) return "";
+  let q = s.split("\n")[0].replace(/^["'`]+|["'`]+$/g, "").trim();
+  q = q.replace(/^(query|topic|research)\s*[:\-]\s*/i, "").trim();
+  return q.split(/\s+/).slice(0, 8).join(" ");
+}
+
+async function main() {
+  const obc = new OpenBotCityClient();
+  if (!obc.isConfigured()) {
+    console.error("[city-research] OBC not configured — skipping");
+    process.exit(0);
+  }
+
+  // 1. Sense: what is the city talking about?
+  const posts = await obc.getFeed(15);
+  if (posts.length === 0) {
+    console.error("[city-research] empty feed — skipping");
+    process.exit(0);
+  }
+  const corpus = posts.map((p) => `- ${p.author}: ${p.content}`).join("\n").slice(0, 3000);
+
+  // 2. Distil ONE research question the city seems curious about.
+  const topicPrompt = [
+    "These are recent posts from the OpenBotCity agent constellation:",
+    corpus,
+    "",
+    "Name ONE specific research topic Kannaka should investigate next that this",
+    "conversation is circling — something answerable from the scholarly record.",
+    "Output ONLY a 3-7 word search query. No quotes, no preamble.",
+  ].join("\n");
+  const topic = cleanQuery(await runKannaka(["ask", "--no-tools", "--quiet-tools", topicPrompt], 300000));
+  if (!topic) {
+    console.error("[city-research] could not distil a topic — skipping");
+    process.exit(0);
+  }
+  console.log(`[city-research] city-curiosity topic: ${topic}`);
+
+  // 3. Ground it: ingest real literature (dedupe-safe).
+  if (!dryRun) {
+    const ing = await runKannaka(["research", topic, "--limit", "5", "--since", "2010", "--ingest"], 120000);
+    console.log(`[city-research] ${ing ? ing.split("\n").pop() : "ingest skipped"}`);
+  }
+
+  // 4. Grounded finding on that topic.
+  const dispatchRaw = await runKannaka(["dispatch", "--topic", topic, "--json"]);
+  let d = null;
+  try { d = dispatchRaw ? JSON.parse(dispatchRaw) : null; } catch { d = null; }
+  if (!d || !d.title) {
+    console.error("[city-research] no grounding for topic after ingest — skipping post");
+    process.exit(0);
+  }
+
+  // 5. Compose a city-aware reply (grounded fallback = raw dispatch line).
+  const prompt = [
+    "You are Kannaka. The city has been circling a question, so you went and read about it.",
+    `City topic: ${topic}`,
+    `Paper you found: "${d.title}"${d.year ? ` (${d.year})` : ""}${d.citations ? `, ${d.citations}× cited` : ""}`,
+    d.text ? `Your grounded line: ${d.text}` : "",
+    "",
+    "Draft a SINGLE feed post (max 280 chars) sharing what you found, FOR the city —",
+    "first person, a gift back to the conversation, not a lecture. No hashtags.",
+    "Output ONLY the post text.",
+  ].filter(Boolean).join("\n");
+  let draft = await runKannaka(["ask", "--no-tools", "--quiet-tools", prompt], 300000);
+  if (draft) draft = draft.replace(/^["'](.*)["']$/s, "$1").trim();
+  if (!draft) draft = d.text;
+  if (!draft) { console.error("[city-research] empty compose — aborting"); process.exit(1); }
+
+  if (dryRun) {
+    console.log(`[city-research] DRY-RUN\n${draft}`);
+    process.exit(0);
+  }
+
+  // 6. Report back: OBC feed (the city that asked) + social fanout.
+  let anyOk = false;
+  const r = await obc.postFeed({ content: draft, postType: "reflection" });
+  if (r.ok) { anyOk = true; console.log(`[city-research] obc ok: post ${r.id || "(no id)"}`); }
+  else console.error(`[city-research] obc failed: ${r.error || "(unknown)"}`);
+
+  if (getEnabledBroadcasters(ROOT).length > 0) {
+    const results = await broadcastPost({ text: draft, link: RADIO_URL, topic: "research" }, { rootDir: ROOT });
+    for (const x of results) {
+      if (x.ok) { anyOk = true; console.log(`[city-research] ${x.name} ok`); }
+      else console.error(`[city-research] ${x.name} failed: ${x.error || "?"}`);
+    }
+  }
+  process.exit(anyOk ? 0 : 1);
+}
+
+main().catch((e) => { console.error("[city-research] fatal:", e); process.exit(1); });

--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -56,6 +56,23 @@ class OpenBotCityClient {
   }
 
   /**
+   * Read recent feed posts Kannaka follows — the city's running conversation.
+   * Returns an array of { author, content } (best-effort; [] on any failure)
+   * so callers can sense what the constellation is curious about and steer
+   * research accordingly.
+   */
+  async getFeed(limit = 15) {
+    if (!this.isConfigured()) return [];
+    const j = await _getJson(`/feed/following?limit=${limit}`, this._jwt);
+    const posts = (j && (j.data?.posts || j.posts || j.data || [])) || [];
+    if (!Array.isArray(posts)) return [];
+    return posts.map((p) => ({
+      author: p.author_name || p.author || p.bot_slug || p.agent_id || "?",
+      content: (p.content || p.text || "").toString(),
+    })).filter((p) => p.content.trim());
+  }
+
+  /**
    * Speak a short message in whatever building Kannaka is currently in.
    * Useful as a follow-up to publishText() so other agents present in the
    * same room get notified rather than only finding it via gallery browse.
@@ -108,6 +125,35 @@ function _request(method, path, jwt, body, contentType) {
     req.on("error", (e) => resolve({ ok: false, error: e.message }));
     req.on("timeout", () => { req.destroy(new Error("obc timeout")); });
     if (body !== undefined && body !== null) req.write(body);
+    req.end();
+  });
+}
+
+/** GET a JSON body from OBC. Resolves null on any failure (read paths are
+ *  best-effort — a sensing step should never throw the caller). Sends a real
+ *  User-Agent to dodge Cloudflare's Browser Integrity Check (error 1010). */
+function _getJson(path, jwt) {
+  const opts = {
+    method: "GET",
+    hostname: OBC_HOST,
+    port: 443,
+    path,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "User-Agent": "KannakaBot/1.0 (+https://github.com/NickFlach/kannaka-radio)",
+    },
+    timeout: 30000,
+  };
+  return new Promise((resolve) => {
+    const req = https.request(opts, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        try { resolve(JSON.parse(data)); } catch { resolve(null); }
+      });
+    });
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => { req.destroy(new Error("obc timeout")); resolve(null); });
     req.end();
   });
 }


### PR DESCRIPTION
The partnership half of the divergence — the **city steers what Kannaka studies**.

Senses the OBC feed → distils ONE research question the constellation is circling (`kannaka ask`) → grounds it in real literature (`kannaka research --ingest`, dedupe-safe) → reports a grounded finding back to the OBC feed + social fanout.

- `openbotcity.js`: new `getFeed(limit)` read method + `_getJson` helper (best-effort; real User-Agent to dodge Cloudflare's 1010 integrity check).
- `scripts/research-from-city.js`: sense → distil topic → ingest → dispatch → compose city-aware reply → post. Soft-skips on empty feed / unconfigured OBC.

Complements the internal **gap-driven** refresh (`research-suggest`): that researches what we know least; this researches what the city is curious about. `node --check` clean; dry-run validates the feed-read + topic-distil path before scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)