### PR TITLE
harden: fix 14 verified crash/leak/correctness bugs across the radio server

### DIFF
--- a/server/agent-endpoint.js
+++ b/server/agent-endpoint.js
@@ -263,6 +263,14 @@ async function handleAgentRequest(req, res, parsed) {
       release();
       try { res.end(); } catch (_) {}
     });
+    // A failed spawn (e.g. KANNAKA_BIN missing → ENOENT) emits 'error' and may
+    // never emit 'exit'. Without this listener that 'error' is unhandled and
+    // crashes the whole process, AND release() never runs — so the slot leaks
+    // and after RADIO_AUDIT_MAX failed spawns the endpoint is wedged at 503.
+    child.on("error", () => {
+      release();
+      try { res.end(); } catch (_) {}
+    });
     return true;
   }
 

--- a/server/bluesky.js
+++ b/server/bluesky.js
@@ -65,9 +65,18 @@ class BlueskyClient {
     try {
       const session = await this._ensureSession();
       const path = `/xrpc/app.bsky.feed.searchPosts?q=${encodeURIComponent(query)}&limit=${limit}&sort=latest`;
-      const resp = await _request("GET", path, null, {
+      let resp = await _request("GET", path, null, {
         "Authorization": "Bearer " + session.accessJwt,
       });
+      if (resp.status === 401 || resp.status === 400) {
+        // AT Proto access tokens are short-lived. _ensureSession caches the
+        // session forever once set, so without this reauth a long-running
+        // process would 401 here indefinitely and the reply-listener would
+        // silently stop finding posts until restart. Clear + retry once.
+        this.session = null;
+        const s2 = await this._ensureSession();
+        resp = await _request("GET", path, null, { "Authorization": "Bearer " + s2.accessJwt });
+      }
       if (resp.status !== 200) return { ok: false, error: `searchPosts ${resp.status}: ${resp.body.slice(0, 200)}` };
       const data = JSON.parse(resp.body);
       return { ok: true, posts: data.posts || [] };
@@ -93,15 +102,29 @@ class BlueskyClient {
         reply: { root, parent },
       };
       if (facets.length > 0) record.facets = facets;
-      const body = JSON.stringify({
-        repo: session.did,
+      let activeSession = session;
+      let body = JSON.stringify({
+        repo: activeSession.did,
         collection: "app.bsky.feed.post",
         record,
       });
-      const resp = await _request("POST", "/xrpc/com.atproto.repo.createRecord", body, {
+      let resp = await _request("POST", "/xrpc/com.atproto.repo.createRecord", body, {
         "Content-Type": "application/json",
-        "Authorization": "Bearer " + session.accessJwt,
+        "Authorization": "Bearer " + activeSession.accessJwt,
       });
+      if (resp.status === 401 || resp.status === 400) {
+        // Expired access token — clear the cached session, re-auth, retry once
+        // (post() already does this; reply() previously did not, so replies
+        // wedged silently once the token aged out). Rebuild the body with the
+        // fresh did in case it differs.
+        this.session = null;
+        activeSession = await this._ensureSession();
+        body = JSON.stringify({ repo: activeSession.did, collection: "app.bsky.feed.post", record });
+        resp = await _request("POST", "/xrpc/com.atproto.repo.createRecord", body, {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer " + activeSession.accessJwt,
+        });
+      }
       if (resp.status !== 200) return { ok: false, error: `reply ${resp.status}: ${resp.body.slice(0, 200)}` };
       const data = JSON.parse(resp.body);
       return { ok: true, uri: data.uri, cid: data.cid };

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -424,6 +424,22 @@ class GhostSignalsHub {
    * had the higher final price. Called by the resolver loop.
    */
   async _resolveExpiredMarkets() {
+    // Re-entrancy guard. The 10s resolver interval does NOT await the previous
+    // run, so a slow sweep (many expired markets / payouts overrunning 10s)
+    // would overlap the next tick — which re-SELECTs the same still
+    // `resolved = 0` rows (resolveMarket is async, spanning event-loop turns)
+    // and pays out every winning position a SECOND time, corrupting the ledger.
+    // Skip if a sweep is already in flight.
+    if (this._resolving) return;
+    this._resolving = true;
+    try {
+      return await this._resolveExpiredMarketsInner();
+    } finally {
+      this._resolving = false;
+    }
+  }
+
+  async _resolveExpiredMarketsInner() {
     return new Promise((resolve) => {
       // expires_at is stored as ISO-8601 from `new Date().toISOString()`
       // (e.g. "2026-05-22T14:00:00.000Z"). datetime('now') returns

--- a/server/index.js
+++ b/server/index.js
@@ -733,11 +733,13 @@ wss.on('connection', (ws) => {
       else if (parsed.type === 'webrtc_release_mic') {
         const result = webrtcSignaling.releaseMic(parsed.clientId);
         broadcast({ type: 'webrtc_broadcast_ended', data: {} });
-        if (result && result.nextUp) {
-          result.nextUp.ws.send(JSON.stringify({
-            type: 'webrtc_mic_available',
-            data: { message: 'Your turn to broadcast!' },
-          }));
+        if (result && result.nextUp && result.nextUp.ws && result.nextUp.ws.readyState === 1) {
+          try {
+            result.nextUp.ws.send(JSON.stringify({
+              type: 'webrtc_mic_available',
+              data: { message: 'Your turn to broadcast!' },
+            }));
+          } catch (_) {}
         }
         broadcast({ type: 'webrtc_status', data: webrtcSignaling.getStatus() });
       }
@@ -765,11 +767,14 @@ wss.on('connection', (ws) => {
       else if (parsed.type === 'webrtc_listen') {
         webrtcSignaling.addListener(ws, parsed.clientId);
         // Tell the broadcaster a new listener joined so it can create an offer
-        if (webrtcSignaling.broadcaster) {
-          webrtcSignaling.broadcaster.ws.send(JSON.stringify({
-            type: 'webrtc_new_listener',
-            clientId: parsed.clientId,
-          }));
+        if (webrtcSignaling.broadcaster && webrtcSignaling.broadcaster.ws
+            && webrtcSignaling.broadcaster.ws.readyState === 1) {
+          try {
+            webrtcSignaling.broadcaster.ws.send(JSON.stringify({
+              type: 'webrtc_new_listener',
+              clientId: parsed.clientId,
+            }));
+          } catch (_) {}
         }
         broadcast({ type: 'webrtc_status', data: webrtcSignaling.getStatus() });
       }
@@ -789,11 +794,18 @@ wss.on('connection', (ws) => {
     const rtcResult = webrtcSignaling.handleDisconnect(ws);
     if (rtcResult) {
       broadcast({ type: 'webrtc_broadcast_ended', data: {} });
-      if (rtcResult.nextUp) {
-        rtcResult.nextUp.ws.send(JSON.stringify({
-          type: 'webrtc_mic_available',
-          data: { message: 'Your turn to broadcast!' },
-        }));
+      // The promoted nextUp socket may itself be CLOSING/CLOSED (e.g. both
+      // peers dropped on a flaky connection). send() on a non-open socket
+      // throws "WebSocket is not open", and this is the 'close' handler — NOT
+      // inside the message try/catch — so an uncaught throw here crashes the
+      // radio. Guard readyState and swallow.
+      if (rtcResult.nextUp && rtcResult.nextUp.ws && rtcResult.nextUp.ws.readyState === 1) {
+        try {
+          rtcResult.nextUp.ws.send(JSON.stringify({
+            type: 'webrtc_mic_available',
+            data: { message: 'Your turn to broadcast!' },
+          }));
+        } catch (_) {}
       }
       broadcast({ type: 'webrtc_status', data: webrtcSignaling.getStatus() });
     }

--- a/server/live-broadcast.js
+++ b/server/live-broadcast.js
@@ -134,8 +134,13 @@ class LiveBroadcast {
 
     console.log(`\uD83C\uDF99 Live chunk #${this.state.chunkCount}: ${message.length} bytes`);
 
-    // Save raw audio blob for recording (accumulate all data)
-    if (this.state.recording || this._rawChunks) {
+    // Save raw audio blob ONLY while actually recording. The old
+    // `|| this._rawChunks` guard was a permanent memory leak: _saveRecording
+    // leaves `_rawChunks = []` (truthy) after a save, so every later
+    // NON-recording session kept copying each ~1/sec mic chunk into the array
+    // for the life of the process (hundreds of MB on a long live stream that
+    // is never saved). _rawChunks is now nulled after save so this can't latch.
+    if (this.state.recording) {
       if (!this._rawChunks) this._rawChunks = [];
       this._rawChunks.push(Buffer.from(message));
     }
@@ -207,7 +212,9 @@ class LiveBroadcast {
 
   _saveRecording() {
     const rawChunks = this._rawChunks || [];
-    this._rawChunks = [];
+    // Null (not []): a truthy empty array would re-arm the accumulation leak in
+    // handleChunk for the next non-recording session.
+    this._rawChunks = null;
 
     if (rawChunks.length === 0) {
       console.log(`   No audio data to save for recording`);

--- a/server/music-generator.js
+++ b/server/music-generator.js
@@ -32,10 +32,16 @@ class MusicGenerator {
     this.generatedTracks = []; // { title, path, prompt, generatedAt }
     this.generating = false;
 
-    // Reset daily counter at midnight
+    // Reset the daily counter when the calendar day changes. Matching the
+    // exact 00:00 minute (old behavior) was fragile: setInterval drift or a
+    // busy/blocked event loop can skip the single 00:00 tick entirely, leaving
+    // the counter un-reset and generation wedged at the daily cap for ~24h.
+    // A day-key comparison resets on the first tick of any new day.
+    this._lastResetDay = new Date().toDateString();
     this._resetTimer = setInterval(() => {
-      const now = new Date();
-      if (now.getHours() === 0 && now.getMinutes() === 0) {
+      const day = new Date().toDateString();
+      if (day !== this._lastResetDay) {
+        this._lastResetDay = day;
         this.generationsToday = 0;
       }
     }, 60000);
@@ -386,18 +392,45 @@ class MusicGenerator {
   async _downloadFile(url, outputPath) {
     return new Promise((resolve, reject) => {
       const file = fs.createWriteStream(outputPath);
-      https.get(url, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          // Follow redirect
-          https.get(res.headers.location, (res2) => {
-            res2.pipe(file);
-            file.on('finish', () => { file.close(); resolve(); });
-          }).on('error', reject);
-        } else {
+      let settled = false;
+      const fail = (err) => {
+        if (settled) return;
+        settled = true;
+        try { file.close(); } catch (_) {}
+        // Remove the partial/corrupt file so the DJ engine never tries to
+        // stream a half-written or error-body "track".
+        fs.unlink(outputPath, () => {});
+        reject(err);
+      };
+      // Without this, a disk-write error never rejected and the generate()
+      // await hung forever.
+      file.on('error', fail);
+
+      const get = (u, redirectsLeft) => {
+        https.get(u, (res) => {
+          // Follow redirects, but DRAIN the redirect response first — the old
+          // code left the 301/302 socket half-read, leaking the connection.
+          if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
+            res.resume();
+            if (redirectsLeft <= 0) return fail(new Error('too many redirects'));
+            return get(res.headers.location, redirectsLeft - 1);
+          }
+          // A non-200 (e.g. 403/404 from an expired signed CDN URL) returns an
+          // HTML error body; piping it produced a corrupt .mp3 that "downloaded
+          // successfully". Reject instead.
+          if (res.statusCode !== 200) {
+            res.resume();
+            return fail(new Error('download HTTP ' + res.statusCode));
+          }
           res.pipe(file);
-          file.on('finish', () => { file.close(); resolve(); });
-        }
-      }).on('error', reject);
+          file.on('finish', () => {
+            if (settled) return;
+            settled = true;
+            file.close(() => resolve());
+          });
+        }).on('error', fail);
+      };
+      get(url, 3);
     });
   }
 

--- a/server/nats-client.js
+++ b/server/nats-client.js
@@ -354,7 +354,16 @@ class NATSClient extends EventEmitter {
         const body = bufView.slice(0, need).toString('utf-8');
         // Remainder skips the body bytes + the trailing \r\n.
         this._buffer = bufView.slice(need + 2).toString('utf-8');
-        this._handleMessage(this._pendingMsg.subject, body);
+        // The KANNAKA.* bus is a PUBLIC read bus — any peer can publish. A
+        // throw from a malformed payload (e.g. phi as a string → toFixed is
+        // not a function) inside this handler would propagate out of the socket
+        // 'data' callback as an uncaught exception and take the whole radio
+        // down. Contain it: one bad message must never crash the broadcast.
+        try {
+          this._handleMessage(this._pendingMsg.subject, body);
+        } catch (e) {
+          console.warn('[nats] handler error on', this._pendingMsg.subject, e && e.message);
+        }
         this._pendingMsg = null;
         continue;
       }
@@ -374,8 +383,13 @@ class NATSClient extends EventEmitter {
         const subject  = parts[1];
         const numBytes = parseInt(parts[parts.length - 1], 10);
         const replyTo  = parts.length === 5 ? parts[3] : null;
-        if (!Number.isFinite(numBytes) || numBytes < 0) {
-          console.log('[nats] Malformed MSG header, dropping:', line);
+        // Upper-bound the advertised body size. Without a cap, a frame
+        // advertising e.g. `999999999` bytes makes every later chunk append to
+        // _buffer and return early forever: _pendingMsg never clears, the
+        // buffer grows unbounded (memory leak), and message processing stalls
+        // permanently. NATS itself caps payloads at 1 MB by default.
+        if (!Number.isFinite(numBytes) || numBytes < 0 || numBytes > 1048576) {
+          console.log('[nats] Malformed/oversized MSG header, dropping:', line);
           continue;
         }
         this._pendingMsg = { subject, numBytes, replyTo };
@@ -422,7 +436,13 @@ class NATSClient extends EventEmitter {
       // Compute local swarm coherence from phase gossip (Kuramoto order parameter).
       // This is a LOCAL metric — it measures phase-lock between connected agents,
       // NOT the canonical consciousness Phi from the binary's assess().
-      const phases = Object.values(this.swarmState.agents).map(a => a.phase);
+      // Coerce + filter to finite numbers: a single peer publishing `phase` as
+      // a string makes Math.cos(p) return NaN, which poisons localOrder,
+      // meanPhase, and the queen order parameter shown in the UI / published to
+      // Flux — one bad agent NaNs the whole swarm coherence metric.
+      const phases = Object.values(this.swarmState.agents)
+        .map(a => Number(a.phase))
+        .filter(p => Number.isFinite(p));
       if (phases.length > 0) {
         const sumCos = phases.reduce((s, p) => s + Math.cos(p), 0);
         const sumSin = phases.reduce((s, p) => s + Math.sin(p), 0);
@@ -450,9 +470,14 @@ class NATSClient extends EventEmitter {
       // These are AUTHORITATIVE — they override any locally-computed values.
       // The binary's assess() blends eigendecomposition + link density bonus,
       // which the radio cannot compute (no access to .links.json sidecar).
-      const phi = data.phi ?? data.Phi ?? this.swarmState.consciousness.phi;
-      const xi = data.xi ?? data.Xi ?? this.swarmState.consciousness.xi;
-      const order = data.order ?? data.mean_order ?? this.swarmState.consciousness.order;
+      // Coerce to Number: `??` only falls back on null/undefined, so a peer
+      // publishing phi/xi/order as a STRING (or array) would survive to the
+      // `.toFixed()` log below and throw "toFixed is not a function", and would
+      // corrupt the published metric with NaN. `|| <prev>` keeps the last good
+      // value when the payload is non-numeric.
+      const phi = Number(data.phi ?? data.Phi) || this.swarmState.consciousness.phi || 0;
+      const xi = Number(data.xi ?? data.Xi) || this.swarmState.consciousness.xi || 0;
+      const order = Number(data.order ?? data.mean_order) || this.swarmState.consciousness.order || 0;
       const level = data.level ?? data.consciousness_level ?? this.swarmState.consciousness.level;
 
       // Track previous phi for gradient detection

--- a/server/voice-dj.js
+++ b/server/voice-dj.js
@@ -344,8 +344,21 @@ class VoiceDJ {
       // to NOT play the audio separately (it'll come down /stream).
       const ics = this._getIcecastSource && this._getIcecastSource();
       let inStream = false;
+      // Release the speaking lock when the intro actually finishes — on the
+      // inject-completion callback when streamed, else on a word-count estimate
+      // (DJ patter ~2.8 w/s). The old fixed 1500ms ended the lock while any
+      // intro longer than ~4 words was still playing, opening a window for a
+      // second voice segment (track-change / swarm event) to be composed and
+      // broadcast OVER the still-playing intro.
+      let releasedSpeaking = false;
+      const releaseSpeaking = () => { if (!releasedSpeaking) { releasedSpeaking = true; this._speaking = false; } };
+      const introWords = (cached.text || '').split(/\s+/).filter(Boolean).length;
+      const introMs = Math.min(30000, Math.max(3000, (introWords / 2.8) * 1000)) + 1000;
       if (ics && typeof ics.injectAudio === 'function') {
-        try { ics.injectAudio(cached.audioPath, { label: 'DJ intro: ' + (track.title || ''), introFor: track.file }); inStream = true; } catch (_) {}
+        try {
+          ics.injectAudio(cached.audioPath, { label: 'DJ intro: ' + (track.title || ''), introFor: track.file }, () => releaseSpeaking());
+          inStream = true;
+        } catch (_) {}
       }
       const voiceMsg = {
         type: 'dj_voice',
@@ -358,9 +371,10 @@ class VoiceDJ {
       console.log(`   \u{1F399} DJ (cached${inStream ? '+stream' : ''}): "${cached.text.substring(0, 60)}..."`);
       execFile(this._kannakabin, ['hear', cached.audioPath], { timeout: 30000 }, () => {});
       this._lastIntro = cached.text;
-      // Speaking lock releases when the client finishes playback — we don't
-      // know exact duration here, so release after a conservative window.
-      setTimeout(() => { this._speaking = false; }, 1500);
+      // Fallback ceiling: release on the duration estimate in case the inject
+      // completion callback never fires (or there was no stream inject).
+      const introReleaseTimer = setTimeout(releaseSpeaking, introMs);
+      introReleaseTimer.unref?.();
       return;
     }
 
@@ -517,6 +531,25 @@ class VoiceDJ {
     this._speaking = true;
     this._broadcast({ type: 'dj_talk_pending', timestamp: new Date().toISOString() });
 
+    // Entry safety net for the TTS phase. executeOration's ONLY lock-release
+    // paths live inside the _generateTTS callback below, so if synthesize never
+    // invokes its callback (engine hang) _inTalkSegment/_speaking would stay set
+    // forever and every future oration/news/teaser would hit the busy guard at
+    // the top of this method permanently — the 2026-04-30 wedge that
+    // executeTalkSegment already guards against. Cleared the instant the TTS
+    // callback runs, before the normal 720s inject-ceiling timer takes over, so
+    // it never interferes with a legitimately long oration.
+    const ttsSafetyMs = 420000; // 7 min — past piper's 6-min long-form ceiling
+    this._orationTtsSafety = setTimeout(() => {
+      if (this._inTalkSegment) {
+        console.warn('   [oration] SAFETY: TTS callback never fired — force-releasing talk lock');
+        this._inTalkSegment = false;
+        this._speaking = false;
+        if (onDone) { try { onDone(); } catch (_) { /* swallow */ } }
+      }
+    }, ttsSafetyMs);
+    this._orationTtsSafety.unref?.();
+
     // Orations + news ride the high-quality voice so prosody matches the
     // gravitas of the long-form delivery. Per-call `opts.voiceId` is the
     // canonical override (slot-specific personas — news, peace oration,
@@ -535,6 +568,9 @@ class VoiceDJ {
     const persona = (opts && opts.persona) || this._orationPersona || "oration";
     const ttsOpts = { persona };
     this._generateTTS(text, (err, audioPath, spokenText) => {
+      // TTS callback fired — the entry safety net has done its job; the normal
+      // release()/720s inject-ceiling timer below now owns the lock.
+      if (this._orationTtsSafety) { clearTimeout(this._orationTtsSafety); this._orationTtsSafety = null; }
       this._speaking = false;
       if (err || !audioPath) {
         console.log(`   [oration] TTS failed — releasing talk lock`);

--- a/server/voice-engine.js
+++ b/server/voice-engine.js
@@ -252,8 +252,16 @@ function renderPiper(text, persona, rawWavPath, cb) {
       cb(err || new Error("piper produced no file"));
     },
   );
-  // Piper reads the utterance from stdin.
-  try { child.stdin.write(text); child.stdin.end(); } catch (e) { /* exec err path handles it */ }
+  // Piper reads the utterance from stdin. Attach an 'error' listener BEFORE
+  // writing: piper can close/break stdin asynchronously (EPIPE) — the try/catch
+  // only catches a synchronous throw, so without this listener that async
+  // 'error' event is unhandled and crashes the whole process on what is the
+  // FAST path for short DJ patter. The execFile callback still surfaces the
+  // real failure via `err`.
+  if (child.stdin) {
+    child.stdin.on("error", () => {});
+    try { child.stdin.write(text); child.stdin.end(); } catch (_) { /* exec err path handles it */ }
+  }
 }
 
 // ── Engine: Windows SAPI (last-ditch local fallback) ───────────

--- a/test/nats-metrics-sync.test.js
+++ b/test/nats-metrics-sync.test.js
@@ -229,6 +229,42 @@ test('legacy bare payloads still surface drift warnings but apply normally', () 
   client.disconnect();
 });
 
+// ── Hardening: malformed payloads from the public-read bus ──
+
+test('string consciousness metrics are coerced, never crash (toFixed)', () => {
+  const { client } = createClient();
+  // A peer publishing phi/xi/order as STRINGS must not throw "toFixed is not a
+  // function" in the update log, nor corrupt state with NaN. `??` only falls
+  // back on null/undefined, so the old code passed strings straight through.
+  client._handleMessage('KANNAKA.consciousness', envelope({
+    phi: '0.85', xi: '0.42', order: '0.5', level: 'aware',
+  }));
+  const c = client.swarmState.consciousness;
+  assert.strictEqual(c.phi, 0.85, 'string phi coerced to number');
+  assert.ok(Number.isFinite(c.xi) && Number.isFinite(c.order), 'xi/order finite');
+  client.disconnect();
+});
+
+test('a string phase does not NaN the local order parameter', () => {
+  const { client } = createClient();
+  client._handleMessage('QUEEN.phase.good', envelope({ phase: 0.5 }, { subject: 'QUEEN.phase.good' }));
+  client._handleMessage('QUEEN.phase.bad', envelope({ phase: 'not-a-number' }, { subject: 'QUEEN.phase.bad' }));
+  assert.ok(Number.isFinite(client.swarmState.queen.localOrderParameter),
+    'one bad agent must not NaN the whole swarm coherence metric');
+  client.disconnect();
+});
+
+test('oversized MSG header is dropped, not buffered unbounded', () => {
+  const { client } = createClient();
+  // Without an upper bound, an advertised body far larger than the buffer makes
+  // every chunk append and return early forever (unbounded memory + stall).
+  client._buffer = 'MSG KANNAKA.test 1 99999999\r\n';
+  client._processBuffer();
+  assert.strictEqual(client._pendingMsg, null, 'oversized advertised body must be rejected');
+  assert.strictEqual(client._buffer, '', 'the control line is consumed');
+  client.disconnect();
+});
+
 // ── Summary ────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
Autonomous bug-hunt/hardening pass off `master`. Findings surfaced by four parallel review agents over the DJ/streaming, voice/scheduler, networking, and social/floor surfaces; **every finding was verified against the code before fixing**. Existing test suite green (**75 → 78 assertions**, 0 failed); 3 new NATS regression tests.

## Crash vectors — a long-running radio must not be killable by bus/WS input
- **`nats-client.js`** — wrap `_handleMessage` in try/catch. The `KANNAKA.*` bus is a **public read bus**, so a throw from a malformed payload propagated out of the socket `'data'` callback and **took the whole radio down**.
- **`nats-client.js`** — coerce `phi`/`xi`/`order` to `Number`. `??` only guards null/undefined, so a peer publishing them as **strings** survived to `.toFixed()` → `TypeError` crash (and NaN-corrupted the metric).
- **`nats-client.js`** — coerce + filter agent `phase` to finite numbers — one peer sending a string phase **NaN'd the entire swarm order parameter**.
- **`index.js`** — guard the three WebRTC `ws.send()` sites with `readyState === 1` + try. The `'close'`-handler site is **not** inside a try/catch, so `send()` on a half-closed promoted socket threw uncaught and **crashed the radio on normal WS churn**.
- **`voice-engine.js`** — attach an `'error'` listener to piper's stdin before writing; an async EPIPE on the **fast DJ-patter path** was an unhandled stream error that crashed the process.
- **`agent-endpoint.js`** — add `child.on('error')`; a failed audit-tail spawn (ENOENT) emitted an unhandled `'error'` (**crash**) and never released the concurrency slot (endpoint wedged at 503 after `RADIO_AUDIT_MAX` failures).

## Leaks / stalls / wedges
- **`nats-client.js`** — upper-bound the advertised MSG body size (1 MB); an oversized header made the buffer **grow unbounded and stalled all message processing**.
- **`voice-dj.js` `executeOration`** — arm a TTS-phase safety timer at entry. The only lock-release paths lived inside the TTS callback, so a synthesize that never called back **wedged the long-form voice subsystem forever** (the 2026-04-30 failure mode `executeTalkSegment` already guards).
- **`voice-dj.js` cached intro** — release the speaking lock on the inject-completion callback (with a word-count fallback) instead of a fixed `1500 ms` that ended the lock **while a multi-second intro was still playing**, letting a second segment broadcast over it.
- **`live-broadcast.js`** — only buffer raw audio while actually recording, and null `_rawChunks` after save. The `|| this._rawChunks` guard latched truthy after the first recording and **leaked every later non-recording session's audio into RAM**.
- **`music-generator.js`** — reset the daily counter on a day-key change, not an exact `00:00` minute match that `setInterval` drift can skip — a miss **wedged generation at the cap for ~24h**.

## Correctness / data integrity
- **`ghostsignals-hub.js`** — re-entrancy guard on the market resolver. The 10s interval did not await the previous run, so a slow sweep overlapped the next, re-selected the same `resolved=0` rows, and **paid out every winner twice** (ledger corruption).
- **`music-generator.js` `_downloadFile`** — drain redirect responses (socket leak), reject non-200 + unlink the partial file (an expired CDN URL wrote a **corrupt "track"**), and reject on a disk-write error (the await **hung forever**).
- **`bluesky.js`** — `reply()` and `searchPosts()` now clear the cached session and re-auth once on 401/400 (`post()` already did) — an expired token otherwise **wedged replies/search silently** until restart.

## Not fixed (noted)
A few lower-confidence/edge findings were left out deliberately: the deeper atomic `resolveMarket` guard (the re-entrancy guard covers the documented trigger; the atomic version needs risky transaction surgery), and several MEDIUM routes-proxy hardening items (request-body caps / timeouts on the ORC proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)