### PR TITLE
[auto-maintainer] fix(webrtc): guard listener lookup in relay() against broadcaster override

### DIFF
--- a/server/webrtc-signaling.js
+++ b/server/webrtc-signaling.js
@@ -116,9 +116,10 @@ class WebRTCSignaling {
     if (this.broadcaster && this.broadcaster.clientId === toClientId) {
       targetWs = this.broadcaster.ws;
     }
-    const listener = this.listeners.get(toClientId);
-    if (listener) targetWs = listener.ws;
-
+    if (!targetWs) {
+      const listener = this.listeners.get(toClientId);
+      if (listener) targetWs = listener.ws;
+    }
     // Also check the queue — someone in the queue might be a signaling target
     if (!targetWs) {
       const queued = this.micQueue.find(q => q.clientId === toClientId);


### PR DESCRIPTION
## What changed

`relay()` in `server/webrtc-signaling.js` — 1 file, +4 / −3 lines.

### The bug

`relay()` resolves the target WebSocket with three fallback levels: broadcaster → listener → queue. The queue lookup was already correctly guarded:

```js
if (!targetWs) {           // ← queue IS guarded
  const queued = this.micQueue.find(...);
  if (queued) targetWs = queued.ws;
}
```

But the listener lookup ran **unconditionally**, silently overwriting any ws already found from the broadcaster check:

```js
if (this.broadcaster && this.broadcaster.clientId === toClientId) {
  targetWs = this.broadcaster.ws;
}
const listener = this.listeners.get(toClientId); // ← no guard
if (listener) targetWs = listener.ws;            // ← overwrites broadcaster silently!
```

### When this fires with a different ws

`claimMic()` does not call `removeListener()`. A client that transitions from listener → broadcaster in the same session is left in both `this.broadcaster` and `this.listeners`. In normal single-connection flow the ws object is identical so the overwrite is harmless, but if the client reconnects between `webrtc_listen` and `webrtc_claim_mic` (e.g. after a browser page reload), `listeners` retains the stale old ws while `broadcaster` has the new one. `relay()` then finds the broadcaster first (correct), immediately overwrites with the stale listener ws (wrong), and delivers the SDP offer or ICE candidate to the dead old connection — the new broadcaster never receives it and the peer-to-peer setup silently fails.

### Fix

Wrap the listener lookup in the same `!targetWs` guard already used for the queue, making the three-level priority explicit and consistent:

```js
// Before
const listener = this.listeners.get(toClientId);
if (listener) targetWs = listener.ws;

// After
if (!targetWs) {
  const listener = this.listeners.get(toClientId);
  if (listener) targetWs = listener.ws;
}
```

Priority order is now enforced: **broadcaster > listener > queue**.

## Why it's safe

- No behaviour change when `toClientId` matches only one of the three lookup sources, which is the common case.
- No behaviour change when the same client is a broadcaster and the same `ws` object is in listeners (overwrite was a no-op anyway).
- Only the stale-ws reconnect edge case changes — now correctly routes to the live broadcaster connection instead of the dead old one.
- No new imports, no dependency changes, no lockfile changes.

## Verification

```
node --check server/webrtc-signaling.js  # syntax OK

npm test
# → test-queensync-dj:         17 passed, 0 failed
# → perception:                10 passed, 0 failed
# → dj-engine:                 14 passed, 0 failed
# → nats-metrics-sync:         11 passed, 0 failed
# → consciousness-dj-hrm:      18 passed, 0 failed
# → icecast-source:             8 passed, 0 failed
# → routes-discoverability:     4 surfaces verified
# Total: 78 passed, 0 failed
```

(No test file directly exercises `webrtc-signaling.js`; fixed by inspection against the WS message handler in `server/index.js:725–810`.)

## Runtime

~22 minutes wall-clock (jitter + in-flight detection + repo selection + anti-noise + code scan + fix + tests + duplicate check + PR).

---
*Auto-maintainer run · 2026-06-24T22:11 UTC · kannaka-radio*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiZJaND8czHRrwn3c8j64Y)_