### PR TITLE
[auto-maintainer] refactor(scheduler-helpers): hoist os require; remove redundant inline requires

### DIFF
--- a/server/lib/scheduler-helpers.js
+++ b/server/lib/scheduler-helpers.js
@@ -11,6 +11,7 @@
 
 const https = require("https");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execFile } = require("child_process");
 
@@ -489,10 +490,6 @@ function composeViaKannakaAsk(kannakabin, prompt, opts = {}) {
  * config as the rest of the constellation. Single round-trip; caller retries.
  */
 function composeViaAnthropicDirect(prompt, opts = {}) {
-  const fs = require("fs");
-  const os = require("os");
-  const https = require("https");
-  const path = require("path");
   const maxTokens = opts.maxTokens || 4096;
 
   let apiKey = process.env.ANTHROPIC_API_KEY || process.env.KANNAKA_LLM_API_KEY || "";


### PR DESCRIPTION
## What changed

`composeViaAnthropicDirect` (line 491) declared four `const` bindings inside its own body — `fs`, `os`, `https`, and `path` — despite three of them (`fs`, `https`, `path`) already being module-level constants at lines 12-14. The inline declarations shadowed the module-level bindings for no reason.

| Symbol | Before | After |
|--------|--------|-------|
| `fs` | `const fs = require("fs")` inside function | module-level (line 13, already present) |
| `os` | `const os = require("os")` inside function | moved to module top (new line 14) |
| `https` | `const https = require("https")` inside function | module-level (line 12, already present) |
| `path` | `const path = require("path")` inside function | module-level (line 15, already present) |

**1 file, +1 −4 lines (net −3).**

This is the identical redundancy fixed in:
- **kannaka-staff PR #35** — `src/index.js` (`probeMetadataMountAlignment`, `probePodcastFilesPlayable`, `hrmExists`, `distributor`, `marketer`)
- **kannaka-radio PR #75** — `server/peace-oration.js` (lifted `fs`/`path`)

No overlap with the only other open auto-maintainer PR in this repo (#90, `server/openbotcity.js`).

## Why it's safe

Node.js caches modules: every `require("fs")` call after the first returns the exact same object the module-level `const fs` already holds. The four inline calls were therefore redundant by construction — not a distinct object, not lazy-load, just copy-paste style from an earlier incarnation before these imports were lifted to the top.

Removing the three redundant re-declarations and hoisting `os` alongside them means `composeViaAnthropicDirect` now reads its dependencies from the same four bindings every other function in the file uses — no hidden shadowing.

## Verification

```
node --check server/lib/scheduler-helpers.js
# → syntax OK

npm test
# → 8 passed, 0 failed (identical to pre-change baseline)
```

## Runtime

~20 minutes wall-clock (jitter + in-flight detection across 6 repos + repo selection + anti-noise PR/issue audit + file scan + fix + verify + push).

---
*Auto-maintainer run · 2026-07-14T14:14 UTC · kannaka-radio*

---
_Generated by [Claude Code](https://claude.ai/code/session_0133vYAKGkzSPQ4bLfhNPYKg)_