### PR TITLE
fix: exclude oracle-authoritative markets from TTL price auto-resolution (ADR-0041)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -458,8 +458,19 @@ class GhostSignalsHub {
       // gets resolved (#43). Fix: pass an identically-formatted ISO
       // string from JS so the lex comparison is consistent.
       const nowIso = new Date().toISOString();
+      // ADR-0041: oracle-authoritative (labs-tier) markets must NEVER be
+      // price-resolved by TTL. Their outcome is decided by the Labs oracle's
+      // measurement (observatory settlement -> /resolve with the oracle
+      // token), not by whichever side traders — including sybils — pumped
+      // the price to before expiry. Excluding them here closes the gap where
+      // the Phase-0 HTTP-endpoint gate is bypassed by this internal loop. An
+      // oracle market that outlives its TTL simply stays open until the
+      // oracle resolves it (or is voided by an operator), which is correct:
+      // no payout is better than a payout on the wrong, manufactured side.
       this.db.all(
-        `SELECT * FROM markets WHERE resolved = 0 AND expires_at < ?`,
+        `SELECT * FROM markets
+           WHERE resolved = 0 AND expires_at < ?
+             AND tag != 'labs' AND (source IS NULL OR source != 'kannaka-labs')`,
         [nowIso],
         async (err, rows) => {
           if (err) return resolve();

--- a/test/ghostsignals-ttl-authority.test.js
+++ b/test/ghostsignals-ttl-authority.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ADR-0041 regression: oracle-authoritative (labs-tier) markets must NEVER be
+// price-resolved by the TTL auto-resolver. Their outcome belongs to the Labs
+// oracle, not to whichever side traders pumped the price to before expiry.
+// A play-tier market with the same expiry must still auto-resolve, so the
+// test also proves we did not simply disable the resolver.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-test-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+async function main() {
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+
+  // Both markets expire immediately (ttl 1s, then we backdate via a past ttl).
+  // createMarket computes expires_at = now + ttl_sec*1000, so a negative ttl
+  // makes them already-expired without waiting.
+  const labs = await hub.createMarket({
+    question: 'labs market — oracle resolves this',
+    ttl_sec: -10, tag: 'labs', source: 'kannaka-labs',
+  });
+  const play = await hub.createMarket({
+    question: 'play market — TTL may resolve this',
+    ttl_sec: -10, tag: 'custom', source: 'system',
+  });
+
+  // Push the labs market's price toward 'No' so that IF the TTL resolver
+  // wrongly fired, it would resolve to the manipulated side (index 1).
+  await hub.registerTrader({ id: 'sybil', display_name: 'sybil', kind: 'ai' });
+  await hub.placeTrade({ market_id: labs.id, trader_id: 'sybil', outcome: 1, shares: 5 });
+
+  // Run the auto-resolver once.
+  await hub._resolveExpiredMarkets();
+
+  const labsAfter = await hub.getMarket(labs.id);
+  const playAfter = await hub.getMarket(play.id);
+
+  assert.strictEqual(labsAfter.resolved, false,
+    'BLOCKER: labs-tier market was price-resolved by the TTL sweep (oracle gate bypassed)');
+  assert.strictEqual(playAfter.resolved, true,
+    'play-tier market should still auto-resolve on TTL — resolver must not be disabled wholesale');
+
+  // And the oracle path still works on the labs market.
+  await hub.resolveMarket({ market_id: labs.id, winning_outcome: 0, method: 'manual' });
+  const labsFinal = await hub.getMarket(labs.id);
+  assert.strictEqual(labsFinal.resolved, true, 'oracle resolve must still settle the labs market');
+  assert.strictEqual(labsFinal.resolved_outcome, 0, 'oracle outcome must win, not the pumped price');
+
+  await hub.stop?.();
+  console.log('ghostsignals-ttl-authority.test.js: OK (labs market survives TTL; play market resolves; oracle wins)');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Follow-on from the ADR-0041 adversarial review — a **live exposure**, not just a design note.

**The hole:** Phase 0 (PR #93) put the oracle-token gate on the HTTP `POST /api/markets/:id/resolve` handler, but `ghostsignals-hub.js::_resolveExpiredMarketsInner` runs every 10s, SELECTs *every* expired `resolved=0` market with **no tag filter**, and resolves each by max traded price (`method:'ttl'`). So a labs-tier market still auto-resolves by whatever side traders — including free sybil registrations — pumped the price to, bypassing 'resolve = oracle only'.

**Why it's live:** `createHubMarket` sets the paired market's TTL to ~`settlesBy`, so **Prediction №2's market `m_4584162dfc2d` expires right around 2026-07-26** and would price-resolve then unless the oracle's resolve lands first.

**Fix:** the TTL sweep excludes `tag='labs'` / `source='kannaka-labs'` markets. An oracle market that outlives its TTL stays open until the oracle resolves it (the auto-settle sweep does exactly that at settle time) — no payout beats a payout on a manufactured side. No schema change (reuses existing `tag`/`source`).

**Test:** `test/ghostsignals-ttl-authority.test.js` (added to `npm test`) proves the labs market survives its TTL unresolved, a play market with the same expiry still auto-resolves (resolver not disabled wholesale), and the oracle resolve still wins with its own outcome over the pumped price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)