### PR TITLE
[auto-maintainer] fix(close-handlers): add settle+close to _fetchJSON and _fetchKaxArtifacts; drop redundant fs require

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -550,7 +550,6 @@ class DJEngine {
 
   _loadRecents() {
     try {
-      const fs = require("fs");
       if (!fs.existsSync(this._recentsPath)) return;
       const raw = JSON.parse(fs.readFileSync(this._recentsPath, "utf8"));
       const cutoff = Date.now() - 24 * 60 * 60 * 1000;
@@ -894,7 +893,7 @@ class DJEngine {
       const req = https.get('https://kax.ninja-portal.com/api/artifacts', (res) => {
         let data = '';
         res.on('data', c => data += c);
-        res.on('end', () => {
+        const settle = () => {
           try {
             const parsed = JSON.parse(data);
             const artifacts = Array.isArray(parsed) ? parsed : (parsed.artifacts || parsed.data || []);
@@ -904,7 +903,9 @@ class DJEngine {
               .reverse(); // play oldest first so the feed flows chronologically
             resolve(audioItems);
           } catch (e) { reject(e); }
-        });
+        };
+        res.on('end', settle);
+        res.on('close', settle);
       });
       req.on('error', reject);
       req.setTimeout(10000, () => { req.destroy(); reject(new Error('timeout')); });

--- a/server/voice-dj.js
+++ b/server/voice-dj.js
@@ -880,10 +880,12 @@ class VoiceDJ {
       const req = mod.get(url, (res) => {
         let data = "";
         res.on("data", c => data += c);
-        res.on("end", () => {
+        const settle = () => {
           try { resolve(JSON.parse(data)); }
           catch (e) { reject(e); }
-        });
+        };
+        res.on("end", settle);
+        res.on("close", settle);
       });
       req.on("error", reject);
       req.setTimeout(timeoutMs, () => { req.destroy(); reject(new Error("timeout")); });


### PR DESCRIPTION
## What changed

Two HTTP response Promises in `server/voice-dj.js` and `server/dj-engine.js` buffered response data into an `end` handler but had no `close` handler. When a remote server drops the TCP connection before finishing the response (network flap, service restart, upstream crash), the `IncomingMessage` emits `'close'` but **not** `'end'`, leaving the Promise pending until the request timeout fires.

| File | Method | Timeout | Hang per premature drop |
|---|---|---|---|
| `server/voice-dj.js` | `_fetchJSON` (used by `_fetchObservatoryMetrics`) | 2 000 ms | 2 s per constellation-metrics call |
| `server/dj-engine.js` | `_fetchKaxArtifacts` (used by `_buildKaxChannel`) | 10 000 ms | 10 s per KAX channel switch |

### Fix

Extract a `settle()` function (body identical to the existing `end` handler) and wire both `end` and `close` to it. `Promise.resolve()` is idempotent — if `end` fires first on the happy path, the subsequent `close` call is a silent no-op. On a premature connection drop, `close` fires immediately and settles the Promise without waiting for the timeout.

This is the same pattern applied in:
- PR #74 (`server/lib/scheduler-helpers.js` — four HTTP fetchers)
- PR #29 in kannaka-staff (`probeHttpJson`/`probeJson`)

### Also

Removed `const fs = require("fs")` inside `_loadRecents()` in `dj-engine.js` (line 553). `fs` is already imported at module scope (line 7). Node.js caches `require()`, so there was no runtime difference — this is dead/redundant code.

## Files changed

- `server/voice-dj.js` — 1 method, +4/-2 lines
- `server/dj-engine.js` — 1 method + 1 line removed, +4/-3 lines

**2 files changed, 8 insertions(+), 5 deletions(−)**

## Why it's safe

- No behaviour change in normal operation: successful responses deliver `end` before `close`; `settle` runs on `end`, and the subsequent `close` call is a no-op.
- `resolve()` / `reject()` are idempotent after first settlement — calling either again is silently ignored per the Promises/A+ spec.
- The only observable difference is faster rejection (immediate vs. after full timeout) when the remote server drops the connection mid-response — strictly better.
- No dependency changes, no lockfile changes, no workflow changes.

## Verification

```
node --check server/voice-dj.js    # OK
node --check server/dj-engine.js   # OK

npm test
# → test-queensync-dj, perception, dj-engine, nats-metrics-sync,
#   consciousness-dj-hrm, icecast-source, routes-discoverability
# All tests pass (same count as baseline)
```

## Runtime

~22 minutes wall-clock (jitter + in-flight detection + repo survey + anti-noise check + code scan + fix + test + duplicate check + PR).

---
*Auto-maintainer run · 2026-06-23T14:18 UTC · kannaka-radio*

---
_Generated by [Claude Code](https://claude.ai/code/session_01EciUwfJoEQSb8P8rUH2som)_