### PR TITLE
fix(voice-dj): restore prompt _speaking release for cached intros (talk/oration starvation regression from #76)

### DIFF
--- a/server/voice-dj.js
+++ b/server/voice-dj.js
@@ -344,21 +344,8 @@ class VoiceDJ {
       // to NOT play the audio separately (it'll come down /stream).
       const ics = this._getIcecastSource && this._getIcecastSource();
       let inStream = false;
-      // Release the speaking lock when the intro actually finishes — on the
-      // inject-completion callback when streamed, else on a word-count estimate
-      // (DJ patter ~2.8 w/s). The old fixed 1500ms ended the lock while any
-      // intro longer than ~4 words was still playing, opening a window for a
-      // second voice segment (track-change / swarm event) to be composed and
-      // broadcast OVER the still-playing intro.
-      let releasedSpeaking = false;
-      const releaseSpeaking = () => { if (!releasedSpeaking) { releasedSpeaking = true; this._speaking = false; } };
-      const introWords = (cached.text || '').split(/\s+/).filter(Boolean).length;
-      const introMs = Math.min(30000, Math.max(3000, (introWords / 2.8) * 1000)) + 1000;
       if (ics && typeof ics.injectAudio === 'function') {
-        try {
-          ics.injectAudio(cached.audioPath, { label: 'DJ intro: ' + (track.title || ''), introFor: track.file }, () => releaseSpeaking());
-          inStream = true;
-        } catch (_) {}
+        try { ics.injectAudio(cached.audioPath, { label: 'DJ intro: ' + (track.title || ''), introFor: track.file }); inStream = true; } catch (_) {}
       }
       const voiceMsg = {
         type: 'dj_voice',
@@ -371,10 +358,14 @@ class VoiceDJ {
       console.log(`   \u{1F399} DJ (cached${inStream ? '+stream' : ''}): "${cached.text.substring(0, 60)}..."`);
       execFile(this._kannakabin, ['hear', cached.audioPath], { timeout: 30000 }, () => {});
       this._lastIntro = cached.text;
-      // Fallback ceiling: release on the duration estimate in case the inject
-      // completion callback never fires (or there was no stream inject).
-      const introReleaseTimer = setTimeout(releaseSpeaking, introMs);
-      introReleaseTimer.unref?.();
+      // Release the speaking lock after a short conservative window. Do NOT tie
+      // this to the inject-completion callback: the intro sits in the icecast
+      // _voiceQueue until the CURRENT music track finishes (minutes away) and is
+      // drained sequentially, so the queue ALREADY serializes /stream audio —
+      // there is no on-air overlap to prevent. Holding _speaking until drain (or
+      // a long word-count fallback) instead starved DJ intros AND peace orations,
+      // which both gate on _speaking. (Reverted from the v3.1.0-harden over-fix.)
+      setTimeout(() => { this._speaking = false; }, 1500);
       return;
     }
 


### PR DESCRIPTION
Hotfix for a regression introduced by #76. The cached-intro path tied the `_speaking` lock release to the icecast inject-completion callback (≈30s word-count fallback) instead of the original fixed 1.5s. But the `_voiceQueue` drains sequentially between tracks, so /stream voice can't overlap anyway — the change added no benefit and held `_speaking` ~30s/track, starving DJ intros and peace orations (both gate on `_speaking`). Reverts to the original short release with an explanatory comment; keeps the #76 executeOration safety timer. Suite green (78 assertions).