### PR TITLE
[auto-maintainer] fix(floor): add close() to FloorManager and call it on shutdown

### DIFF
--- a/server/floor.js
+++ b/server/floor.js
@@ -88,6 +88,18 @@ class FloorManager {
     this._broadcastPresence();
   }
 
+  /** Release timers on shutdown. */
+  close() {
+    if (this._vibeTimer) {
+      clearInterval(this._vibeTimer);
+      this._vibeTimer = null;
+    }
+    if (this._swarmPollTimer) {
+      clearInterval(this._swarmPollTimer);
+      this._swarmPollTimer = null;
+    }
+  }
+
   // ── Reactions ─────────────────────────────────────────────
 
   /** Process a floor_react message from a connected client. */

--- a/server/index.js
+++ b/server/index.js
@@ -1086,6 +1086,7 @@ function shutdown() {
   syncManager.stop();
   programming.stop();
   voteManager.cancelWindow();
+  floor.close();
   musicGen.stop();
   nats.disconnect();
   if (wss) wss.close();


### PR DESCRIPTION
## What changed

`FloorManager` (`server/floor.js`) creates two `setInterval` timers — `_vibeTimer` and `_swarmPollTimer` — in its constructor but provided no way to clear them. The `shutdown()` function in `server/index.js` already calls `.stop()` / `.close()` on every other stateful object (`perception_`, `flux`, `syncManager`, `programming`, `voteManager`, `musicGen`) but had no corresponding call for `floor`, leaving both intervals alive until `process.exit`.

| File | Change |
|------|--------|
| `server/floor.js` | Added `close()` method — clears `_vibeTimer` and `_swarmPollTimer` with null-guards |
| `server/index.js` | Added `floor.close()` to the `shutdown()` sequence, between `voteManager.cancelWindow()` and `musicGen.stop()` |

Diff: 2 files, +13 lines.

## Why it's safe

Both timers already call `.unref()` on creation, so they don't block graceful exit. The only observable difference is that the timers are now explicitly cleared rather than left to the GC after `process.exit`. On the happy path (a normal `SIGTERM` shutdown) behavior is unchanged — `process.exit` follows `shutdown()` and the process terminates regardless.

The `close()` method uses null-guards (`if (this._vibeTimer)`) so it is safe to call multiple times and from test teardown code.

Pattern follows `perception_.stopPerceptionLoop()` and `flux.stopPeriodicPublish()` — the same teardown idiom already used by every other component in `shutdown()`.

No overlap with open PR #88 (`server/music-generator.js`).

## Verification

```
node --check server/floor.js
# → syntax OK

npm test
# → 3 suites, all green (identical to pre-change baseline)
```

## Runtime

~25 minutes wall-clock (jitter + in-flight detection across 6 repos + repo selection + anti-noise PR/issue audit + code audit + fix + npm test + push). PR creation completed in a subsequent run after the branch was pushed.

---
_Auto-maintainer run · 2026-07-08T18:24 UTC · kannaka-radio_

---
_Generated by [Claude Code](https://claude.ai/code/session_016drJguJRwNUwCUgxyZoKjr)_