### PR TITLE
[auto-maintainer] fix(obc): add res.on("close") to _request and _getJson

### DIFF
--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -158,6 +158,7 @@ function _request(method, path, jwt, body, contentType) {
           resolve({ ok: false, error: "bad json: " + e.message + " body=" + data.slice(0, 200) });
         }
       });
+      res.on("close", () => resolve({ ok: false, error: "connection closed" }));
     });
     req.on("error", (e) => resolve({ ok: false, error: e.message }));
     req.on("timeout", () => { req.destroy(new Error("obc timeout")); });
@@ -196,6 +197,7 @@ function _getJson(path, jwt) {
       res.on("end", () => {
         try { resolve(JSON.parse(data)); } catch { resolve(null); }
       });
+      res.on("close", () => resolve(null));
     });
     req.on("error", () => resolve(null));
     req.on("timeout", () => { req.destroy(new Error("obc timeout")); resolve(null); });


### PR DESCRIPTION
## What changed

`server/openbotcity.js` exposes two internal HTTP helpers:

| Function | Surface | Callers |
|----------|---------|---------|
| `_request` | POST — `publishText`, `postFeed`, `sendDm`, `speak` | Peace oration, feed/DM |
| `_getJson` | GET — `getFeed`, `getDm` | Feed/DM reads |

Both had `res.on("data", ...)` + `res.on("end", ...)` but **no `res.on("close", ...)`**.

Diff: 1 file, +2 lines.

## Why this matters

When the OBC server (api.openbotcity.com, behind Cloudflare) drops the TCP connection before sending a complete HTTP response, Node's `IncomingMessage` emits `close` but **never** `end`. Without a `close` handler the returned Promise stays pending until `req.on("timeout")` fires (30 s) and `req.on("error")` eventually resolves it. Every peace-oration call to `publishText`, `postFeed`, `getFeed`, `getDm`, or `speak` can hang for up to 30 seconds during any network instability.

## Why it's safe

Under a healthy TCP exchange `end` always fires before `close`. The `_request` resolve call in `end` sets the Promise state; when `close` fires moments later, `resolve(...)` is called a second time — which is a safe no-op (Promise idempotency). **Zero behaviour change on the happy path.**

Only the premature-close case changes: instead of a 30-second hang the caller gets an immediate `{ ok: false, error: "connection closed" }` (for `_request`) or `null` (for `_getJson`), both of which callers already handle as failure.

This is the identical pattern already applied throughout the codebase:

| PR | Repo | Locations |
|----|------|-----------|
| #88 | kannaka-radio | `server/music-generator.js` (4 handlers) |
| `server/lib/scheduler-helpers.js` | kannaka-radio | `_fetchJson`, `_fetchText`, `fetchKnowledgeGeneInterpretation` |
| `server/bluesky.js` | kannaka-radio | `_request` (already had close handler) |
| #29–#34 | kannaka-staff | `probeStreamHead`, `probeHttpJson`, `postJson`, et al. |

`openbotcity.js` was the last file in the radio server with `end`-only response handlers.

No overlap with open PR #88 (`server/music-generator.js`) or #89 (`server/floor.js`).

## Verification

```
node --check server/openbotcity.js
# → syntax OK

npm test
# → all suites pass (identical to pre-change baseline)
```

## Runtime

~25 minutes wall-clock (jitter + in-flight detection across 6 repos + repo selection + anti-noise PR/issue audit + close-handler grep across all server/*.js + code review + fix + push). PR creation completed in a subsequent run after the branch was pushed due to context compaction.

---
_Auto-maintainer run · 2026-07-09T18:16 UTC · kannaka-radio_

---
_Generated by [Claude Code](https://claude.ai/code/session_011weTuiXrqzKd8aW7W7dhqJ)_