### PR TITLE
feat: KAX ledger client + funded-AMM economic math (ADR-0041 Phase 2, PR 2a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/kax-ledger.js
+++ b/server/kax-ledger.js
@@ -1,0 +1,235 @@
+'use strict';
+
+/**
+ * kax-ledger.js — client + economic math for the KAX double-entry credit
+ * ledger (ADR-0041 Phase 2, funded-AMM PR 2).
+ *
+ * Labs-tier GhostSignals markets move REAL conserved credits on the KAX ledger
+ * (Agent-Kax, Postgres) instead of unbacked local SQLite capital. This module
+ * is (a) the integer economic math that keeps the funded AMM provably solvent
+ * and (b) the thin HTTP client that posts server-built transactions to the
+ * typed KAX endpoints (/api/ledger/grant|escrow|trade|payout, GET /tx/:txId).
+ *
+ * INERT UNTIL CONFIGURED. The mint / trade / read surfaces are each "enabled"
+ * only when KAX_LEDGER_BASE and the corresponding token are set, so the hub
+ * behaves EXACTLY as today until Nick arms the env in prod. Nothing here runs
+ * on the non-labs / ambient TTL path — those keep SQLite capital untouched.
+ *
+ * Two adversarial-review blockers live here and are unit-tested without a
+ * network (see test/kax-ledger.test.js):
+ *   #10 rounding in the POOL's favor — costMinor = ceil, payoutMinor = floor —
+ *       so amm = subsidy + Σceil(cost) − Σfloor(payout) ≥ 0; a split-buy can't
+ *       drain the pool via accumulated sub-unit dust.
+ *   #12 ambiguous ≠ failed — only a definitive 4xx means "not posted". A
+ *       timeout / 5xx stays ambiguous (the tx MAY have committed) and the
+ *       caller must reconcile via getTx before telling the trader anything.
+ */
+
+const crypto = require('crypto');
+
+// Integer minor units per credit. 6 dp (like USDC) keeps small LMSR costs from
+// being swamped by the ceil rounding, while staying well inside 2^53 for the
+// float→int multiply: credits stay < ~10^6, so credits*MINOR < ~10^12 << 2^53.
+const MINOR = 1_000_000;
+
+/** Env-derived config, read fresh each call so tests / redeploys pick up changes. */
+function cfg() {
+  return {
+    base: (process.env.KAX_LEDGER_BASE || '').replace(/\/+$/, ''),
+    mintToken: process.env.KAX_LEDGER_MINT_TOKEN || '',
+    tradeToken: process.env.KAX_LEDGER_TRADE_TOKEN || '',
+    readToken: process.env.KAX_SERVICE_TOKEN || process.env.KAX_LEDGER_READ_TOKEN || '',
+    asset: process.env.KAX_LEDGER_ASSET || 'play_credit',
+    timeoutMs: Number(process.env.KAX_LEDGER_TIMEOUT_MS || 8000),
+  };
+}
+
+function tradeEnabled() { const c = cfg(); return !!(c.base && c.tradeToken); }
+function mintEnabled() { const c = cfg(); return !!(c.base && c.mintToken); }
+function readEnabled() { const c = cfg(); return !!(c.base && c.readToken); }
+
+// ── Economic math (pure, exported for tests) ─────────────────────────────
+
+/** ceil(credits · MINOR) as a decimal integer STRING of minor units. */
+function toMinorCeil(credits) {
+  if (!Number.isFinite(credits) || credits < 0) throw new Error('credits must be a finite number >= 0');
+  return String(Math.ceil(credits * MINOR));
+}
+
+/** floor(credits · MINOR) as a decimal integer STRING of minor units. */
+function toMinorFloor(credits) {
+  if (!Number.isFinite(credits) || credits < 0) throw new Error('credits must be a finite number >= 0');
+  return String(Math.floor(credits * MINOR));
+}
+
+/**
+ * The LMSR worst-case subsidy the pool must be funded with before it opens:
+ * ceil(b · ln(n) · MINOR). This is the maximum the market maker can lose across
+ * all outcomes, so escrowing it guarantees every payout is backed.
+ */
+function subsidyMinor(b, n) {
+  if (!(b > 0) || !Number.isInteger(n) || n < 2) throw new Error('b>0 and integer n>=2 required');
+  return toMinorCeil(b * Math.log(n));
+}
+
+/**
+ * A trade's cost rounded UP into minor units (charge the trader the ceil), and
+ * a rejection of dust trades that round to 0 — a free share is a mint. Returns a
+ * decimal integer string; throws on cost that rounds to <= 0.
+ */
+function tradeCostMinor(costCredits) {
+  if (!Number.isFinite(costCredits)) throw new Error('cost must be finite');
+  const m = Math.ceil(costCredits * MINOR);
+  if (!(m > 0)) throw new Error('trade cost rounds to <= 0 minor units (dust)');
+  return String(m);
+}
+
+/** A winning position's payout rounded DOWN into minor units (floor toward the pool). */
+function payoutMinor(shares) {
+  return toMinorFloor(shares);
+}
+
+// ── Deterministic transaction ids (idempotency keys) ─────────────────────
+// Same logical event → same txId → the KAX idempotency registry applies it at
+// most once, so a retry after an ambiguous outcome is always safe.
+const txid = {
+  escrow: (m) => `escrow:${m}`,
+  resolve: (m) => `resolve:${m}`,
+  voidMarket: (m) => `void:${m}`,
+  grantRegister: (p) => `grant:register:${p}`,
+  trade: (uuid) => `trade:${uuid}`,
+  refund: (orig) => `refund:${orig}`,
+  sweep: (m) => `sweep:${m}`,
+};
+
+/** A fresh trade uuid to persist in the pending_trades journal BEFORE posting. */
+function newTradeUuid() { return crypto.randomUUID(); }
+
+// Ledger principal grammar mirror (KAX PRINCIPAL_RE). A labs trader_id is the
+// KAX token subject (e.g. "kax:agent:<bot>"); the ledger account is
+// `trader:<principal>`. Reject anything that wouldn't validate server-side so we
+// fail locally with a clear error instead of a 400.
+const PRINCIPAL_RE = /^[a-z0-9][a-z0-9:_.-]{2,127}$/i;
+function principalFor(traderId) {
+  if (typeof traderId !== 'string' || !PRINCIPAL_RE.test(traderId)) {
+    throw new Error(`trader_id "${traderId}" is not a valid ledger principal`);
+  }
+  return traderId;
+}
+
+// ── HTTP core ────────────────────────────────────────────────────────────
+
+/**
+ * POST/GET JSON with a bounded timeout and the review's ambiguity contract:
+ *   { ok:true,  definitive:true,  status, result }   — committed (2xx)
+ *   { ok:false, definitive:true,  status, error }    — NOT posted (4xx: bad
+ *       request / auth / 409 conflict / 429 cap); retrying the same body won't help
+ *   { ok:false, definitive:false, status, error }    — AMBIGUOUS (5xx / timeout /
+ *       network): the tx MAY have committed — reconcile via getTx, do not assume
+ */
+async function httpJson(method, pathname, token, body) {
+  if (typeof fetch !== 'function') {
+    return { ok: false, definitive: false, status: 0, error: 'global fetch unavailable (need Node >= 18)' };
+  }
+  const c = cfg();
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), c.timeoutMs);
+  try {
+    const res = await fetch(c.base + pathname, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: ctrl.signal,
+    });
+    let json = null;
+    try { json = await res.json(); } catch (_) { json = null; }
+    if (res.ok) return { ok: true, definitive: true, status: res.status, result: json };
+    if (res.status >= 400 && res.status < 500) {
+      return { ok: false, definitive: true, status: res.status, error: (json && json.error) || `http ${res.status}` };
+    }
+    return { ok: false, definitive: false, status: res.status, error: (json && json.error) || `http ${res.status}` };
+  } catch (err) {
+    // AbortError (timeout) and network failures are ambiguous, never "not posted".
+    return { ok: false, definitive: false, status: 0, error: (err && err.message) || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Typed transaction methods ────────────────────────────────────────────
+
+/** Fund a market's AMM pool with its LMSR subsidy (house → amm). Mint surface. */
+async function escrow({ marketId, subsidyMinor: sub, ref }) {
+  if (!mintEnabled()) throw new Error('kax mint surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/escrow', c.mintToken, {
+    txId: txid.escrow(marketId), marketId, amount: String(sub), asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Grant play credits to a trader (house → trader). Mint surface. Idempotent on txId. */
+async function grant({ principal, amountMinor, txId: id, ref }) {
+  if (!mintEnabled()) throw new Error('kax mint surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/grant', c.mintToken, {
+    txId: id || txid.grantRegister(principal), principal, amount: String(amountMinor), asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Move a trade's cost between a trader and a pool (buy: trader→amm; sell: amm→trader). Trade surface. */
+async function trade({ txId: id, principal, marketId, amountMinor, side, ref }) {
+  if (!tradeEnabled()) throw new Error('kax trade surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/trade', c.tradeToken, {
+    txId: id, principal, marketId, amount: String(amountMinor), side: side === 'sell' ? 'sell' : 'buy', asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Pay all winners out of a pool + sweep residual to house, in ONE balanced tx. Trade surface. */
+async function payout({ marketId, winners, residualMinor, ref }) {
+  if (!tradeEnabled()) throw new Error('kax trade surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/payout', c.tradeToken, {
+    txId: txid.resolve(marketId),
+    marketId,
+    winners: (winners || []).map((w) => ({ principal: w.principal, amount: String(w.amountMinor) })),
+    residual: String(residualMinor || '0'),
+    asset: c.asset,
+    ref: ref || null,
+  });
+}
+
+/** Look up a committed tx by id for reconciliation of an ambiguous outcome. Read surface. */
+async function getTx(txId) {
+  if (!readEnabled()) throw new Error('kax read surface not configured');
+  const c = cfg();
+  return httpJson('GET', `/api/ledger/tx/${encodeURIComponent(txId)}`, c.readToken, null);
+}
+
+module.exports = {
+  MINOR,
+  cfg,
+  tradeEnabled,
+  mintEnabled,
+  readEnabled,
+  // math
+  toMinorCeil,
+  toMinorFloor,
+  subsidyMinor,
+  tradeCostMinor,
+  payoutMinor,
+  // ids
+  txid,
+  newTradeUuid,
+  principalFor,
+  // http
+  httpJson,
+  escrow,
+  grant,
+  trade,
+  payout,
+  getTx,
+};

--- a/test/kax-ledger.test.js
+++ b/test/kax-ledger.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+// Unit tests for the KAX ledger client + economic math (ADR-0041 Phase 2,
+// funded-AMM PR 2a). No network, no DB — exercises the two review blockers that
+// live in this module:
+//   #10 rounding in the pool's favor (solvency), and
+//   #12 ambiguous ≠ failed (the httpJson classification contract).
+
+const assert = require('assert');
+const kax = require('../server/kax-ledger');
+
+function testRoundingDirection() {
+  // ceil charges the trader up; floor pays the winner down. Same fractional
+  // input must round in OPPOSITE directions (the pool keeps the sub-unit).
+  assert.strictEqual(kax.toMinorCeil(1.0000004), '1000001', 'ceil rounds up');
+  assert.strictEqual(kax.toMinorFloor(1.0000004), '1000000', 'floor rounds down');
+  assert.strictEqual(kax.toMinorCeil(2), '2000000', 'integer credits exact (ceil)');
+  assert.strictEqual(kax.toMinorFloor(2), '2000000', 'integer credits exact (floor)');
+  console.log('ok  rounding direction (ceil up / floor down)');
+}
+
+function testDustRejected() {
+  // A trade whose cost rounds to <= 0 minor units would be a free share. Because
+  // we ceil, any strictly-positive cost charges at least 1 minor unit (in the
+  // pool's favor), so only cost <= 0 is dust.
+  assert.throws(() => kax.tradeCostMinor(0), /dust/, 'zero cost rejected');
+  assert.throws(() => kax.tradeCostMinor(-0.5), /dust/, 'negative cost rejected');
+  assert.strictEqual(kax.tradeCostMinor(1e-9), '1', 'tiny positive cost still charges 1 minor unit');
+  assert.strictEqual(kax.tradeCostMinor(1e-6), '1', 'exactly one minor unit');
+  assert.strictEqual(kax.tradeCostMinor(0.5), '500000', 'half credit');
+  console.log('ok  dust trades rejected (no free shares); tiny costs charge >= 1');
+}
+
+function testSubsidyFormula() {
+  // subsidy = ceil(b·ln(n)·MINOR). b=10, n=2 → 10·0.6931… = 6.931… credits.
+  const s = kax.subsidyMinor(10, 2);
+  assert.strictEqual(s, String(Math.ceil(10 * Math.log(2) * kax.MINOR)), 'subsidy = ceil(b·ln n·MINOR)');
+  assert.ok(BigInt(s) > 6_931_000n && BigInt(s) < 6_932_000n, `subsidy ~6.931 credits, got ${s}`);
+  assert.throws(() => kax.subsidyMinor(10, 1), /n>=2/, 'n<2 rejected');
+  assert.throws(() => kax.subsidyMinor(0, 2), /b>0/, 'b<=0 rejected');
+  console.log('ok  subsidy formula');
+}
+
+function testSolvencyInvariant() {
+  // The core conservation claim: for ANY sequence of trades then payouts, with
+  // ceil charging and floor paying, the pool never goes negative. Construct the
+  // worst case: costs and payouts that (unrounded) would net the pool to exactly
+  // 0, then show integer rounding leaves it >= 0.
+  const b = 10, n = 2;
+  const subsidy = BigInt(kax.subsidyMinor(b, n));
+  // 200 trades with fractional per-unit costs.
+  let charged = 0n;
+  const trueCosts = [];
+  for (let i = 0; i < 200; i++) {
+    const c = 0.0000005 + (i % 7) * 0.13; // fractional credits
+    trueCosts.push(c);
+    charged += BigInt(kax.tradeCostMinor(c));
+  }
+  // Winners are paid the floor of some share amounts whose TRUE total value
+  // equals subsidy(true) + Σ trueCosts — i.e. the market maker's break-even.
+  const trueInflow = trueCosts.reduce((a, c) => a + c, 0) + b * Math.log(n);
+  // Split the break-even inflow across 50 winners as share payouts.
+  let paid = 0n;
+  const per = trueInflow / 50;
+  for (let i = 0; i < 50; i++) paid += BigInt(kax.payoutMinor(per));
+  const poolAfter = subsidy + charged - paid;
+  assert.ok(poolAfter >= 0n, `pool must stay solvent; got ${poolAfter}`);
+  console.log(`ok  solvency invariant (pool residual ${poolAfter} minor units >= 0)`);
+}
+
+function testTxidDeterminism() {
+  assert.strictEqual(kax.txid.escrow('m_abc'), 'escrow:m_abc');
+  assert.strictEqual(kax.txid.resolve('m_abc'), 'resolve:m_abc');
+  assert.strictEqual(kax.txid.grantRegister('kax:agent:alias'), 'grant:register:kax:agent:alias');
+  // Same logical event → identical id (idempotency key stability).
+  assert.strictEqual(kax.txid.resolve('m_abc'), kax.txid.resolve('m_abc'));
+  console.log('ok  deterministic txids');
+}
+
+function testPrincipalValidation() {
+  assert.strictEqual(kax.principalFor('kax:agent:alias'), 'kax:agent:alias');
+  assert.throws(() => kax.principalFor(''), /valid ledger principal/);
+  assert.throws(() => kax.principalFor('has space'), /valid ledger principal/);
+  assert.throws(() => kax.principalFor('a'), /valid ledger principal/, 'too short');
+  console.log('ok  principal validation mirrors server grammar');
+}
+
+// #12: the ambiguity contract. Stub global.fetch to drive each branch.
+async function testAmbiguityContract() {
+  const origFetch = global.fetch;
+  const stub = (status, jsonBody, opts = {}) => {
+    global.fetch = async () => {
+      if (opts.throwErr) throw new Error('network down');
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => jsonBody,
+      };
+    };
+  };
+  try {
+    // 2xx → committed, definitive.
+    stub(201, { ok: true, head: 'h', count: 2 });
+    let r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [true, true], '2xx committed+definitive');
+
+    // 409 (conflict / insufficient) → NOT posted, definitive.
+    stub(409, { ok: false, error: 'insufficient funds' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [false, true], '409 not-posted+definitive');
+
+    // 400 → definitive.
+    stub(400, { ok: false, error: 'bad request' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.strictEqual(r.definitive, true, '400 definitive');
+
+    // 429 (grant cap) → definitive.
+    stub(429, { ok: false, error: 'daily grant cap exceeded' });
+    r = await kax.httpJson('POST', '/api/ledger/grant', 't', { a: 1 });
+    assert.strictEqual(r.definitive, true, '429 definitive');
+
+    // 500 → AMBIGUOUS (may have committed) — must NOT be treated as failed.
+    stub(500, { ok: false, error: 'boom' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [false, false], '5xx ambiguous');
+
+    // network error / timeout → AMBIGUOUS.
+    stub(0, null, { throwErr: true });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive, r.status], [false, false, 0], 'network error ambiguous');
+
+    console.log('ok  ambiguity contract (4xx=not-posted, 5xx/timeout=reconcile)');
+  } finally {
+    global.fetch = origFetch;
+  }
+}
+
+function testInertUntilConfigured() {
+  // With no env, the surfaces are disabled and mutating calls refuse locally.
+  const saved = { ...process.env };
+  delete process.env.KAX_LEDGER_BASE;
+  delete process.env.KAX_LEDGER_MINT_TOKEN;
+  delete process.env.KAX_LEDGER_TRADE_TOKEN;
+  try {
+    assert.strictEqual(kax.tradeEnabled(), false);
+    assert.strictEqual(kax.mintEnabled(), false);
+    return Promise.all([
+      assert.rejects(() => kax.trade({ txId: 'trade:x', principal: 'kax:agent:a', marketId: 'm_1', amountMinor: '10' }), /not configured/),
+      assert.rejects(() => kax.escrow({ marketId: 'm_1', subsidyMinor: '10' }), /not configured/),
+    ]).then(() => console.log('ok  inert until configured'));
+  } finally {
+    Object.assign(process.env, saved);
+  }
+}
+
+(async () => {
+  testRoundingDirection();
+  testDustRejected();
+  testSubsidyFormula();
+  testSolvencyInvariant();
+  testTxidDeterminism();
+  testPrincipalValidation();
+  await testAmbiguityContract();
+  await testInertUntilConfigured();
+  console.log('\nPASSED kax-ledger.test.js');
+})().catch((e) => {
+  console.error('\nFAILED kax-ledger.test.js:', e.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
First increment of the **hub economy wiring** (funded-AMM PR 2, items #10/#12/#15/#16 from the hardened blueprint). Adds the client + integer math that will let **labs-tier** GhostSignals markets move **real conserved credits** on the KAX ledger (Agent-Kax, Postgres) instead of unbacked local SQLite capital.

**Inert until armed.** Every surface is gated on `KAX_LEDGER_BASE` + its token — with none set, `tradeEnabled()/mintEnabled()` are false and mutating calls reject locally. The hub behaves exactly as today until Nick sets the env in prod. Nothing here touches the non-labs / ambient TTL path (those keep SQLite capital untouched, per scope item #18).

### `server/kax-ledger.js`
- **Integer economic math** (minor units, 6 dp) — the two review blockers, both unit-tested with no network:
  - **#10 rounding in the pool's favor**: `tradeCostMinor = ceil` (charge up, reject dust ≤ 0), `payoutMinor = floor` (pay down), `subsidyMinor = ceil(b·ln(n)·MINOR)`. So `amm = subsidy + Σceil(cost) − Σfloor(payout) ≥ 0` — a split-buy can't drain the pool via accumulated sub-unit dust.
  - **#12 ambiguous ≠ failed**: the HTTP client classifies `2xx=committed`, `4xx=definitively-not-posted`, `5xx/timeout/network=AMBIGUOUS` (the tx may have committed → reconcile via `getTx`, never assume failed). Bounded timeout via `AbortController`.
- **Deterministic txIds** (`escrow:` / `resolve:` / `grant:register:` / `trade:` / `refund:` / `sweep:`) as idempotency keys, so a retry after an ambiguous outcome applies at most once (matches the KAX idempotency registry in Agent-Kax PR #80).
- `principalFor()` mirrors the server `PRINCIPAL_RE` (fail locally, not on a 400); amounts sent as **decimal strings**.

### `test/kax-ledger.test.js` (wired into `npm test`)
Rounding direction · dust rejection · subsidy formula · **the solvency invariant** (200 trades → 50 payouts, pool residual stays ≥ 0; observed +122 minor units in the pool's favor) · txid determinism · principal validation · the full ambiguity contract via a stubbed `fetch` · inert-until-configured. Existing `ghostsignals-ledger-safety` still passes.

**Depends on** Agent-Kax PR #80 (the typed `/api/ledger/*` endpoints this client calls). Safe to merge independently — inert until both this deploys and the KAX env is armed.

**Next (PR 2b):** wire this client into `createMarket` (escrow-before-open), `placeTrade` (per-market mutex + pending_trades journal + integer cost_minor), and `resolveMarket` (batched payout), then adversarially review that diff.
