### PR TITLE
feat: wire GhostSignals hub economy onto the KAX ledger (ADR-0041 Phase 2, PR 2b)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -17,6 +17,15 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const os = require('os');
+// ADR-0041 Phase 2 (funded-AMM PR 2): labs-tier markets move REAL conserved
+// credits on the KAX ledger. INERT until KAX_LEDGER_BASE + tokens are set —
+// kax.mintEnabled()/tradeEnabled() gate everything, so with no env every market
+// is ledger_backed=0 and the existing SQLite economy runs exactly as before.
+const kax = require('./kax-ledger');
+
+// Integer share ticks per share (mirror of kax.MINOR). A winning position pays
+// $1/share, so its payout in ledger minor units is exactly its share_ticks.
+const SHARE_TICK = kax.MINOR;
 
 // We require the stem-server's sqlite3 install if available — both apps
 // run on the same host so they share the binary. Falls back to the local
@@ -72,6 +81,34 @@ class GhostSignalsHub {
     // "cannot start a transaction within a transaction". This chain guarantees
     // one at a time.
     this._txChain = Promise.resolve();
+    // Per-market serialization for the ledger path (ADR-0041 PR 2). A labs
+    // market's trade unit is price → POST /ledger/trade → q-CAS → position; all
+    // of it must be serialized PER MARKET so the q we priced against is still
+    // current when we commit (the q-CAS then becomes a should-never-fire assert)
+    // and two trades can't both be mid-flight against the same pool.
+    this._marketChains = new Map();
+  }
+
+  /** Serialize `work` against a single market id (see _marketChains). */
+  _serializeMarket(marketId, work) {
+    const prev = this._marketChains.get(marketId) || Promise.resolve();
+    const result = prev.then(() => work(), () => work());
+    // Keep the chain alive regardless of outcome; prune when it drains.
+    const link = result.then(() => {}, () => {});
+    this._marketChains.set(marketId, link);
+    link.then(() => {
+      if (this._marketChains.get(marketId) === link) this._marketChains.delete(marketId);
+    });
+    return result;
+  }
+
+  /**
+   * A market is ledger-backed iff it was created as labs-tier WHILE the KAX
+   * mint+trade surfaces were configured. Dormant by default: with no env, no
+   * market is ever ledger_backed, so the SQLite path below is untouched.
+   */
+  _isLabsLedger(marketRow) {
+    return !!(marketRow && marketRow.ledger_backed) && kax.tradeEnabled();
   }
 
   /**
@@ -144,6 +181,34 @@ class GhostSignalsHub {
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_markets_active ON markets(resolved, expires_at)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_markets_volume ON markets(volume)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_market ON trades(market_id)`);
+        // ── ADR-0041 Phase 2 (funded-AMM PR 2) additive migration ──────────
+        // Ledger-backed labs markets carry a lifecycle state + funded subsidy;
+        // trades carry audit-grade integer minor units alongside the float; a
+        // pending_trades journal records intent BEFORE each ledger POST so an
+        // ambiguous outcome is reconcilable. Run unconditionally and swallow the
+        // "duplicate column" error so the migration is idempotent across boots.
+        const addCol = (sql) => this.db.run(sql, (e) => {
+          if (e && !/duplicate column/i.test(e.message)) console.error('gshub migrate:', e.message);
+        });
+        addCol(`ALTER TABLE markets ADD COLUMN state TEXT NOT NULL DEFAULT 'open'`);
+        addCol(`ALTER TABLE markets ADD COLUMN subsidy_minor TEXT`);
+        addCol(`ALTER TABLE markets ADD COLUMN ledger_backed INTEGER NOT NULL DEFAULT 0`);
+        addCol(`ALTER TABLE trades ADD COLUMN cost_minor TEXT`);
+        addCol(`ALTER TABLE trades ADD COLUMN share_ticks INTEGER`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS pending_trades (
+          tx_id TEXT PRIMARY KEY,
+          market_id TEXT NOT NULL,
+          trader_id TEXT NOT NULL,
+          outcome_idx INTEGER NOT NULL,
+          shares REAL NOT NULL,
+          cost_minor TEXT NOT NULL,
+          share_ticks INTEGER NOT NULL,
+          q_before TEXT NOT NULL,
+          state TEXT NOT NULL DEFAULT 'posting',
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )`);
+        this.db.run(`CREATE INDEX IF NOT EXISTS idx_pending_trades_state ON pending_trades(state)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_trader ON trades(trader_id)`, (err) => {
           if (err) return reject(err);
           // Seed system trader if not present
@@ -230,30 +295,48 @@ class GhostSignalsHub {
   }
 
   // ── Market API ───────────────────────────────────────────────────
-  createMarket({ question, outcomes = ['Yes', 'No'], ttl_sec = 3600, liquidity, tag = 'custom', source = 'system', source_app, metadata }) {
-    return new Promise((resolve, reject) => {
-      const id = 'm_' + crypto.randomBytes(6).toString('hex');
-      const lq = liquidity || this.defaultLiquidity;
-      const q = new Array(outcomes.length).fill(0);
-      const expiresAt = new Date(Date.now() + ttl_sec * 1000).toISOString();
-      this.db.run(
-        `INSERT INTO markets
-          (id, question, outcomes, liquidity, q, source, source_app, tag, metadata, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          id, question, JSON.stringify(outcomes), lq, JSON.stringify(q),
-          source, source_app || null, tag, metadata ? JSON.stringify(metadata) : null,
-          expiresAt,
-        ],
-        (err) => {
-          if (err) return reject(err);
-          this.getMarket(id).then(m => {
-            this.broadcast({ type: 'gs_market_created', data: m });
-            resolve(m);
-          }).catch(reject);
-        }
-      );
-    });
+  async createMarket({ question, outcomes = ['Yes', 'No'], ttl_sec = 3600, liquidity, tag = 'custom', source = 'system', source_app, metadata }) {
+    const id = 'm_' + crypto.randomBytes(6).toString('hex');
+    const lq = liquidity || this.defaultLiquidity;
+    const q = new Array(outcomes.length).fill(0);
+    const expiresAt = new Date(Date.now() + ttl_sec * 1000).toISOString();
+    // Ledger-backed ONLY when created labs-tier AND the KAX mint+trade surfaces
+    // are both armed. Dormant otherwise → a plain SQLite market, unchanged.
+    const labsLedger = (tag === 'labs' || source === 'kannaka-labs') && kax.mintEnabled() && kax.tradeEnabled();
+    const subsidyMinor = labsLedger ? kax.subsidyMinor(lq, outcomes.length) : null;
+    const state = labsLedger ? 'pending_escrow' : 'open';
+
+    await this._run(
+      `INSERT INTO markets
+        (id, question, outcomes, liquidity, q, source, source_app, tag, metadata, expires_at, state, subsidy_minor, ledger_backed)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id, question, JSON.stringify(outcomes), lq, JSON.stringify(q),
+        source, source_app || null, tag, metadata ? JSON.stringify(metadata) : null,
+        expiresAt, state, subsidyMinor, labsLedger ? 1 : 0,
+      ],
+    );
+
+    if (labsLedger) {
+      // Fund the LMSR subsidy into the pool BEFORE opening (idempotent escrow:<id>).
+      // A definitive rejection voids the market; an ambiguous outcome leaves it
+      // pending_escrow for the reconciler — either way it never opens unfunded.
+      let r;
+      try { r = await kax.escrow({ marketId: id, subsidyMinor, ref: `market:${id}` }); }
+      catch (e) { await this._setMarketState(id, 'voided'); throw new Error(`escrow failed to send: ${e.message}`); }
+      if (r.ok) {
+        await this._setMarketState(id, 'open');
+      } else if (r.definitive) {
+        await this._setMarketState(id, 'voided');
+        throw new Error(`escrow rejected (${r.status}): ${r.error}`);
+      } else {
+        throw new Error(`escrow ambiguous (${r.status}): ${r.error} — market ${id} pending reconciliation`);
+      }
+    }
+
+    const m = await this.getMarket(id);
+    this.broadcast({ type: 'gs_market_created', data: m });
+    return m;
   }
 
   getMarket(id) {
@@ -288,6 +371,11 @@ class GhostSignalsHub {
       resolved_at: row.resolved_at,
       resolution_method: row.resolution_method,
       volume: row.volume,
+      // ADR-0041 PR 2: ledger lifecycle. Defaults ('open'/0/null) mean the
+      // pre-ledger SQLite economy, so existing markets read back unchanged.
+      state: row.state || 'open',
+      ledger_backed: !!row.ledger_backed,
+      subsidy_minor: row.subsidy_minor || null,
       ttl_remaining_sec: Math.max(0, Math.floor((new Date(row.expires_at).getTime() - Date.now()) / 1000)),
     };
   }
@@ -325,6 +413,12 @@ class GhostSignalsHub {
     if (outcome >= market.outcomes.length) throw new Error('outcome out of range');
     const trader = await this.getTrader(trader_id);
     if (!trader) throw new Error('trader not registered');
+
+    // ADR-0041 PR 2: labs-tier ledger markets move real credits on KAX instead
+    // of SQLite capital. Dormant unless the market was created ledger-backed.
+    if (this._isLabsLedger(market)) {
+      return this._placeTradeLedger({ market, trader_id, outcome, shares });
+    }
 
     // The q we read is the state our cost is priced against. The write below
     // is a compare-and-swap on exactly this value (`WHERE q = qBeforeJson`),
@@ -417,6 +511,10 @@ class GhostSignalsHub {
     if (winning_outcome < 0 || winning_outcome >= market.outcomes.length) {
       throw new Error('winning_outcome out of range');
     }
+    // ADR-0041 PR 2: ledger-backed markets settle on KAX (batched payout).
+    if (this._isLabsLedger(market)) {
+      return this._resolveMarketLedger({ market, winning_outcome, method });
+    }
     const finalPrices = market.prices.slice();
     return this._serializeTx(() => new Promise((resolve, reject) => {
         self.db.serialize(() => {
@@ -485,6 +583,195 @@ class GhostSignalsHub {
           );
         });
       }));
+  }
+
+  // ── Ledger-path helpers (ADR-0041 PR 2) ─────────────────────────────
+  // Small promisified sqlite wrappers keep the money-path code readable; the
+  // shared-connection ordering guarantees still hold (calls queue in order, and
+  // _serializeTx prevents two BEGIN…COMMIT units from interleaving).
+  _run(sql, params = []) { return new Promise((res, rej) => this.db.run(sql, params, function (e) { e ? rej(e) : res(this); })); }
+  _get(sql, params = []) { return new Promise((res, rej) => this.db.get(sql, params, (e, row) => e ? rej(e) : res(row))); }
+  _all(sql, params = []) { return new Promise((res, rej) => this.db.all(sql, params, (e, rows) => e ? rej(e) : res(rows))); }
+
+  _setMarketState(id, state) { return this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id]); }
+  _setPendingState(txId, state) {
+    return this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]);
+  }
+  _journalPending(r) {
+    return this._run(
+      `INSERT INTO pending_trades (tx_id, market_id, trader_id, outcome_idx, shares, cost_minor, share_ticks, q_before, state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [r.txId, r.market_id, r.trader_id, r.outcome, r.shares, r.costMinor, r.shareTicks, r.qBeforeJson, r.state],
+    );
+  }
+
+  /**
+   * Place a labs-tier trade against the KAX ledger. Serialized PER MARKET:
+   * re-price under the mutex, journal intent, POST the debit (money first),
+   * then commit the shares (q-CAS + position). Ledger-backed traders never
+   * touch SQLite capital.
+   */
+  async _placeTradeLedger({ market, trader_id, outcome, shares }) {
+    const market_id = market.id;
+    const principal = kax.principalFor(trader_id);
+    return this._serializeMarket(market_id, async () => {
+      // Re-read INSIDE the mutex so the q we price against is current.
+      const m = await this.getMarket(market_id);
+      if (!m || m.resolved) throw new Error('market already resolved');
+      if (m.state !== 'open') throw new Error(`market not open for trading (state=${m.state})`);
+      if (outcome >= m.outcomes.length) throw new Error('outcome out of range');
+      const qBefore = m.q.slice();
+      const qBeforeJson = JSON.stringify(qBefore);
+      const qAfter = qBefore.slice();
+      qAfter[outcome] += shares;
+      const cost = lmsrCost(qAfter, m.liquidity) - lmsrCost(qBefore, m.liquidity);
+      const costMinor = kax.tradeCostMinor(cost);           // ceil, rejects dust <= 0
+      const shareTicks = Math.floor(shares * SHARE_TICK);    // floor — pool's favor
+      if (!(shareTicks > 0)) throw new Error('shares round to zero ticks');
+      const txId = kax.txid.trade(kax.newTradeUuid());
+
+      // 1) Journal intent BEFORE the POST (so an ambiguous outcome is recoverable).
+      await this._journalPending({ txId, market_id, trader_id, outcome, shares, costMinor, shareTicks, qBeforeJson, state: 'posting' });
+
+      // 2) Money FIRST — debit trader, credit pool. (q-first would mint free
+      //    shares on a crash between shares and money.)
+      const r = await kax.trade({ txId, principal, marketId: market_id, amountMinor: costMinor, side: 'buy', ref: `trade:${market_id}` });
+      if (!r.ok) {
+        if (r.definitive) { await this._setPendingState(txId, 'failed'); throw new Error(`ledger trade rejected (${r.status}): ${r.error}`); }
+        await this._setPendingState(txId, 'reconcile');
+        throw new Error(`ledger trade ambiguous (${r.status}): ${r.error} — pending reconciliation`);
+      }
+
+      // 3) Shares AFTER money: q-CAS + audit-grade trade row + position, one tx.
+      //    Under the per-market mutex the CAS should never fail; if it does, the
+      //    debit already landed, so flag for refund reconciliation (PR 2c).
+      try {
+        await this._commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
+      } catch (e) {
+        await this._setPendingState(txId, 'refund');
+        throw new Error(`shares commit failed after ledger debit (refund queued, tx ${txId}): ${e.message}`);
+      }
+      await this._setPendingState(txId, 'posted');
+      const updated = await this.getMarket(market_id);
+      this.broadcast({ type: 'gs_trade', data: { market_id, trader_id, outcome, shares, cost, cost_minor: costMinor, ledger: true, prices: updated.prices } });
+      return { cost, cost_minor: costMinor, prices: updated.prices, market: updated };
+    });
+  }
+
+  /** The SQLite side of a ledger trade: q-CAS + trade row + position. No capital. */
+  _commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
+    const self = this;
+    return this._serializeTx(async () => {
+      await self._run('BEGIN');
+      try {
+        const q = await self._run(
+          `UPDATE markets SET q = ?, volume = volume + ? WHERE id = ? AND q = ? AND resolved = 0 AND state = 'open'`,
+          [qAfterJson, shares, market_id, qBeforeJson],
+        );
+        if (q.changes === 0) throw new Error('market state changed concurrently (q-CAS)');
+        await self._run(`UPDATE traders SET trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ?`, [trader_id]);
+        await self._run(
+          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks],
+        );
+        await self._run(
+          `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
+           ON CONFLICT(market_id, trader_id, outcome_idx) DO UPDATE SET shares = shares + ?`,
+          [market_id, trader_id, outcome, shares, shares],
+        );
+        await self._run('COMMIT');
+      } catch (e) {
+        await self._run('ROLLBACK').catch(() => {});
+        throw e;
+      }
+    });
+  }
+
+  /** Winning payouts for a ledger market: Σ share_ticks per trader, in minor units. */
+  async _winningPayouts(market_id, winning_outcome) {
+    const rows = await this._all(
+      `SELECT trader_id, COALESCE(SUM(share_ticks), 0) AS ticks
+         FROM trades WHERE market_id = ? AND outcome_idx = ? AND share_ticks IS NOT NULL
+         GROUP BY trader_id HAVING ticks > 0`,
+      [market_id, winning_outcome],
+    );
+    return rows.map((r) => ({ principal: kax.principalFor(r.trader_id), amountMinor: String(r.ticks) }));
+  }
+
+  /** Pool value in minor units = subsidy + Σ cost_minor collected on this market. */
+  async _poolValueMinor(market_id, subsidyMinor) {
+    const rows = await this._all(`SELECT cost_minor FROM trades WHERE market_id = ? AND cost_minor IS NOT NULL`, [market_id]);
+    let sum = BigInt(subsidyMinor || '0');
+    for (const r of rows) sum += BigInt(r.cost_minor);
+    return sum;
+  }
+
+  /**
+   * Resolve a ledger-backed market. Freeze trading (single-flip resolved=1)
+   * FIRST, then pay all winners out of the pool + sweep residual to house in ONE
+   * balanced KAX transaction (txId=resolve:<id>, idempotent). Payout progress is
+   * decoupled from the resolved flag: a definitive rejection or ambiguity leaves
+   * the (frozen) market for the PR-2c reconciler rather than paying twice.
+   */
+  async _resolveMarketLedger({ market, winning_outcome, method }) {
+    const market_id = market.id;
+    const finalPrices = market.prices.slice();
+    return this._serializeMarket(market_id, async () => {
+      // Freeze — only the transaction that flips 0->1 proceeds.
+      const flip = await this._serializeTx(async () => {
+        const u = await this._run(
+          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ? AND resolved = 0`,
+          [winning_outcome, method, market_id],
+        );
+        return u.changes;
+      });
+      if (flip === 0) throw new Error('already resolved');
+
+      // Trading is frozen. Compute + POST the batched payout (an HTTP call, so
+      // OUTSIDE any SQLite transaction).
+      const winners = await this._winningPayouts(market_id, winning_outcome);
+      const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
+      const poolValue = await this._poolValueMinor(market_id, market.subsidy_minor);
+      let residual = poolValue - totalPayout;
+      if (residual < 0n) {
+        // Should be impossible under pool-favor rounding. Never sweep-then-assert:
+        // alert, sweep nothing, and let the KAX overdraft guard 409 if truly short.
+        console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
+        residual = 0n;
+      }
+      if (winners.length > 0) {
+        const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
+        if (!r.ok && r.definitive) {
+          console.error(`gshub payout rejected market ${market_id} (${r.status}): ${r.error} — frozen, awaiting reconciliation`);
+        } else if (!r.ok) {
+          console.error(`gshub payout ambiguous market ${market_id} (${r.status}): ${r.error} — will reconcile (idempotent resolve:${market_id})`);
+        }
+      }
+      await this._updateLedgerReputation(market_id, winning_outcome).catch(() => {});
+      const m = await this.getMarket(market_id);
+      this.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices, ledger: true } });
+      return m;
+    });
+  }
+
+  /** Non-monetary reputation/accuracy update for a resolved ledger market. */
+  async _updateLedgerReputation(market_id, winning_outcome) {
+    const positions = await this._all(`SELECT trader_id, outcome_idx, shares FROM positions WHERE market_id = ?`, [market_id]);
+    const traders = new Map();
+    for (const p of positions) {
+      if (!traders.has(p.trader_id)) traders.set(p.trader_id, { yes: 0, total: 0 });
+      const t = traders.get(p.trader_id);
+      t.total += p.shares;
+      if (p.outcome_idx === winning_outcome) t.yes += p.shares;
+    }
+    for (const [trader_id, t] of traders.entries()) {
+      const impliedYes = t.total > 0 ? t.yes / t.total : 0.5;
+      const accuracy = brierAccuracy(impliedYes, 1);
+      await this._run(
+        `UPDATE traders SET trades_won = trades_won + ?, reputation = reputation * 0.95 + ? * 0.05, last_active = CURRENT_TIMESTAMP WHERE id = ?`,
+        [t.yes > 0 ? 1 : 0, accuracy, trader_id],
+      );
+    }
   }
 
   /**

--- a/test/kax-ledger-wiring.test.js
+++ b/test/kax-ledger-wiring.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+// Integration test for the labs-tier LEDGER PATH in the GhostSignals hub
+// (ADR-0041 Phase 2, funded-AMM PR 2b). Arms the KAX surfaces via env and
+// stubs global.fetch with an in-memory fake ledger, then drives a full market
+// lifecycle and asserts the money-flow invariants:
+//   - escrow-before-open (pool funded, market state → 'open')
+//   - trades post ceil-rounded cost to /ledger/trade and DON'T touch SQLite capital
+//   - resolve pays winners in ONE batched /ledger/payout
+//   - the fake ledger stays conserved (Σ postings == 0) and no account goes negative
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+// Arm the KAX surfaces BEFORE requiring the hub (cfg() reads env fresh anyway).
+process.env.KAX_LEDGER_BASE = 'http://kax.test';
+process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
+process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
+process.env.KAX_SERVICE_TOKEN = 'read-tok';
+
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-wiring-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+// ── In-memory fake KAX ledger (double-entry, conserved, overdraft-guarded) ──
+function makeFakeLedger() {
+  const balances = new Map(); // account -> bigint
+  const txs = new Map();      // txId -> { head, count }
+  const calls = [];           // {path, body}
+  const bal = (a) => balances.get(a) || 0n;
+
+  function apply(txId, postings) {
+    if (txs.has(txId)) return { replay: true, ...txs.get(txId) }; // idempotent
+    // overdraft guard: non-house debits can't go negative
+    for (const p of postings) {
+      if (p.amount < 0n && p.account !== 'house' && bal(p.account) + p.amount < 0n) {
+        const e = new Error('insufficient funds'); e.status = 409; throw e;
+      }
+    }
+    const sum = postings.reduce((a, p) => a + p.amount, 0n);
+    if (sum !== 0n) { const e = new Error('not balanced'); e.status = 400; throw e; }
+    for (const p of postings) balances.set(p.account, bal(p.account) + p.amount);
+    const rec = { head: 'h' + txs.size, count: postings.length };
+    txs.set(txId, rec);
+    return { replay: false, ...rec };
+  }
+
+  global.fetch = async (url, opts = {}) => {
+    const u = new URL(url);
+    const body = opts.body ? JSON.parse(opts.body) : {};
+    calls.push({ path: u.pathname, body });
+    const S = (v) => BigInt(v);
+    try {
+      let postings = null;
+      if (u.pathname === '/api/ledger/escrow') {
+        postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+      } else if (u.pathname === '/api/ledger/grant') {
+        postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
+      } else if (u.pathname === '/api/ledger/trade') {
+        const amm = { account: `amm:${body.marketId}`, amount: S(body.amount) };
+        const trader = { account: `trader:${body.principal}`, amount: -S(body.amount) };
+        postings = body.side === 'sell' ? [{ ...amm, amount: -S(body.amount) }, { ...trader, amount: S(body.amount) }] : [trader, amm];
+      } else if (u.pathname === '/api/ledger/payout') {
+        const total = (body.winners || []).reduce((a, w) => a + S(w.amount), 0n) + S(body.residual || '0');
+        postings = [{ account: `amm:${body.marketId}`, amount: -total }];
+        for (const w of body.winners) postings.push({ account: `trader:${w.principal}`, amount: S(w.amount) });
+        if (S(body.residual || '0') > 0n) postings.push({ account: 'house', amount: S(body.residual) });
+      }
+      if (postings) {
+        const r = apply(body.txId, postings);
+        return { ok: true, status: r.replay ? 200 : 201, json: async () => ({ ok: true, ...r, idempotentReplay: r.replay }) };
+      }
+      return { ok: false, status: 404, json: async () => ({ ok: false, error: 'no route' }) };
+    } catch (e) {
+      const status = e.status || 500;
+      return { ok: status >= 200 && status < 300, status, json: async () => ({ ok: false, error: e.message }) };
+    }
+  };
+
+  return { balances, txs, calls, bal };
+}
+
+async function run() {
+  const led = makeFakeLedger();
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+
+  // Seed the two labs traders with ledger credits (grant) so they can trade.
+  const alice = 'kax:agent:alice';
+  const bob = 'kax:agent:bob';
+  await hub.registerTrader({ id: alice, display_name: 'Alice', kind: 'ai' });
+  await hub.registerTrader({ id: bob, display_name: 'Bob', kind: 'ai' });
+  await require('../server/kax-ledger').grant({ principal: alice, amountMinor: '100000000', txId: 'grant:register:' + alice });
+  await require('../server/kax-ledger').grant({ principal: bob, amountMinor: '100000000', txId: 'grant:register:' + bob });
+
+  // 1) Create a labs market → escrow-before-open.
+  const m = await hub.createMarket({ question: 'ledger path?', outcomes: ['Yes', 'No'], ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs' });
+  assert.strictEqual(m.state, 'open', 'market should be open after successful escrow');
+  assert.strictEqual(m.ledger_backed, true, 'market should be ledger-backed');
+  const escrowCall = led.calls.find((c) => c.path === '/api/ledger/escrow');
+  assert.ok(escrowCall, 'escrow POST must have happened');
+  assert.strictEqual(escrowCall.body.marketId, m.id, 'escrow funds THIS market');
+  assert.ok(led.bal(`amm:${m.id}`) > 0n, 'pool funded with subsidy');
+  console.log(`ok  escrow-before-open (pool = ${led.bal(`amm:${m.id}`)} minor units, market open)`);
+
+  // 2) Trades post to the ledger, ceil-rounded, and DON'T touch SQLite capital.
+  const capBefore = (await hub.getTrader(alice)).capital;
+  const t = await hub.placeTrade({ market_id: m.id, trader_id: alice, outcome: 0, shares: 5 });
+  const tradeCall = led.calls.find((c) => c.path === '/api/ledger/trade');
+  assert.ok(tradeCall, 'trade POST must have happened');
+  assert.strictEqual(tradeCall.body.principal, alice);
+  assert.strictEqual(typeof tradeCall.body.amount, 'string', 'amount is a decimal string');
+  assert.strictEqual(tradeCall.body.amount, String(Math.ceil(t.cost * 1e6)), 'cost charged is ceil(cost·MINOR)');
+  const capAfter = (await hub.getTrader(alice)).capital;
+  assert.strictEqual(capAfter, capBefore, 'SQLite capital untouched on the ledger path');
+  assert.ok(led.bal(`trader:${alice}`) < 100000000n, 'ledger debited the trader');
+  console.log(`ok  ledger trade (charged ${tradeCall.body.amount} minor, SQLite capital untouched)`);
+
+  // A second trader takes the other side.
+  await hub.placeTrade({ market_id: m.id, trader_id: bob, outcome: 1, shares: 3 });
+
+  // 3) Resolve → ONE batched payout.
+  const poolBefore = led.bal(`amm:${m.id}`);
+  await hub.resolveMarket({ market_id: m.id, winning_outcome: 0, method: 'manual' });
+  const payoutCalls = led.calls.filter((c) => c.path === '/api/ledger/payout');
+  assert.strictEqual(payoutCalls.length, 1, 'exactly ONE batched payout');
+  const p = payoutCalls[0];
+  assert.ok(Array.isArray(p.body.winners) && p.body.winners.length >= 1, 'winners present');
+  assert.ok(p.body.winners.some((w) => w.principal === alice), 'Alice (outcome 0) is a winner');
+  assert.ok(!p.body.winners.some((w) => w.principal === bob), 'Bob (outcome 1) is not paid');
+  console.log(`ok  batched payout (1 tx, ${p.body.winners.length} winner(s), residual ${p.body.residual})`);
+
+  // 4) Conservation: every posting summed to zero, so Σ all balances == 0, and
+  //    the pool never went negative.
+  let total = 0n;
+  for (const v of led.balances.values()) total += v;
+  assert.strictEqual(total, 0n, 'ledger conserved (Σ balances == 0)');
+  assert.ok(led.bal(`amm:${m.id}`) >= 0n, `pool solvent (${led.bal(`amm:${m.id}`)} >= 0)`);
+  assert.ok(poolBefore >= 0n);
+  console.log('ok  conservation (Σ balances == 0, pool never negative)');
+
+  console.log('\nPASSED kax-ledger-wiring.test.js');
+}
+
+run().catch((e) => {
+  console.error('\nFAILED kax-ledger-wiring.test.js:', e.stack || e.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Wires the **labs-tier** market lifecycle onto the KAX credit ledger client (PR #101) so those credits are **real conserved postings**, not unbacked SQLite capital. **Stacked on** #101 (base branch = `feat/adr-0041-funded-amm-client`).

**Dormant until armed.** A market is `ledger_backed` only when created labs-tier *while* `kax.mintEnabled() && kax.tradeEnabled()` — both false until `KAX_LEDGER_BASE` + tokens are set. With no env, every market is `ledger_backed=0` and the existing SQLite economy runs exactly as before. All prior hub tests pass unchanged.

### Money path (labs-tier only — blueprint items 11–16, 18)
- **`createMarket` escrow-before-open**: insert `state='pending_escrow'` → POST `/ledger/escrow` the LMSR subsidy `ceil(b·ln(n)·MINOR)` → `state='open'`. Definitive rejection voids; ambiguous stays `pending_escrow` for the reconciler. A market never opens unfunded.
- **`placeTrade` ledger path** under a **per-market async mutex**: re-price inside the mutex → journal intent to `pending_trades` **before** the POST → **money-first** (`POST /ledger/trade`, ceil cost, reject dust) → **shares** (q-CAS + integer `cost_minor`/`share_ticks` + position). Ledger traders never touch SQLite capital. A post-debit shares failure flags refund reconciliation; under the mutex the q-CAS is a should-never-fire assert.
- **`resolveMarket` ledger path**: single-flip freeze (`resolved=1`) **first**, then pay all winners from the pool + sweep residual to house in **ONE** batched `/ledger/payout` (`txId=resolve:<id>`, idempotent). Winners from integer `share_ticks`; residual from tracked pool value; a solvency-violation alert never sweeps-then-asserts.
- **Schema** (additive, idempotent migration): `markets.state/subsidy_minor/ledger_backed`, `trades.cost_minor/share_ticks`, `pending_trades` journal.
- The **ambiguity contract** (4xx=not-posted, 5xx/timeout=reconcile) is honored throughout.

### Test — `test/kax-ledger-wiring.test.js` (wired into `npm test`)
Full lifecycle against an **in-memory fake KAX ledger** (double-entry, overdraft-guarded): asserts escrow-before-open, ceil-cost trade with **SQLite capital untouched**, exactly **one** batched payout to the winning side only, and **ledger conservation** (Σ balances == 0, pool never negative). Observed: pool funded at 6931472 minor units (= exact subsidy), payout to winners only, Σ balances == 0.

**Deferred to PR 2c:** continuous reconciliation audit (item 17) + boot reconciler for `pending_escrow` / `pending_trades(reconcile,refund)` crash recovery — then an adversarial review of the 2b+2c diff.

Depends on Agent-Kax PR #80 (the `/api/ledger/*` endpoints). Safe to merge — dormant until the env is armed.
