### PR TITLE
radio: default oration/teaser composer to Haiku 4.5 (best+cheapest)

### DIFF
--- a/server/lib/scheduler-helpers.js
+++ b/server/lib/scheduler-helpers.js
@@ -512,9 +512,14 @@ function composeViaAnthropicDirect(prompt, opts = {}) {
   // failing the segment. This is exactly what masked the ADR-0012 oration
   // outage: ~/.kannaka/config.toml pinned a retired sonnet-4 snapshot, so the
   // direct composer (and `kannaka ask`) 404'd and the oration never spoke.
-  const FALLBACKS = ["claude-sonnet-4-5", "claude-haiku-4-5-20251001"];
+  // Haiku 4.5 leads — best value for short creative orations/teasers ($1/$5 per
+  // MTok); Sonnet 4.6 is the quality safety net. The `startsWith("claude")`
+  // guard skips a non-Anthropic [llm] model (e.g. a local ollama model name)
+  // so it's never sent to api.anthropic.com — keeps this path decoupled from
+  // the kannaka [llm] provider.
+  const FALLBACKS = ["claude-haiku-4-5", "claude-sonnet-4-6"];
   const candidates = [];
-  for (const m of [cfgModel, ...FALLBACKS]) if (m && !candidates.includes(m)) candidates.push(m);
+  for (const m of [cfgModel, ...FALLBACKS]) if (m && m.startsWith("claude") && !candidates.includes(m)) candidates.push(m);
 
   const tryModel = (model) => new Promise((resolve) => {
     const body = JSON.stringify({ model, max_tokens: maxTokens, messages: [{ role: "user", content: prompt }] });


### PR DESCRIPTION
## What
Make the radio's direct-Anthropic composer (`server/lib/scheduler-helpers.js`) — peace orations and news teasers — default to **`claude-haiku-4-5`**, best value for short creative segments ($1/$5 per MTok).

## Why
- The fallback chain led with Sonnet, not the cheaper Haiku.
- A stale/`none` `[llm]` model in `~/.kannaka/config.toml` could pin a retired snapshot (the original ADR-0012 oration outage), or — once the local ollama LLM is restored — pass a non-Anthropic model name straight to `api.anthropic.com`.

## Change
- `FALLBACKS` → `["claude-haiku-4-5", "claude-sonnet-4-6"]` (Haiku primary, Sonnet 4.6 quality safety net).
- Candidate filter now requires `m.startsWith("claude")`, so a local ollama `[llm]` model name is skipped instead of 404'ing against Anthropic — decouples this path from the kannaka `[llm]` provider.

## Verification
Deployed and verified live on the ninjaportal hub — a peace oration was generated through the patched composer via Haiku 4.5. The API key is provisioned out-of-repo at `~/.kannaka-anthropic.env` (sourced by `run-radio.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)