### PR TITLE
[auto-maintainer] fix(music-generator): add settle+close to all four HTTPS response handlers

### DIFF
--- a/server/music-generator.js
+++ b/server/music-generator.js
@@ -173,8 +173,10 @@ class MusicGenerator {
         },
       }, (res) => {
         let data = '';
-        res.on('data', chunk => data += chunk);
-        res.on('end', () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           try {
             const result = JSON.parse(data);
 
@@ -202,7 +204,10 @@ class MusicGenerator {
           } catch (e) {
             reject(new Error(`AceMusic parse error: ${e.message}. Raw body: ${data.slice(0, 300)}`));
           }
-        });
+        };
+        res.on('data', chunk => data += chunk);
+        res.on('end', settle);
+        res.on('close', settle);
       });
       req.on('error', (err) => reject(new Error(`AceMusic request failed: ${err.message}`)));
       req.write(createBody);
@@ -234,8 +239,10 @@ class MusicGenerator {
         },
       }, (res) => {
         let data = '';
-        res.on('data', chunk => data += chunk);
-        res.on('end', () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           try {
             const result = JSON.parse(data);
 
@@ -285,7 +292,10 @@ class MusicGenerator {
           } catch (e) {
             reject(new Error(`AceMusic poll parse error: ${e.message}. Raw: ${data.slice(0, 300)}`));
           }
-        });
+        };
+        res.on('data', chunk => data += chunk);
+        res.on('end', settle);
+        res.on('close', settle);
       });
       req.on('error', (err) => reject(new Error(`AceMusic poll request failed: ${err.message}`)));
       req.write(pollBody);
@@ -325,8 +335,10 @@ class MusicGenerator {
         },
       }, (res) => {
         let data = '';
-        res.on('data', chunk => data += chunk);
-        res.on('end', () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           try {
             const result = JSON.parse(data);
             if (result.error) return reject(new Error(result.error));
@@ -336,7 +348,10 @@ class MusicGenerator {
           } catch (e) {
             reject(new Error(`Parse error: ${e.message}`));
           }
-        });
+        };
+        res.on('data', chunk => data += chunk);
+        res.on('end', settle);
+        res.on('close', settle);
       });
       req.on('error', reject);
       req.write(createBody);
@@ -363,8 +378,10 @@ class MusicGenerator {
         headers: { 'Authorization': `Bearer ${this.replicateToken}` },
       }, (res) => {
         let data = '';
-        res.on('data', chunk => data += chunk);
-        res.on('end', () => {
+        let settled = false;
+        const settle = () => {
+          if (settled) return;
+          settled = true;
           try {
             const result = JSON.parse(data);
             if (result.status === 'succeeded') {
@@ -379,7 +396,10 @@ class MusicGenerator {
           } catch (e) {
             reject(new Error(`Poll parse error: ${e.message}`));
           }
-        });
+        };
+        res.on('data', chunk => data += chunk);
+        res.on('end', settle);
+        res.on('close', settle);
       });
       req.on('error', reject);
       req.end();


### PR DESCRIPTION
## What changed

Four `http.request` response callbacks in `server/music-generator.js` listened for `end` but not `close`:

| Method | Endpoint | Risk |
|--------|----------|------|
| `generateViaAceMusic` | `POST api.acemusic.ai/release_task` | Promise hangs on TCP drop; `this.generating` stays `true` until resolve/reject eventually fires |
| `_pollAceMusic` | `POST api.acemusic.ai/query_result` | Each poll-round stalls, adding cumulative delay to every generation |
| `generateViaReplicate` | `POST api.replicate.com/v1/predictions` | Promise hangs, blocking the outer `generate()` call |
| `_pollReplicate` | `GET api.replicate.com/v1/predictions/:id` | Same stall-per-poll-round as the AceMusic poller |

When a remote server drops the TCP connection before sending `end` (network flap, service restart, API rate-limit reset), `IncomingMessage` emits `close` but never `end`. Without a `close` handler the Promise is left pending until a `req.on('error')` fires — or indefinitely if no error event arrives.

## Why it's safe

Under a healthy TCP exchange `end` always fires before `close`, so `settle` runs exactly once via the `end` path and the subsequent `close` call hits the `settled` guard and returns immediately — **zero behaviour change on the happy path**.

A `settled` boolean guard (rather than relying solely on Promise idempotency) is necessary here because `_pollAceMusic` and `_pollReplicate` make recursive calls that must not execute twice; `Promise.resolve/reject` subsequent calls are already no-ops but the recursive poll invocations are not.

## Consistency with the rest of the codebase

This is the identical pattern already applied to every other HTTP response handler in the constellation:

| PR | Repo | Locations |
|----|------|-----------|
| #29, #31, #33, #34 | kannaka-staff | `probeStreamHead`, `probeHttpJson`, `postJson`, `probeHttp`, `fireRescue` |
| #74 | kannaka-radio | `voice-dj _fetchJSON`, `dj-engine _fetchKaxArtifacts` |

`music-generator.js` was the last file in the radio server with `end`-only response handlers.

## Verification

```
node --check server/music-generator.js
# → syntax OK

npm test
# → 78/78 pass (identical to pre-change baseline)
```

Diff: 1 file, +32 −12 lines.

## Runtime

~25 minutes wall-clock (jitter + in-flight detection across 6 repos + repo selection + anti-noise PR/issue audit + close-handler grep + code review + 4 edits + syntax check + npm test + push).

---
_Auto-maintainer run · 2026-07-08T14:16 UTC · kannaka-radio_

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbJeRq7W5DCrEAU8smehy1)_