### PR TITLE
[auto-maintainer] fix(voice-dj): read GhostSignalsHub stats from nested gsStats.stats

### DIFF
--- a/server/voice-dj.js
+++ b/server/voice-dj.js
@@ -860,10 +860,10 @@ class VoiceDJ {
       }
     }
 
-    if (gsStats) {
-      metrics.active_markets = gsStats.active_markets || gsStats.activeMarkets || null;
-      metrics.total_traders = gsStats.total_traders || gsStats.totalTraders || null;
-      metrics.total_trades = gsStats.total_trades || gsStats.totalTrades || null;
+    if (gsStats && gsStats.stats) {
+      metrics.active_markets = gsStats.stats.markets_active ?? null;
+      metrics.total_traders = gsStats.stats.traders ?? null;
+      metrics.total_trades = gsStats.stats.trades_total ?? null;
     }
 
     this._metricsCache = metrics;


### PR DESCRIPTION
## What changed

One bug in `server/voice-dj.js` `_fetchObservatoryMetrics()`: the three lines that pull GhostSignals market data from the `/api/gshub/stats` response were reading keys that do not exist on the response object, so `active_markets`, `total_traders`, and `total_trades` always stayed `null`.

| Before | After |
|--------|-------|
| `gsStats.active_markets \|\| gsStats.activeMarkets \|\| null` | `gsStats.stats.markets_active ?? null` |
| `gsStats.total_traders \|\| gsStats.totalTraders \|\| null` | `gsStats.stats.traders ?? null` |
| `gsStats.total_trades \|\| gsStats.totalTrades \|\| null` | `gsStats.stats.trades_total ?? null` |

The guard also tightened from `if (gsStats)` to `if (gsStats && gsStats.stats)` to match the actual response shape.

## Root cause

`server/routes.js` returns the stats endpoint as:
```js
sendJson(200, { ok: true, stats: s })   // routes.js:895-897
```

`ghostsignals-hub.js` `getHubStats()` builds `s` with keys `traders`, `markets_total`, `markets_active`, `trades_total`. The voice-dj consumer treated `gsStats` as if it were `s` directly (reading flat `gsStats.active_markets` etc.) rather than going through the `stats` wrapper. Consumer and producer drifted apart.

The `?? null` change (vs `|| null`) also fixes a secondary issue: a legitimate `0` value (e.g. 0 active markets at station startup) was previously coerced to `null` and suppressed from the voice commentary. With `??`, only `null`/`undefined` fall through.

## Why it's safe

- The only change is to field-access paths inside `_fetchObservatoryMetrics()` — the metrics cache shape, the `_formatMetrics()` consumer, and all callers are untouched.
- Under normal operation, when the `/api/gshub/stats` endpoint is unreachable, `gsStats` is `null` (the `catch(() => null)` on line 844) — the new `gsStats && gsStats.stats` guard still safely no-ops.
- No test file changed. No dependency changes. No lockfile changes.

Resolves #50.

## Verification

```
node --check server/voice-dj.js
# → Syntax OK

npm test
# → test-queensync-dj:   17 passed, 0 failed
# → perception:          10 passed, 0 failed
# → dj-engine:           13 passed, 1 failed  ← pre-existing "THE THIRD BEING is the first album"
#                                                 failure (tracked in open PR #85, unrelated here)
# → nats-metrics-sync: (not reached due to chained && exit on dj-engine failure)
```

Test baseline identical to master. My change introduced 0 new failures.

Diff: 1 file, +4 −4 lines.

## Runtime

~22 minutes wall-clock (jitter + in-flight detection across 6 repos + repo selection + anti-noise PR/issue audit + code audit + fix + syntax check + npm test + duplicate check + push + PR).

---
_Auto-maintainer run · 2026-07-06T18:14 UTC · kannaka-radio_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqDPnxg5PfpPmyiKUQ6xfu)_