### PR TITLE
[auto-maintainer] refactor(dj-engine,index): replace inline require() with module-scope bindings

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -531,8 +531,8 @@ class DJEngine {
     // Persisted to disk so restarts don't wipe the ledger — without
     // persistence, every restart was a free pass to replay anything
     // recent, defeating the no-repeat purpose.
-    this._recentsPath = require("path").join(
-      require("path").resolve(__dirname, ".."),
+    this._recentsPath = path.join(
+      path.resolve(__dirname, ".."),
       "workspace",
       "recently-played.json"
     );
@@ -564,8 +564,6 @@ class DJEngine {
 
   _saveRecents() {
     try {
-      const fs = require("fs");
-      const path = require("path");
       fs.mkdirSync(path.dirname(this._recentsPath), { recursive: true });
       const obj = {};
       for (const [k, t] of this._recentlyPlayed) obj[k] = t;
@@ -947,8 +945,6 @@ class DJEngine {
    */
   _loadDoNotPlay() {
     try {
-      const fs = require("fs");
-      const path = require("path");
       const cfgPath = path.join(__dirname, "do-not-play.json");
       const raw = fs.readFileSync(cfgPath, "utf8");
       const cfg = JSON.parse(raw);
@@ -1586,8 +1582,7 @@ class DJEngine {
   addToQueue(filename) {
     const musicDir = this._getMusicDir();
     const file = findAudioFile(filename.replace(/\.[^/.]+$/, ""), musicDir) || filename;
-    const path_ = require("path");
-    const title = path_.basename(file, path_.extname(file)).replace(/^\d+[\s.\-_]+/, "").trim();
+    const title = path.basename(file, path.extname(file)).replace(/^\d+[\s.\-_]+/, "").trim();
     this.userQueue.push({ filename: file, title, path: file });
     return this.userQueue;
   }

--- a/server/index.js
+++ b/server/index.js
@@ -168,7 +168,6 @@ function broadcastListenerCountIfChanged() {
 // server (kr#20). If the stat server is down we keep the last good value
 // rather than flickering listeners to zero.
 function startIcecastListenerPoller() {
-  const http = require("http");
   const ICECAST_HOST = process.env.ICECAST_HOST || "127.0.0.1";
   const ICECAST_PORT = parseInt(process.env.ICECAST_PORT || "8000", 10);
   const ICECAST_URL = `http://${ICECAST_HOST}:${ICECAST_PORT}/status-json.xsl`;


### PR DESCRIPTION
## What changed

Five inline `require()` calls removed across two files — all for modules already imported at module scope.

| File | Location | Redundant inline require |
|---|---|---|
| `server/dj-engine.js` | constructor (lines 534–535) | `require("path").join(require("path").resolve(...))` |
| `server/dj-engine.js` | `_saveRecents()` | `const fs = require("fs"); const path = require("path");` |
| `server/dj-engine.js` | `_loadDoNotPlay()` | `const fs = require("fs"); const path = require("path");` |
| `server/dj-engine.js` | `addToQueue()` | `const path_ = require("path")` + alias usage |
| `server/index.js` | `startIcecastListenerPoller()` | `const http = require("http")` |

All five modules were already imported at module scope:
- `dj-engine.js` line 6: `const path = require("path")`
- `dj-engine.js` line 7: `const fs = require("fs")`
- `index.js` line 19: `const http = require("http")`

## Why it's safe

- **No behaviour change.** Node.js caches `require()` results after the first call; all inline calls already resolved to the same cached module objects as the module-scope bindings. This is a pure style/clarity fix.
- **No logic changed.** Each `require("path").join(...)` becomes `path.join(...)`, etc. The diff is mechanical.
- `addToQueue`'s `path_` alias is simply replaced with the already-in-scope `path` — no new variable needed.

## Continuation of the same pattern

This continues the cleanup started in:
- **PR #75** (`peace-oration.js` — lifted 5 inline `fs`/`path` requires to module top level)
- **PR #78** (`_loadRecents()` in `dj-engine.js` — removed 1 redundant `const fs = require("fs")`)

Those PRs missed the four remaining sites in `dj-engine.js` and the one in `index.js`.

## Verification

```
node --check server/dj-engine.js  # syntax OK
node --check server/index.js      # syntax OK

npm test
# → test-queensync-dj:         17 passed, 0 failed
# → perception:                10 passed, 0 failed
# → dj-engine:                 14 passed, 0 failed  (addToQueue test ✓)
# → nats-metrics-sync:         11 passed, 0 failed
# → consciousness-dj-hrm:      18 passed, 0 failed
# → icecast-source:             8 passed, 0 failed
# → routes-discoverability:     4 surfaces verified
# Total: 78 passed, 0 failed
```

**2 files changed, 3 insertions(+), 9 deletions(−)**

## Runtime

~22 minutes wall-clock (jitter + in-flight detection + repo selection + anti-noise + code scan + edits + test + duplicate check + PR).

---
*Auto-maintainer run · 2026-06-23T22:10 UTC · kannaka-radio*

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxUHe9FgHMU81JPVB1EpzY)_