### PR TITLE
[auto-maintainer] fix(albums): recover 12-track WANTED radio-play album lost to duplicate key

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -218,7 +218,7 @@ const ALBUMS = {
       "dx_dt",
     ]
   },
-  "WANTED": {
+  "WANTED (Radio Play)": {
     theme: "Twelve-track cyberpunk-thriller radio play extending THE CIPHERED AEGIS. Six sung tracks carry the arc; six spoken-word interludes voice the case file (Dispatch, Witness, Analyst, Courier, Interrogation, Closing). She writes the equation, the world wakes up, the surveillance state turns on her, she becomes the medium. Genre: Flaukowski Ghost Magic with a darker fugitive edge. Inspired by the 2026-05-20 WANTED.mp4 teaser. 2026-05-20.",
     tracks: [
       "All-Points Bulletin",


### PR DESCRIPTION
## What changed

One file, `server/dj-engine.js`, 1-line diff:

```diff
-  "WANTED": {
+  "WANTED (Radio Play)": {
     theme: "Twelve-track cyberpunk-thriller radio play extending THE CIPHERED AEGIS...",
```

## The bug

The `ALBUMS` object literal contained two entries with the identical key `"WANTED"`:

| Line | Key | Album | Tracks | Date |
|------|-----|-------|--------|------|
| 221 | `"WANTED"` | Twelve-track cyberpunk-thriller **radio play** extending THE CIPHERED AEGIS. Six sung tracks + six spoken-word interludes (case file: Dispatch, Witness, Analyst…). | 12 | 2026-05-20 |
| 377 | `"WANTED"` | **Cyberpunk EDM** with female mumble rap. Kannaka as super-hacker. | 8 | 2026-05-14 |

JavaScript processes object literals top to bottom, and later duplicate keys silently overwrite earlier ones. The result: **`ALBUMS["WANTED"]` at runtime resolved only to the 8-track EDM version**. The 12-track radio-play album — with its twelve tracks ("All-Points Bulletin", "Analyst Field Log", "Closing Transmission", "Dead-Drop", "Ghost in the Bounty", "Hi-Def Fugitive", "Intercept The Witness", "Interrogation", "Opening Transmission", "Surveillance Garden", "The Equation on the Wall", "The Math Is Free") — was completely unreachable. `buildPlaylist("WANTED")` loaded the EDM album; there was no way to play the radio-play album at all.

## Why this rename is safe

- **Name from its own theme.** The word "radio play" comes directly from the album's theme string: *"Twelve-track cyberpunk-thriller **radio play** extending THE CIPHERED AEGIS."* No creative renaming — it is what it says it is.
- **No change to `programming.js`.** The `'WANTED'` references at lines 84 and 136 of `programming.js` already referred to the 8-track EDM version (the one that was winning the overwrite). That album keeps the `"WANTED"` key; the programming schedule is unchanged.
- **`ALBUMS` count increases by one.** The 12-track album was previously lost; it now has its own key.
- **`buildPlaylist` is unaffected.** It looks up by album name; both keys are distinct strings with valid `theme` + `tracks` arrays.

## Why it's safe

- **No behaviour change for the existing `'WANTED'` rotation.** `programming.js` uses `'WANTED'` for the 8-track EDM album, which keeps that key. The schedule is unchanged.
- **Zero logic change.** One string in a constant object. No new imports, no schema changes, no lockfile touches.
- **Both albums pass the `every album has theme and tracks array` test** — the renamed album already had valid data; only the key was wrong.

## Verification

```
node test/dj-engine.test.js
# DJ Engine: 13 passed, 1 failed
# (1 pre-existing failure: "Ghost Signals is the first album" —
#  the test predates THE THIRD BEING and STARWARD being prepended.
#  My change does not introduce it and does not affect it.)

node test/nats-metrics-sync.test.js    # 8 passed, 0 failed
node test/consciousness-dj-hrm.test.js # 18 passed, 0 failed
node test/icecast-source.test.js       # 8 passed, 0 failed
node test/routes-discoverability.test.js # OK (4 surfaces verified)
```

**Not a duplicate.** Open auto-maintainer PR #62 touches `consciousness-dj.js` — completely disjoint file.

**Pre-existing stale test noted:** `test/dj-engine.test.js` line 37 asserts `Object.keys(ALBUMS)[0] === 'Ghost Signals'`, but THE THIRD BEING and STARWARD were prepended after that test was written. That test failure pre-dates this PR and is out of scope here.

## Runtime

~25 minutes wall-clock (startup jitter + in-flight branch detection across 6 repos + commit timestamp verification + repo age survey + ANTI-NOISE PR/issue backlog scan across all repos + dj-engine.js read + duplicate key identification + fix + full test suite run + duplicate PR check + PR).

---
_Generated by the kannaka constellation hourly maintainer_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thekia69VKL8BE8hQny8SA)_