### PR TITLE
fix: guard hub ledger races — single-flip resolve, guarded debit, q CAS (ADR-0041)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -67,6 +67,25 @@ class GhostSignalsHub {
     this.broadcast = opts.broadcast || (() => {});
     this.db = null;
     this._resolverInterval = null;
+    // Serializes write-transactions (see _serializeTx). The whole hub shares
+    // ONE sqlite connection, so two overlapping BEGIN…COMMIT blocks error with
+    // "cannot start a transaction within a transaction". This chain guarantees
+    // one at a time.
+    this._txChain = Promise.resolve();
+  }
+
+  /**
+   * Run a write-transaction with exclusive access to the shared connection.
+   * The in-SQL guards (single-flip resolve, guarded debit, q compare-and-swap)
+   * provide correctness under contention; this just prevents two transactions
+   * from physically interleaving on the one connection (which sqlite rejects).
+   * `work` is a thunk returning a Promise for one BEGIN…COMMIT unit.
+   */
+  _serializeTx(work) {
+    const result = this._txChain.then(() => work(), () => work());
+    // Keep the chain alive regardless of this unit's outcome.
+    this._txChain = result.then(() => {}, () => {});
+    return result;
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────
@@ -307,53 +326,82 @@ class GhostSignalsHub {
     const trader = await this.getTrader(trader_id);
     if (!trader) throw new Error('trader not registered');
 
+    // The q we read is the state our cost is priced against. The write below
+    // is a compare-and-swap on exactly this value (`WHERE q = qBeforeJson`),
+    // so a concurrent trade that moved q first makes THIS write a no-op and we
+    // roll back — otherwise two trades computed from the same stale snapshot
+    // would each overwrite q absolutely (last-writer-wins), silently dropping
+    // one trade's shares from the market while both traders keep their credited
+    // positions, so total payouts could exceed collected cost (a mint).
     const qBefore = market.q.slice();
+    const qBeforeJson = JSON.stringify(qBefore);
+    const qAfter = qBefore.slice();
     const costBefore = lmsrCost(qBefore, market.liquidity);
-    qBefore[outcome] += shares;
-    const costAfter = lmsrCost(qBefore, market.liquidity);
+    qAfter[outcome] += shares;
+    const costAfter = lmsrCost(qAfter, market.liquidity);
     const cost = costAfter - costBefore;
 
     if (cost > trader.capital) {
       throw new Error(`insufficient capital: cost ${cost.toFixed(2)}, available ${trader.capital.toFixed(2)}`);
     }
 
-    return new Promise((resolve, reject) => {
-      this.db.serialize(() => {
-        this.db.run('BEGIN');
-        // Update market q + volume
-        this.db.run(
-          `UPDATE markets SET q = ?, volume = volume + ? WHERE id = ?`,
-          [JSON.stringify(qBefore), shares, market_id]
-        );
-        // Deduct trader capital + bump trades_total
-        this.db.run(
-          `UPDATE traders SET capital = capital - ?, trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ?`,
-          [cost, trader_id]
-        );
-        // Append trade
-        this.db.run(
-          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost) VALUES (?, ?, ?, ?, ?)`,
-          [market_id, trader_id, outcome, shares, cost]
-        );
-        // Upsert position
-        this.db.run(
-          `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
-           ON CONFLICT(market_id, trader_id, outcome_idx) DO UPDATE SET shares = shares + ?`,
-          [market_id, trader_id, outcome, shares, shares],
-          (err) => {
-            if (err) {
-              this.db.run('ROLLBACK');
-              return reject(err);
+    const self = this;
+    return this._serializeTx(() => new Promise((resolve, reject) => {
+      self.db.serialize(() => {
+        self.db.run('BEGIN');
+        // Compare-and-swap the market q. `AND resolved = 0` also blocks a trade
+        // that races a resolve. changes()===0 => someone moved q (or resolved)
+        // between our read and now; roll back and let the caller retry.
+        self.db.run(
+          `UPDATE markets SET q = ?, volume = volume + ? WHERE id = ? AND q = ? AND resolved = 0`,
+          [JSON.stringify(qAfter), shares, market_id, qBeforeJson],
+          function (qErr) {
+            if (qErr) { self.db.run('ROLLBACK'); return reject(qErr); }
+            if (this.changes === 0) {
+              self.db.run('ROLLBACK');
+              return reject(new Error('market state changed concurrently; retry'));
             }
-            this.db.run('COMMIT', async () => {
-              const updated = await this.getMarket(market_id);
-              this.broadcast({ type: 'gs_trade', data: { market_id, trader_id, outcome, shares, cost, prices: updated.prices } });
-              resolve({ cost, prices: updated.prices, market: updated });
-            });
+            // Guarded debit: the `AND capital >= ?` makes overdraft impossible
+            // even if two concurrent trades both passed the JS precheck above —
+            // the second sees the already-reduced balance and fails here rather
+            // than driving capital negative (a double-spend).
+            self.db.run(
+              `UPDATE traders SET capital = capital - ?, trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ? AND capital >= ?`,
+              [cost, trader_id, cost],
+              function (dErr) {
+                if (dErr) { self.db.run('ROLLBACK'); return reject(dErr); }
+                if (this.changes === 0) {
+                  self.db.run('ROLLBACK');
+                  return reject(new Error('insufficient capital'));
+                }
+                // Append trade
+                self.db.run(
+                  `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost) VALUES (?, ?, ?, ?, ?)`,
+                  [market_id, trader_id, outcome, shares, cost]
+                );
+                // Upsert position
+                self.db.run(
+                  `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
+                   ON CONFLICT(market_id, trader_id, outcome_idx) DO UPDATE SET shares = shares + ?`,
+                  [market_id, trader_id, outcome, shares, shares],
+                  (err) => {
+                    if (err) {
+                      self.db.run('ROLLBACK');
+                      return reject(err);
+                    }
+                    self.db.run('COMMIT', async () => {
+                      const updated = await self.getMarket(market_id);
+                      self.broadcast({ type: 'gs_trade', data: { market_id, trader_id, outcome, shares, cost, prices: updated.prices } });
+                      resolve({ cost, prices: updated.prices, market: updated });
+                    });
+                  }
+                );
+              }
+            );
           }
         );
       });
-    });
+    }));
   }
 
   /**
@@ -361,70 +409,82 @@ class GhostSignalsHub {
    * traders, then updates each participating trader's reputation via
    * brier scoring.
    */
-  resolveMarket({ market_id, winning_outcome, method = 'manual' }) {
-    return new Promise((resolve, reject) => {
-      this.getMarket(market_id).then(market => {
-        if (!market) return reject(new Error('market not found'));
-        if (market.resolved) return reject(new Error('already resolved'));
-        if (winning_outcome < 0 || winning_outcome >= market.outcomes.length) {
-          return reject(new Error('winning_outcome out of range'));
-        }
-        const finalPrices = market.prices.slice();
-        this.db.serialize(() => {
-          this.db.run('BEGIN');
-          this.db.run(
-            `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ?`,
-            [winning_outcome, method, market_id]
-          );
-          // Pay out winning shares + update reputation for every participant
-          this.db.all(
-            `SELECT trader_id, outcome_idx, shares FROM positions WHERE market_id = ?`,
-            [market_id],
-            (err, positions) => {
-              if (err) { this.db.run('ROLLBACK'); return reject(err); }
-              const traders = new Map();
-              for (const p of positions) {
-                if (!traders.has(p.trader_id)) traders.set(p.trader_id, { yes: 0, no: 0, totalShares: 0 });
-                const t = traders.get(p.trader_id);
-                t.totalShares += p.shares;
-                if (p.outcome_idx === winning_outcome) t.yes += p.shares;
-                else t.no += p.shares;
-              }
-              const tasks = [];
-              for (const [trader_id, t] of traders.entries()) {
-                // Payout = winning shares × $1
-                const payout = t.yes;
-                // Compute brier-style accuracy update from this trader's
-                // implied predicted probability (their share allocation
-                // toward the winning outcome).
-                const impliedYes = t.totalShares > 0 ? t.yes / t.totalShares : 0.5;
-                const accuracy = brierAccuracy(impliedYes, 1);
-                tasks.push(new Promise((ok, fail) => {
-                  this.db.run(
-                    `UPDATE traders SET
-                       capital = capital + ?,
-                       trades_won = trades_won + ?,
-                       reputation = reputation * 0.95 + ? * 0.05,
-                       last_active = CURRENT_TIMESTAMP
-                     WHERE id = ?`,
-                    [payout, t.yes > 0 ? 1 : 0, accuracy, trader_id],
-                    (e) => e ? fail(e) : ok()
-                  );
-                }));
-              }
-              Promise.all(tasks).then(() => {
-                this.db.run('COMMIT', () => {
-                  this.getMarket(market_id).then(m => {
-                    this.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices } });
-                    resolve(m);
-                  });
-                });
-              }).catch(e => { this.db.run('ROLLBACK'); reject(e); });
+  async resolveMarket({ market_id, winning_outcome, method = 'manual' }) {
+    const self = this;
+    const market = await this.getMarket(market_id);
+    if (!market) throw new Error('market not found');
+    if (market.resolved) throw new Error('already resolved');
+    if (winning_outcome < 0 || winning_outcome >= market.outcomes.length) {
+      throw new Error('winning_outcome out of range');
+    }
+    const finalPrices = market.prices.slice();
+    return this._serializeTx(() => new Promise((resolve, reject) => {
+        self.db.serialize(() => {
+          self.db.run('BEGIN');
+          // Single-flip guard: only the transaction that actually changes
+          // resolved 0->1 proceeds to pay out. A concurrent resolve (the manual
+          // /resolve racing the 10s TTL sweep, or two callers) reads resolved=0
+          // in the async gap before this UPDATE, but only ONE of them flips the
+          // flag; the loser sees changes()===0 and rolls back WITHOUT paying, so
+          // winning positions can never be paid twice (which would mint credits).
+          // The `market.resolved` precheck above is only a fast path; THIS is the
+          // real guard.
+          self.db.run(
+            `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ? AND resolved = 0`,
+            [winning_outcome, method, market_id],
+            function (uErr) {
+              if (uErr) { self.db.run('ROLLBACK'); return reject(uErr); }
+              if (this.changes === 0) { self.db.run('ROLLBACK'); return reject(new Error('already resolved')); }
+              // Pay out winning shares + update reputation for every participant
+              self.db.all(
+                `SELECT trader_id, outcome_idx, shares FROM positions WHERE market_id = ?`,
+                [market_id],
+                (err, positions) => {
+                  if (err) { self.db.run('ROLLBACK'); return reject(err); }
+                  const traders = new Map();
+                  for (const p of positions) {
+                    if (!traders.has(p.trader_id)) traders.set(p.trader_id, { yes: 0, no: 0, totalShares: 0 });
+                    const t = traders.get(p.trader_id);
+                    t.totalShares += p.shares;
+                    if (p.outcome_idx === winning_outcome) t.yes += p.shares;
+                    else t.no += p.shares;
+                  }
+                  const tasks = [];
+                  for (const [trader_id, t] of traders.entries()) {
+                    // Payout = winning shares × $1
+                    const payout = t.yes;
+                    // Compute brier-style accuracy update from this trader's
+                    // implied predicted probability (their share allocation
+                    // toward the winning outcome).
+                    const impliedYes = t.totalShares > 0 ? t.yes / t.totalShares : 0.5;
+                    const accuracy = brierAccuracy(impliedYes, 1);
+                    tasks.push(new Promise((ok, fail) => {
+                      self.db.run(
+                        `UPDATE traders SET
+                           capital = capital + ?,
+                           trades_won = trades_won + ?,
+                           reputation = reputation * 0.95 + ? * 0.05,
+                           last_active = CURRENT_TIMESTAMP
+                         WHERE id = ?`,
+                        [payout, t.yes > 0 ? 1 : 0, accuracy, trader_id],
+                        (e) => e ? fail(e) : ok()
+                      );
+                    }));
+                  }
+                  Promise.all(tasks).then(() => {
+                    self.db.run('COMMIT', () => {
+                      self.getMarket(market_id).then(m => {
+                        self.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices } });
+                        resolve(m);
+                      });
+                    });
+                  }).catch(e => { self.db.run('ROLLBACK'); reject(e); });
+                }
+              );
             }
           );
         });
-      }).catch(reject);
-    });
+      }));
   }
 
   /**

--- a/test/ghostsignals-ledger-safety.test.js
+++ b/test/ghostsignals-ledger-safety.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// ADR-0041 Phase-0 ledger-safety regressions for the GhostSignals hub:
+//   1. Concurrent resolveMarket must pay winners at most ONCE (single-flip
+//      guard) — the manual /resolve racing the TTL sweep must not double-pay.
+//   2. A trade over capital is rejected, and two concurrent trades that each
+//      fit alone but not together can never drive capital negative (guarded
+//      debit) — no credit double-spend.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-ledger-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+async function testDoubleResolve() {
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+  const m = await hub.createMarket({ question: 'double-resolve guard', ttl_sec: 3600, tag: 'custom' });
+  await hub.registerTrader({ id: 'winner', display_name: 'winner', kind: 'ai' });
+  const beforeCapital = (await hub.getTrader('winner')).capital;
+  const { cost } = await hub.placeTrade({ market_id: m.id, trader_id: 'winner', outcome: 0, shares: 10 });
+
+  // Fire two resolves for the SAME winning outcome concurrently (models the
+  // manual /resolve racing the TTL sweep). Exactly one must win; the other
+  // must reject 'already resolved' and pay nothing.
+  const settled = await Promise.allSettled([
+    hub.resolveMarket({ market_id: m.id, winning_outcome: 0, method: 'manual' }),
+    hub.resolveMarket({ market_id: m.id, winning_outcome: 0, method: 'ttl' }),
+  ]);
+  const ok = settled.filter((r) => r.status === 'fulfilled').length;
+  const rejected = settled.filter((r) => r.status === 'rejected');
+  assert.strictEqual(ok, 1, `exactly one resolve should succeed, got ${ok}`);
+  assert.ok(rejected.every((r) => /already resolved/.test(r.reason.message)),
+    'the losing resolve must reject with "already resolved"');
+
+  // Winner held 10 winning shares → paid exactly 10 once. Capital must be
+  // beforeCapital - cost + 10, NOT + 20 (which double-pay would produce).
+  const afterCapital = (await hub.getTrader('winner')).capital;
+  const expected = beforeCapital - cost + 10;
+  assert.ok(Math.abs(afterCapital - expected) < 1e-9,
+    `BLOCKER: winner capital ${afterCapital} != single-payout ${expected} (double-pay?)`);
+}
+
+async function testNoNegativeCapital() {
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10, startingCapital: 100 });
+  await hub.init();
+  const m = await hub.createMarket({ question: 'capital guard', ttl_sec: 3600, tag: 'custom' });
+  await hub.registerTrader({ id: 'broke', display_name: 'broke', kind: 'ai' });
+
+  // A single trade whose cost exceeds capital must be rejected.
+  let overRejected = false;
+  try {
+    await hub.placeTrade({ market_id: m.id, trader_id: 'broke', outcome: 0, shares: 100000 });
+  } catch (e) { overRejected = /insufficient capital/.test(e.message); }
+  assert.ok(overRejected, 'a trade over capital must reject with "insufficient capital"');
+
+  // Two concurrent trades that each fit alone but not together: at most the
+  // ones that fit may commit, and capital must never go negative.
+  const hub2 = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 1000, startingCapital: 100 });
+  await hub2.init();
+  const m2 = await hub2.createMarket({ question: 'concurrent debit', ttl_sec: 3600, tag: 'custom' });
+  await hub2.registerTrader({ id: 't', display_name: 't', kind: 'ai' });
+  // With high liquidity, cost ≈ shares/2 near the origin; 120 shares ≈ ~60 cost,
+  // so two of them (~120) exceed the 100 capital but one fits.
+  const results = await Promise.allSettled([
+    hub2.placeTrade({ market_id: m2.id, trader_id: 't', outcome: 0, shares: 120 }),
+    hub2.placeTrade({ market_id: m2.id, trader_id: 't', outcome: 0, shares: 120 }),
+  ]);
+  const cap = (await hub2.getTrader('t')).capital;
+  assert.ok(cap >= 0, `BLOCKER: capital went negative (${cap}) — unguarded concurrent debit`);
+  const committed = results.filter((r) => r.status === 'fulfilled').length;
+  assert.ok(committed <= 1, `at most one of the two over-together trades may commit, got ${committed}`);
+}
+
+async function main() {
+  await testDoubleResolve();
+  await testNoNegativeCapital();
+  console.log('ghostsignals-ledger-safety.test.js: OK (no double-pay; no negative capital)');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/test/market-auth-gate.test.js
+++ b/test/market-auth-gate.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// ADR-0041 Phase-0 regression: the oracle-token gate on the hub HTTP surface.
+// Drives the REAL routes.js handleRequest with mock req/res so a future edit
+// that removes or weakens the gate is caught in CI — not just verified by a
+// one-off live curl.
+//
+//   POST /api/markets/:id/resolve      no/ wrong token -> 403, hub NOT called
+//   POST /api/markets/:id/resolve      correct token   -> reaches the hub
+//   POST /api/markets (tag=labs)       no token        -> 403, hub NOT called
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const setupRoutes = require('../server/routes');
+
+process.env.GSHUB_ORACLE_TOKEN = 'test-oracle-token';
+
+function mockReq(method, url, headers, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = Object.assign({ host: 'localhost' }, headers || {});
+  const origOn = req.on.bind(req);
+  // Emit the body once a consumer attaches its 'end' listener, so it survives
+  // any awaits before readJson() subscribes.
+  req.on = (event, cb) => {
+    origOn(event, cb);
+    if (event === 'end') {
+      setImmediate(() => {
+        if (body != null) req.emit('data', Buffer.from(body));
+        req.emit('end');
+      });
+    }
+    return req;
+  };
+  return req;
+}
+
+function mockRes() {
+  const res = {};
+  res.statusCode = null;
+  res.body = '';
+  res.headers = null;
+  res._resolve = null;
+  res.done = new Promise((r) => { res._resolve = r; });
+  res.writeHead = (code, hdrs) => { res.statusCode = code; res.headers = hdrs; };
+  res.end = (data) => { if (data) res.body += data; res._resolve(); };
+  return res;
+}
+
+function makeHandler(hubStub) {
+  const deps = {
+    gsHub: hubStub,
+    broadcast: () => {},
+    config: { baseDir: __dirname, spaPath: __dirname, getMusicDir: () => __dirname },
+  };
+  return setupRoutes(deps);
+}
+
+async function main() {
+  // 1. resolve without a token -> 403, hub.resolveMarket never called.
+  {
+    let called = false;
+    const handler = makeHandler({ resolveMarket: async () => { called = true; return {}; } });
+    const req = mockReq('POST', '/api/markets/m_x/resolve', {}, JSON.stringify({ winning_outcome: 0 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(res.statusCode, 403, `no-token resolve should be 403, got ${res.statusCode}`);
+    assert.strictEqual(called, false, 'BLOCKER: hub.resolveMarket was reached without a token');
+  }
+
+  // 2. resolve with the WRONG token -> 403.
+  {
+    let called = false;
+    const handler = makeHandler({ resolveMarket: async () => { called = true; return {}; } });
+    const req = mockReq('POST', '/api/markets/m_x/resolve', { authorization: 'Bearer nope' }, JSON.stringify({ winning_outcome: 0 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(res.statusCode, 403, `wrong-token resolve should be 403, got ${res.statusCode}`);
+    assert.strictEqual(called, false, 'BLOCKER: hub.resolveMarket reached with a wrong token');
+  }
+
+  // 3. resolve WITH the correct token -> reaches the hub, 200.
+  {
+    let called = false;
+    const handler = makeHandler({ resolveMarket: async () => { called = true; return { id: 'm_x', resolved: true }; } });
+    const req = mockReq('POST', '/api/markets/m_x/resolve', { authorization: 'Bearer test-oracle-token' }, JSON.stringify({ winning_outcome: 0 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(called, true, 'correct-token resolve must reach the hub');
+    assert.strictEqual(res.statusCode, 200, `correct-token resolve should be 200, got ${res.statusCode}`);
+  }
+
+  // 4. labs-tier market creation without a token -> 403, hub.createMarket never called.
+  {
+    let called = false;
+    const handler = makeHandler({ createMarket: async () => { called = true; return {}; } });
+    const req = mockReq('POST', '/api/markets', {}, JSON.stringify({ question: 'x', tag: 'labs', ttl_sec: 60 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(res.statusCode, 403, `no-token labs create should be 403, got ${res.statusCode}`);
+    assert.strictEqual(called, false, 'BLOCKER: labs market created without a token');
+  }
+
+  console.log('market-auth-gate.test.js: OK (capless resolve/labs-create denied; oracle token reaches the hub)');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Three concurrency blockers from the ADR-0041 adversarial review, plus the missing gate regression test.

- **Double-pay on resolve**: `resolveMarket` flipped `resolved=1` with no `WHERE resolved=0` / changes check, so a manual `/resolve` racing the 10s TTL sweep could pay winners twice (mint). Now single-flip guarded — only the txn that changes 0→1 pays.
- **Negative capital**: `placeTrade` did check-then-act with an unguarded debit. Now `WHERE capital >= cost` + changes check → no overdraft/double-spend. Plus q is a **compare-and-swap** (`WHERE q = qBefore`) so a stale snapshot can't clobber another trade's shares (which would let payouts exceed collected cost).
- **Shared-connection transactions**: both wrap BEGIN…COMMIT in `_serializeTx` (a per-hub tx queue) so two transactions never overlap on the one sqlite connection (`cannot start a transaction within a transaction`).

**Tests** (both added to `npm test`, full suite green):
- `ghostsignals-ledger-safety` — concurrent resolve pays once; over/concurrent spend never goes negative.
- `market-auth-gate` — drives the real `routes.js` handler: capless resolve + labs-create → 403, oracle token reaches the hub. This is the **capless-caller-denied regression** the review flagged as missing.

Part of ADR-0041 Phase 0 (kannaka-memory). Continues #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)