### PR TITLE
[auto-maintainer] fix(scheduler-helpers): add res.on(close) handlers to all four HTTP fetchers

### DIFF
--- a/server/lib/scheduler-helpers.js
+++ b/server/lib/scheduler-helpers.js
@@ -110,6 +110,7 @@ function fetchKnowledgeGeneInterpretation() {
             resolve(null);
           }
         });
+        res.on("close", () => resolve(null));
       })
       .on("error", () => resolve(null))
       .on("timeout", () => resolve(null));
@@ -137,6 +138,7 @@ function _fetchJson(url, timeoutMs) {
           try { resolve(JSON.parse(Buffer.concat(chunks).toString("utf8"))); }
           catch { resolve(null); }
         });
+        res.on("close", () => resolve(null));
       })
       .on("error", () => resolve(null))
       .on("timeout", () => resolve(null));
@@ -236,6 +238,7 @@ function _fetchText(url, timeoutMs) {
           const chunks = [];
           res.on("data", (c) => chunks.push(c));
           res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+          res.on("close", () => resolve(null));
         })
         .on("error", () => resolve(null))
         .on("timeout", () => resolve(null));
@@ -540,6 +543,7 @@ function composeViaAnthropicDirect(prompt, opts = {}) {
         console.warn(`   [${opts.label || "direct"}] anthropic ${res.statusCode} (${model})${notFound ? " — trying next model" : ""}: ${chunks.slice(0, 160)}`);
         resolve({ text: null, notFound });
       });
+      res.on("close", () => resolve({ text: null }));
     });
     req.on("error", () => resolve({ text: null }));
     req.setTimeout(180000, () => req.destroy(new Error("timeout")));


### PR DESCRIPTION
## What changed

`fetchKnowledgeGeneInterpretation`, `_fetchJson`, `_fetchText`, and `composeViaAnthropicDirect` in `server/lib/scheduler-helpers.js` all buffer response data into an `end` handler but had no `close` handler on the response.

When the remote server gracefully closes the TCP connection mid-body (network flap, Icecast restart, Anthropic API issue), the `IncomingMessage` emits `'close'` but **not** `'end'`, leaving the Promise pending until the request idle-timeout fires:

| Function | Idle timeout | Hang per mid-body drop |
|---|---|---|
| `fetchKnowledgeGeneInterpretation` | 15 s | 15 s |
| `_fetchJson` | 8 s | 8 s per call — used by USGS earthquakes, NASA EONET, NOAA SWPC, USGS water (up to 4+ calls per news tick) |
| `_fetchText` | 8 s | 8 s per call — used by Smithsonian volcanoes, arXiv, NDBC buoys (3 station loop) |
| `composeViaAnthropicDirect` | 180 s | up to 180 s per model attempt (3 candidates = 9 minutes max hang) |

The `composeViaAnthropicDirect` case is the most painful: it's the fallback path that keeps gossip/news/peace-oration on the air when `kannaka ask` fails. A dropped mid-body Anthropic response could stall the entire composition path for up to 9 minutes.

## Fix

One `res.on("close", () => resolve(null))` per site (four lines total). `Promise.resolve()` is idempotent — if `end` fires first on the happy path, the subsequent `close` resolve is a silent no-op. On a premature connection drop, `close` fires immediately and settles the Promise rather than waiting for the idle timeout.

This is the same pattern as:
- PR #29 (kannaka-staff: `probeHttpJson`/`probeJson` close handlers)
- PR #73 (this repo's `flux-publisher._send`)

## Why it's safe

- No logic change in normal operation — all four code paths were already correct when the server delivers a full response
- `resolve()` is idempotent — double-calling it is a documented no-op in the Promises/A+ spec
- 1 file changed, 4 insertions, 0 deletions

## Verification

```
node --check server/lib/scheduler-helpers.js
# → Syntax OK

npm test
# → 75 tests pass across all 7 test files:
#   test-queensync-dj, perception, dj-engine, nats-metrics-sync,
#   consciousness-dj-hrm, icecast-source, routes-discoverability
```

## Runtime

~15 minutes wall-clock.

---
_Generated by the kannaka constellation hourly maintainer_

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9befQr6gvVxyckk7KEQAs)_