### PR TITLE
feat: hub verifies KAX identity tokens; labs-tier trading requires a verified trader (ADR-0041 Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,23 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js"
   },
   "dependencies": {
+    "jose": "^6.2.3",
     "ws": "^8.18.0"
   },
   "optionalDependencies": {
     "sqlite3": "^5.1.7"
   },
-  "keywords": ["radio", "perception", "ghost", "music", "ai", "consciousness"],
+  "keywords": [
+    "radio",
+    "perception",
+    "ghost",
+    "music",
+    "ai",
+    "consciousness"
+  ],
   "author": "Kannaka",
   "license": "Space Child License v1.0"
 }

--- a/server/kax-identity.js
+++ b/server/kax-identity.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * kax-identity.js — verify KAX-issued identity tokens (ADR-0041 Phase 1).
+ *
+ * KAX is the constellation identity provider; it signs short-lived EdDSA
+ * tokens and publishes its public keys at a JWKS URL. The hub verifies those
+ * tokens LOCALLY against the fetched JWKS — no per-request call back to KAX.
+ *
+ * Hardening (matches KAX's own verifier, per the ADR-0041 review):
+ *  - algorithm pinned to EdDSA (rejects alg=none and HMAC-with-public-key
+ *    confusion — jose never treats an asymmetric key as an HMAC secret),
+ *  - issuer required, exp/iat/sub/kind required, small clock tolerance,
+ *  - key selected by kid from the remote JWKS (cached; refetched on an unknown
+ *    kid with a cooldown so a rotation is picked up without hammering KAX),
+ *  - FAIL-CLOSED: if the JWKS can't be fetched, verification throws and the
+ *    caller denies — a KAX/JWKS outage never silently admits an unverified
+ *    trader.
+ *
+ * jose is ESM-only (v6); loaded via dynamic import() so this stays a plain
+ * CommonJS module regardless of the Node version on the host.
+ */
+
+const KAX_JWKS_URL = process.env.KAX_JWKS_URL || "https://kax.ninja-portal.com/api/auth/jwks.json";
+const KAX_ISSUER = process.env.KAX_IDENTITY_ISSUER || "https://kax.ninja-portal.com";
+const IDENTITY_ALG = "EdDSA";
+
+let _jwks = null;
+async function getJwks() {
+  const { createRemoteJWKSet } = await import("jose");
+  if (!_jwks) {
+    _jwks = createRemoteJWKSet(new URL(KAX_JWKS_URL), {
+      cooldownDuration: 30_000, // min gap between refetches on an unknown kid
+      timeoutDuration: 8_000,
+    });
+  }
+  return _jwks;
+}
+
+/** Reset the cached JWKS — for tests that point KAX_JWKS_URL at a fixture. */
+function _resetJwksCache() {
+  _jwks = null;
+}
+
+function bearer(authHeader) {
+  if (typeof authHeader !== "string") return null;
+  const m = authHeader.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+/**
+ * Verify an Authorization header carrying a KAX token.
+ * Returns { ok:true, claims } or { ok:false, error }. Never throws.
+ */
+async function verifyKaxToken(authHeader) {
+  const token = bearer(authHeader);
+  if (!token) return { ok: false, error: "missing bearer token" };
+  try {
+    const { jwtVerify } = await import("jose");
+    const jwks = await getJwks();
+    const { payload } = await jwtVerify(token, jwks, {
+      issuer: KAX_ISSUER,
+      algorithms: [IDENTITY_ALG],
+      requiredClaims: ["exp", "iat", "sub", "kind"],
+      clockTolerance: 5,
+    });
+    const kind = payload.kind;
+    if (kind !== "user" && kind !== "agent" && kind !== "service") {
+      return { ok: false, error: "invalid principal kind" };
+    }
+    return { ok: true, claims: payload };
+  } catch (e) {
+    return { ok: false, error: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * The stable hub trader id derived from a verified token. Agent tokens trade
+ * AS the OBC bot they proved control of; users trade as their user id. The
+ * `kax:` namespace guarantees these can never collide with open play-tier
+ * self-registered trader ids (which are arbitrary strings), so an attacker
+ * can't self-register a play trader that impersonates an authenticated one.
+ */
+function traderIdFromClaims(claims) {
+  if (claims.kind === "agent" && claims.bot_id) return `kax:agent:${claims.bot_id}`;
+  return `kax:${claims.kind}:${claims.sub}`;
+}
+
+module.exports = { verifyKaxToken, traderIdFromClaims, _resetJwksCache };

--- a/server/routes.js
+++ b/server/routes.js
@@ -10,6 +10,7 @@ const { execFile } = require("child_process");
 const { ALBUMS } = require("./dj-engine");
 const { MIME, readBody, getSPA, findAudioFile } = require("./utils");
 const { handleAgentRequest, attachNatsClient } = require("./agent-endpoint");
+const { verifyKaxToken, traderIdFromClaims } = require("./kax-identity");
 
 // Delete-token check (#69). If RADIO_DELETE_TOKEN is set, compare the
 // supplied password against it (constant-time when lengths match). If
@@ -984,9 +985,32 @@ module.exports = function setupRoutes(deps) {
       }
       const tradeMatch = parsed.pathname.match(/^\/api\/markets\/(m_[\w-]+)\/trade$/);
       if (tradeMatch && req.method === "POST") {
-        readJson().then(body => gsHub.placeTrade({ ...body, market_id: tradeMatch[1] }))
-          .then(r => sendJson(200, { ok: true, ...r }))
-          .catch(e => sendJson(400, { ok: false, error: e.message }));
+        // ADR-0041 Phase 1: labs-tier (oracle-authoritative) markets require a
+        // verified KAX identity to trade, and the trader id is DERIVED from the
+        // token — never taken from the request body. This closes the sybil /
+        // grief / impersonation hole (self-registered `trader_id` strings) on
+        // exactly the markets whose price is cited as signal. Open play-tier
+        // markets are unchanged: anonymous, body-supplied trader id.
+        (async () => {
+          const body = await readJson();
+          const market = await gsHub.getMarket(tradeMatch[1]);
+          if (!market) { sendJson(404, { ok: false, error: "market not found" }); return; }
+          const labsTier = market.tag === "labs" || market.source === "kannaka-labs";
+          let traderId = body.trader_id;
+          if (labsTier) {
+            const v = await verifyKaxToken(req.headers["authorization"]);
+            if (!v.ok) {
+              sendJson(401, { ok: false, error: `labs-tier trading requires a KAX identity token: ${v.error}` });
+              return;
+            }
+            traderId = traderIdFromClaims(v.claims);
+            // Auto-register the authenticated trader on first trade so callers
+            // don't need a separate registration step.
+            await gsHub.registerTrader({ id: traderId, display_name: traderId, kind: v.claims.kind });
+          }
+          const r = await gsHub.placeTrade({ ...body, trader_id: traderId, market_id: tradeMatch[1] });
+          sendJson(200, { ok: true, ...r });
+        })().catch(e => sendJson(400, { ok: false, error: e.message }));
         return;
       }
       const resolveMatch = parsed.pathname.match(/^\/api\/markets\/(m_[\w-]+)\/resolve$/);

--- a/test/kax-identity.test.js
+++ b/test/kax-identity.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// ADR-0041 Phase 1: the hub's KAX token verifier. Spins up a tiny JWKS server
+// with a test Ed25519 key, points KAX_JWKS_URL at it, and checks that valid
+// tokens verify and every forgery/expiry/issuer vector is rejected — the same
+// hardening KAX's own verifier has.
+
+const assert = require('assert');
+const http = require('http');
+
+async function main() {
+  const { generateKeyPair, exportJWK, importJWK, SignJWT, calculateJwkThumbprint } = await import('jose');
+
+  const ISS = 'https://kax.ninja-portal.com';
+  const ALG = 'EdDSA';
+  const { privateKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+  const privJwk = await exportJWK(privateKey);
+  const kid = await calculateJwkThumbprint(privJwk);
+  const signKey = await importJWK({ ...privJwk, alg: ALG }, ALG);
+  const { d, ...pubJwk } = privJwk; // public = private minus d
+  pubJwk.kid = kid; pubJwk.alg = ALG; pubJwk.use = 'sig';
+
+  // Serve the JWKS on an ephemeral loopback port.
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ keys: [pubJwk] }));
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  process.env.KAX_JWKS_URL = `http://127.0.0.1:${port}/jwks.json`;
+  process.env.KAX_IDENTITY_ISSUER = ISS;
+
+  // Require AFTER env is set; reset the cache to be safe.
+  const { verifyKaxToken, traderIdFromClaims, _resetJwksCache } = require('../server/kax-identity');
+  _resetJwksCache();
+
+  const now = Math.floor(Date.now() / 1000);
+  const mk = (o = {}) => new SignJWT(o.claims || { kind: 'agent', bot_id: 'bot-xyz' })
+    .setProtectedHeader({ alg: ALG, kid: o.kid || kid, typ: 'JWT' })
+    .setIssuer(o.iss || ISS).setSubject(o.sub || 'user-1')
+    .setIssuedAt(o.iat || now).setExpirationTime(o.exp || now + 900).setJti('j')
+    .sign(o.key || signKey);
+
+  // 1. valid agent token verifies + derives the bot-scoped trader id
+  {
+    const token = await mk();
+    const v = await verifyKaxToken(`Bearer ${token}`);
+    assert.strictEqual(v.ok, true, `valid token should verify: ${v.error}`);
+    assert.strictEqual(v.claims.kind, 'agent');
+    assert.strictEqual(traderIdFromClaims(v.claims), 'kax:agent:bot-xyz');
+  }
+  // 2. user token derives a user-scoped trader id
+  {
+    const token = await mk({ claims: { kind: 'user' }, sub: 'user-42' });
+    const v = await verifyKaxToken(`Bearer ${token}`);
+    assert.strictEqual(v.ok, true);
+    assert.strictEqual(traderIdFromClaims(v.claims), 'kax:user:user-42');
+  }
+  // 3. missing bearer -> rejected
+  assert.strictEqual((await verifyKaxToken(undefined)).ok, false);
+  assert.strictEqual((await verifyKaxToken('Basic abc')).ok, false);
+  // 4. expired -> rejected
+  assert.strictEqual((await verifyKaxToken(`Bearer ${await mk({ iat: now - 3600, exp: now - 3000 })}`)).ok, false);
+  // 5. wrong issuer -> rejected
+  assert.strictEqual((await verifyKaxToken(`Bearer ${await mk({ iss: 'https://evil' })}`)).ok, false);
+  // 6. alg=none unsigned forgery -> rejected
+  {
+    const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+    const p = Buffer.from(JSON.stringify({ iss: ISS, sub: 'x', kind: 'service', iat: now, exp: now + 900 })).toString('base64url');
+    assert.strictEqual((await verifyKaxToken(`Bearer ${h}.${p}.`)).ok, false);
+  }
+  // 7. token signed by a foreign key (unknown kid) -> rejected
+  {
+    const { privateKey: ak } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+    const akey = await importJWK({ ...await exportJWK(ak), alg: ALG }, ALG);
+    assert.strictEqual((await verifyKaxToken(`Bearer ${await mk({ kid: 'attacker', key: akey })}`)).ok, false);
+  }
+
+  server.close();
+  console.log('kax-identity.test.js: OK (valid tokens verify + derive trader id; forgery/expiry/issuer all rejected)');
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/test/market-auth-gate.test.js
+++ b/test/market-auth-gate.test.js
@@ -102,7 +102,39 @@ async function main() {
     assert.strictEqual(called, false, 'BLOCKER: labs market created without a token');
   }
 
-  console.log('market-auth-gate.test.js: OK (capless resolve/labs-create denied; oracle token reaches the hub)');
+  // 5. labs-tier TRADE without a KAX token -> 401, placeTrade never called.
+  //    (verifyKaxToken short-circuits on a missing bearer — no network needed.)
+  {
+    let traded = false;
+    const handler = makeHandler({
+      getMarket: async () => ({ id: 'm_labs', tag: 'labs', source: 'kannaka-labs', outcomes: ['Yes', 'No'] }),
+      placeTrade: async () => { traded = true; return { cost: 1 }; },
+      registerTrader: async () => ({}),
+    });
+    const req = mockReq('POST', '/api/markets/m_labs/trade', {}, JSON.stringify({ trader_id: 'sybil', outcome: 0, shares: 5 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(res.statusCode, 401, `no-token labs trade should be 401, got ${res.statusCode}`);
+    assert.strictEqual(traded, false, 'BLOCKER: labs-tier trade placed without a KAX identity');
+  }
+
+  // 6. play-tier TRADE without a token -> unchanged: reaches the hub with the
+  //    body-supplied trader id (open play tier is intentionally anonymous).
+  {
+    let seenTraderId = null;
+    const handler = makeHandler({
+      getMarket: async () => ({ id: 'm_play', tag: 'custom', source: 'system', outcomes: ['Yes', 'No'] }),
+      placeTrade: async (args) => { seenTraderId = args.trader_id; return { cost: 1, prices: [0.5, 0.5] }; },
+      registerTrader: async () => ({}),
+    });
+    const req = mockReq('POST', '/api/markets/m_play/trade', {}, JSON.stringify({ trader_id: 'anon-player', outcome: 0, shares: 5 }));
+    const res = mockRes();
+    await handler(req, res); await res.done;
+    assert.strictEqual(res.statusCode, 200, `play-tier trade should be 200, got ${res.statusCode}`);
+    assert.strictEqual(seenTraderId, 'anon-player', 'play-tier trade must keep its anonymous body trader id');
+  }
+
+  console.log('market-auth-gate.test.js: OK (capless resolve/labs-create/labs-trade denied; play trade open; oracle token reaches the hub)');
 }
 
 main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
ADR-0041 **Phase 1, increment 2** — the radio hub can now verify KAX identity tokens, and **labs-tier trading is bound to a verified identity**. This closes the review's sybil/grief/impersonation finding on exactly the markets whose price is cited as signal.

## What this adds

- **`server/kax-identity.js`** — a local verifier for KAX-issued tokens. Fetches KAX's JWKS (jose `createRemoteJWKSet`, cached, refetch-on-unknown-kid with cooldown) and verifies with the same hardening as KAX's issuer: **EdDSA pinned** (rejects `alg=none` + HMAC confusion), issuer required, `exp`/`iat`/`sub`/`kind` required, small clock tolerance, **fail-closed** if the JWKS can't be fetched (a KAX/JWKS outage denies, never admits). jose is loaded via dynamic `import()` so this stays CommonJS on any Node version.
- **Labs-tier trade gate** (`POST /api/markets/:id/trade`): if the market is `tag: labs` / `source: kannaka-labs`, the caller must present a valid KAX token and the **`trader_id` is derived from the token** (`kax:agent:<bot>` or `kax:<kind>:<sub>`), never from the request body. The authenticated trader is auto-registered on first trade. **Open play-tier markets are unchanged** — anonymous, body-supplied trader id, per the ADR's two-tier design.

## Why the namespace

Derived ids are `kax:`-prefixed so they can never collide with a self-registered play-tier trader string — an attacker can't register a play trader that impersonates an authenticated one.

## Tests (both added to `npm test`, full suite green)

- **`kax-identity.test.js`** — spins up a local JWKS fixture with a test Ed25519 key: valid user/agent tokens verify and derive the right trader id; missing-bearer, expired, wrong-issuer, `alg=none`, and foreign-key/unknown-kid are all rejected.
- **`market-auth-gate.test.js`** (extended) — a labs-tier trade with no token → **401** and `placeTrade` is never reached; a play-tier trade → **200** keeping its anonymous body trader id.

## Deploy note

Adds the `jose` dependency, so the Oracle deploy is `git pull && npm install && systemctl restart kannaka-radio` (not just pull+restart). `KAX_JWKS_URL` defaults to `https://kax.ninja-portal.com/api/auth/jwks.json`; `KAX_IDENTITY_ISSUER` defaults to the KAX origin — both already correct in prod, no new secret needed.

Next: increment 3 — observatory verifier + proposal `proposed→open→settled` lifecycle + observatory login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
