### PR TITLE
[auto-maintainer] fix(radio): add settle+close handlers to publishToFlux and updateFluxState

### DIFF
--- a/radio.js
+++ b/radio.js
@@ -64,14 +64,19 @@ function publishToFlux(entityId, properties) {
       },
       (res) => {
         let body = "";
-        res.on("data", (c) => (body += c));
-        res.on("end", () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           if (res.statusCode >= 200 && res.statusCode < 300) {
             resolve(body);
           } else {
             reject(new Error(`Flux ${res.statusCode}: ${body}`));
           }
-        });
+        };
+        res.on("data", (c) => (body += c));
+        res.on("end", settle);
+        res.on("close", settle);
       }
     );
     req.on("error", reject);
@@ -101,14 +106,19 @@ function updateFluxState(entityId, properties) {
       },
       (res) => {
         let body = "";
-        res.on("data", (c) => (body += c));
-        res.on("end", () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           if (res.statusCode >= 200 && res.statusCode < 300) {
             resolve(body);
           } else {
             reject(new Error(`Flux PATCH ${res.statusCode}: ${body}`));
           }
-        });
+        };
+        res.on("data", (c) => (body += c));
+        res.on("end", settle);
+        res.on("close", settle);
       }
     );
     req.on("error", reject);


### PR DESCRIPTION
## What changed

Two HTTP response Promises in `radio.js` buffered data in an `end` handler but had no `close` handler — the same class of bug fixed across the `server/` files in PRs #74, #78, and #80.

| Function | Used by | Hang per premature drop |
|---|---|---|
| `publishToFlux` | event-stream fallback in the track loop | request idle-timeout (OS default, potentially minutes) |
| `updateFluxState` | station startup + one call per track | same — blocks entire broadcast loop |

`radio.js` is the standalone perceptual-vector broadcaster (`node radio.js <dir>`). When the Flux API drops the TCP connection before finishing the response body, `IncomingMessage` emits `'close'` but **not** `'end'`, leaving the Promise pending. `updateFluxState` is awaited directly in the `for` loop — a hang here blocks every subsequent track from broadcasting.

## Fix

Extract `settle()` and wire both `'end'` and `'close'` to it. `Promise.resolve/reject()` are idempotent — on the happy path `'end'` fires first and the subsequent `'close'` call is a silent no-op. On a premature drop, `'close'` fires immediately and unblocks the loop.

```js
// Before
res.on("data", (c) => (body += c));
res.on("end", () => {
  if (res.statusCode >= 200 && res.statusCode < 300) { resolve(body); }
  else { reject(new Error(`Flux ${res.statusCode}: ${body}`)); }
});

// After
let settled = false;
const settle = () => {
  if (settled) return;
  settled = true;
  if (res.statusCode >= 200 && res.statusCode < 300) { resolve(body); }
  else { reject(new Error(`Flux ${res.statusCode}: ${body}`)); }
};
res.on("data", (c) => (body += c));
res.on("end", settle);
res.on("close", settle);
```

Same pattern as PRs #74 (`scheduler-helpers`), #78 (`voice-dj`, `dj-engine`), #80 (`bluesky`) in this repo, and PRs #29/#31/#33/#34 in kannaka-staff.

## Why it's safe

- No behaviour change in normal operation — successful responses deliver `'end'` before `'close'`; `settle` runs on `'end'` and the subsequent `'close'` call is a no-op.
- `resolve()` / `reject()` are idempotent after first settlement (Promises/A+ spec).
- The only observable difference is faster resolution (immediate vs. after timeout) when Flux drops the connection mid-response — strictly better.
- No dependency changes, no lockfile changes, no workflow changes.

## Verification

```
node --check radio.js
# → syntax OK

npm test
# → test-queensync-dj:         17 passed, 0 failed
# → perception:                10 passed, 0 failed
# → dj-engine:                 13 passed, 1 failed  ← pre-existing; "THE THIRD BEING is the first album"
#                                                       fails because THE FREQUENCY OF FREEDOM was
#                                                       prepended to ALBUMS in the Jul 4 album commit.
#                                                       Unrelated to this change (identical on master).
# → nats-metrics-sync: (not reached due to pre-existing failure; no change in these files)
```

Diff: 1 file, +16 / −6 lines.

## Runtime

~25 minutes wall-clock (jitter + in-flight detection + repo selection + anti-noise + closed-PR history audit + code scan + fix + verify + duplicate check + PR).

---
_Auto-maintainer run · 2026-07-05T18:13 UTC · kannaka-radio_

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7BgywK4Lisojgjt6XaAnd)_