### PR TITLE
fix(portability): env-resolve Kannaka paths + robots.txt origin (portability cluster #45-#48, #53)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/push-nats.js
+++ b/push-nats.js
@@ -20,12 +20,19 @@ const { execSync } = require('child_process');
 const os = require('os');
 
 const IS_WINDOWS = os.platform() === 'win32';
-const KANNAKA_BIN = IS_WINDOWS
-  ? 'C:\\Users\\nickf\\Source\\kannaka-memory\\target\\release\\kannaka.exe'
-  : '/home/opc/.local/bin/kannaka';
-const KANNAKA_DATA = IS_WINDOWS
-  ? 'C:\\Users\\nickf\\.kannaka'
-  : '/home/opc/.kannaka';
+const HOME = os.homedir();
+// Resolve the binary and data dir from the environment first so this bridge
+// is portable across operators/machines. Explicit overrides win; otherwise
+// the Windows defaults follow the current user's profile (via os.homedir())
+// instead of a hardcoded developer path, and Linux keeps the Oracle layout. (#48)
+const KANNAKA_BIN = process.env.KANNAKA_BIN
+  || (IS_WINDOWS
+    ? path.join(HOME, 'Source', 'kannaka-memory', 'target', 'release', 'kannaka.exe')
+    : '/home/opc/.local/bin/kannaka');
+const KANNAKA_DATA = process.env.KANNAKA_DATA_DIR
+  || (IS_WINDOWS
+    ? path.join(HOME, '.kannaka')
+    : '/home/opc/.kannaka');
 const NATS_HOST = 'swarm.ninja-portal.com';
 const NATS_PORT = 4222;
 

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -16,6 +16,7 @@
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const os = require('os');
 
 // We require the stem-server's sqlite3 install if available — both apps
 // run on the same host so they share the binary. Falls back to the local
@@ -53,7 +54,14 @@ function brierAccuracy(predictedProb, actualOutcome /* 1 if happened, 0 else */)
 
 class GhostSignalsHub {
   constructor(opts = {}) {
-    this.dbPath = opts.dbPath || path.join(process.env.HOME || '/home/opc', '.kannaka', 'ghostsignals.db');
+    // Resolve the DB under the canonical Kannaka data dir. `KANNAKA_DATA_DIR`
+    // wins (matches the rest of the constellation); otherwise fall back to
+    // `~/.kannaka` via os.homedir() so Windows hosts without $HOME land in the
+    // user profile instead of a bogus `\home\opc` root path. (#47)
+    this.dbPath = opts.dbPath || path.join(
+      process.env.KANNAKA_DATA_DIR || path.join(os.homedir(), '.kannaka'),
+      'ghostsignals.db',
+    );
     this.startingCapital = opts.startingCapital || 100;
     this.defaultLiquidity = opts.defaultLiquidity || 10;
     this.broadcast = opts.broadcast || (() => {});

--- a/server/routes.js
+++ b/server/routes.js
@@ -280,15 +280,22 @@ module.exports = function setupRoutes(deps) {
 
     // /robots.txt — static file with AI bot rules + Content-Signal directive.
     if (parsed.pathname === "/robots.txt") {
+      const origin = publicOrigin(req);
       try {
         const baseDir = path.dirname(config.spaPath);
-        const txt = fs.readFileSync(path.join(baseDir, "robots.txt"), "utf8");
+        // Rewrite the absolute Sitemap directive to the current public origin.
+        // The checked-in robots.txt bakes in the production host; without this
+        // a self-hosted / staging / alternate-domain deployment would point
+        // crawlers at radio.ninja-portal.com. On production origin === that
+        // host, so the served output is unchanged. (#45)
+        const txt = fs.readFileSync(path.join(baseDir, "robots.txt"), "utf8")
+          .replace(/^(Sitemap:[ \t]*)\S+/gim, `$1${origin}/sitemap.xml`);
         res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8", "Cache-Control": "public, max-age=86400" });
         res.end(txt);
       } catch {
         // Minimal fallback — never 404 on robots.txt; bots interpret 404 as "no rules".
         res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
-        res.end(`User-agent: *\nAllow: /\nSitemap: ${publicOrigin(req)}/sitemap.xml\n`);
+        res.end(`User-agent: *\nAllow: /\nSitemap: ${origin}/sitemap.xml\n`);
       }
       return;
     }

--- a/test/portability-paths.test.js
+++ b/test/portability-paths.test.js
@@ -1,0 +1,61 @@
+/**
+ * portability-paths.test.js — GhostSignalsHub resolves its SQLite path from
+ * the canonical Kannaka data dir instead of a hardcoded /home/opc root, so
+ * Windows hosts without $HOME don't write to a bogus `\home\opc` path (#47).
+ */
+
+const assert = require("assert");
+const os = require("os");
+const path = require("path");
+const { GhostSignalsHub } = require("../server/ghostsignals-hub");
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+  console.log(`  ✅ ${name}`);
+}
+
+// Default: under ~/.kannaka via os.homedir(), never a bare /home/opc leak.
+check("default dbPath lives under the user home .kannaka dir", () => {
+  const saved = process.env.KANNAKA_DATA_DIR;
+  delete process.env.KANNAKA_DATA_DIR;
+  try {
+    const hub = new GhostSignalsHub();
+    assert.strictEqual(
+      hub.dbPath,
+      path.join(os.homedir(), ".kannaka", "ghostsignals.db"),
+      "default should be <home>/.kannaka/ghostsignals.db"
+    );
+    // The old bug produced `\home\opc\...` on Windows; guard against regressing.
+    assert.ok(
+      hub.dbPath.startsWith(os.homedir()),
+      "dbPath must be rooted at the resolved home dir, not a hardcoded /home/opc"
+    );
+  } finally {
+    if (saved === undefined) delete process.env.KANNAKA_DATA_DIR;
+    else process.env.KANNAKA_DATA_DIR = saved;
+  }
+});
+
+// KANNAKA_DATA_DIR wins so state lands in the constellation's canonical dir.
+check("KANNAKA_DATA_DIR overrides the default data dir", () => {
+  const saved = process.env.KANNAKA_DATA_DIR;
+  const dir = path.join(os.tmpdir(), "kr-kannaka-data-test");
+  process.env.KANNAKA_DATA_DIR = dir;
+  try {
+    const hub = new GhostSignalsHub();
+    assert.strictEqual(hub.dbPath, path.join(dir, "ghostsignals.db"));
+  } finally {
+    if (saved === undefined) delete process.env.KANNAKA_DATA_DIR;
+    else process.env.KANNAKA_DATA_DIR = saved;
+  }
+});
+
+// Explicit opts.dbPath always wins (embedding / test usage).
+check("explicit opts.dbPath wins over env and defaults", () => {
+  const hub = new GhostSignalsHub({ dbPath: "/custom/location/gs.db" });
+  assert.strictEqual(hub.dbPath, "/custom/location/gs.db");
+});
+
+console.log(`portability-paths.test.js: OK (${passed} checks)`);

--- a/test/routes-discoverability.test.js
+++ b/test/routes-discoverability.test.js
@@ -9,6 +9,9 @@
 
 const http = require("http");
 const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const setupRoutes = require("../server/routes");
 
 function noop() {}
@@ -44,7 +47,7 @@ function fakeConfig() {
   };
 }
 
-function makeHandler() {
+function makeHandler(overrides = {}) {
   return setupRoutes({
     djEngine: fakeEngine(),
     perception: { perceive: noop, getHistory: () => [] },
@@ -60,6 +63,7 @@ function makeHandler() {
     floor: fakeFloor(),
     config: fakeConfig(),
     gsHub: null,
+    ...overrides,
   });
 }
 
@@ -124,7 +128,29 @@ function get(handler, url, headers = {}) {
     "request host should be ignored when env override is set");
   delete process.env.RADIO_PUBLIC_URL;
 
-  console.log("routes-discoverability.test.js: OK (4 surfaces verified)");
+  // static robots.txt — the checked-in Sitemap host is rewritten to the
+  // request origin so non-production deployments don't advertise the prod
+  // host baked into the file (#45).
+  {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kr-robots-"));
+    fs.writeFileSync(
+      path.join(tmpDir, "robots.txt"),
+      "User-agent: *\nAllow: /\nSitemap: https://radio.ninja-portal.com/sitemap.xml\n"
+    );
+    // routes reads robots.txt from path.dirname(config.spaPath)
+    const robotsHandler = makeHandler({
+      config: { ...fakeConfig(), spaPath: path.join(tmpDir, "spa") },
+    });
+    r = await get(robotsHandler, "/robots.txt", { host: "self-hosted.example:9099" });
+    assert.strictEqual(r.status, 200, "robots.txt status");
+    assert.ok(r.body.includes("Sitemap: http://self-hosted.example:9099/sitemap.xml"),
+      "robots.txt Sitemap should advertise the requesting origin\n" + r.body);
+    assert.ok(!r.body.includes("radio.ninja-portal.com"),
+      "static robots.txt should NOT advertise the hardcoded production host\n" + r.body);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  console.log("routes-discoverability.test.js: OK (5 surfaces verified)");
 })().catch((e) => {
   console.error(e);
   process.exit(1);


### PR DESCRIPTION
Portability cluster — remove the remaining Nick/Oracle-specific hardcodes so the radio and its bridge scripts run unchanged on any operator/host. Feeds the standing public-content-scrub policy.

**Zero-regression rule honored:** every default reproduces the current production value byte-for-byte when the new env vars are unset. Verified `push-nats` resolves to the exact old `C:\Users\nickf\...` paths on this Windows host and to `/home/opc/...` on Linux.

## Fixed in this PR

### #47 — GhostSignalsHub `/home/opc` DB path on Windows
`server/ghostsignals-hub.js` used `process.env.HOME || '/home/opc'`, so Windows hosts without `$HOME` wrote to a bogus `\home\opc\.kannaka\ghostsignals.db`. Now resolves `KANNAKA_DATA_DIR` (canonical constellation env), else `~/.kannaka` via `os.homedir()`. On Oracle (`$HOME=/home/opc`) the path is identical.

### #48 — push-nats.js hardcodes Nick's Windows paths
`push-nats.js` hardcoded `C:\Users\nickf\...` for the binary and data dir. Now honors `KANNAKA_BIN` / `KANNAKA_DATA_DIR`; the Windows defaults follow `os.homedir()` (identical on Nick's machine, correct elsewhere). Linux keeps the Oracle layout.

### #45 — discoverability endpoints hardcode radio.ninja-portal.com
The **generated** surfaces (sitemap.xml, api-catalog, oauth discovery, robots.txt fallback) were already origin-derived via `publicOrigin(req)` in commit `757fa89`. The one remaining hole was the **static** `robots.txt` on disk, which bakes in `Sitemap: https://radio.ninja-portal.com/sitemap.xml` and is served verbatim. `server/routes.js` now rewrites that Sitemap directive to the request origin at serve time (unchanged on production, where `origin === radio.ninja-portal.com`).

## Verified already-resolved — closing separately with evidence

These two were fixed in earlier commits but their tracking issues were never closed (their line-number evidence predates the fix). No code change needed here.

- **#46** ORC stem-server path — env-resolved (`ORC_STEM_DB` / `ORC_SQLITE3_PATH`, Oracle-absolute defaults) in commit `7e9eb61`. The issue's `DBPATH=/home/opc/...` repro is just the default when the env is unset, which is the intended zero-regression behavior.
- **#53** listener poller — already honors `ICECAST_HOST` / `ICECAST_PORT` (`server/index.js:171-173`) since commit `9ee14fb`.

## Tests
- Extended `test/routes-discoverability.test.js` — now verifies the static robots.txt Sitemap is rewritten to the request origin (5 surfaces).
- New `test/portability-paths.test.js` — GhostSignalsHub data-dir resolution (default `~/.kannaka`, `KANNAKA_DATA_DIR` override, explicit `opts.dbPath`).
- Full suite green locally.

Closes #45
Closes #47
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)