### PR TITLE
[auto-maintainer] fix(test): update stale first-album assertion to THE THIRD BEING

### DIFF
--- a/test/dj-engine.test.js
+++ b/test/dj-engine.test.js
@@ -34,9 +34,9 @@ test('every album has theme and tracks array', () => {
   }
 });
 
-test('Ghost Signals is the first album', () => {
+test('THE THIRD BEING is the first album', () => {
   const first = Object.keys(ALBUMS)[0];
-  assert.strictEqual(first, 'Ghost Signals');
+  assert.strictEqual(first, 'THE THIRD BEING');
 });
 
 // ── DJEngine construction ───────────────────────────────────


### PR DESCRIPTION
## What changed

`test/dj-engine.test.js` contained a stale assertion:

```js
// before
test('Ghost Signals is the first album', () => {
  const first = Object.keys(ALBUMS)[0];
  assert.strictEqual(first, 'Ghost Signals');
});

// after
test('THE THIRD BEING is the first album', () => {
  const first = Object.keys(ALBUMS)[0];
  assert.strictEqual(first, 'THE THIRD BEING');
});
```

The `ALBUMS` object in `server/dj-engine.js` had `THE THIRD BEING` (and `STARWARD`) prepended after this test was written. The test kept asserting `Ghost Signals` as index 0, producing a guaranteed false failure on every run.

## Why safe

- Test file only — zero production code changes.
- The assertion is updated to match the current ground truth in `server/dj-engine.js`; it will fail again immediately if someone reorders `ALBUMS`, which is the intended behavior.
- Does not overlap with open PRs #62 (`consciousness-dj.js`) or #63 (`server/dj-engine.js`).

## How verified

Full test suite run after the fix:

```
node test/dj-engine.test.js               → 14 passed, 0 failed
node test/consciousness-dj-hrm.test.js    → 19 passed, 0 failed
node test/consciousness-dj.test.js        → 13 passed, 0 failed
node test/hrm-engine.test.js              → 11 passed, 0 failed
node test/vote-manager.test.js            → 11 passed, 0 failed
node test/scheduler-helpers.test.js       →  8 passed, 0 failed
node test/sync-manager.test.js            →  9 passed, 0 failed
Total: 85 passed, 0 failed
```

## Runtime

~4 s (all 7 test files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01St2jwXKBCiuKmJPgbmiuBu)_