### PR TITLE
feat: ledger reconciliation + pool-solvency audit (ADR-0041 Phase 2, PR 2c)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -195,6 +195,11 @@ class GhostSignalsHub {
         addCol(`ALTER TABLE markets ADD COLUMN ledger_backed INTEGER NOT NULL DEFAULT 0`);
         addCol(`ALTER TABLE trades ADD COLUMN cost_minor TEXT`);
         addCol(`ALTER TABLE trades ADD COLUMN share_ticks INTEGER`);
+        // tx_id correlates a committed trade row with its ledger debit, so the
+        // reconciler can tell "debit landed AND shares committed" (row exists)
+        // from "debit landed, shares did NOT commit" (needs refund).
+        addCol(`ALTER TABLE trades ADD COLUMN tx_id TEXT`);
+        this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_txid ON trades(tx_id)`);
         this.db.run(`CREATE TABLE IF NOT EXISTS pending_trades (
           tx_id TEXT PRIMARY KEY,
           market_id TEXT NOT NULL,
@@ -227,7 +232,14 @@ class GhostSignalsHub {
 
   startResolverLoop(intervalMs = 10000) {
     if (this._resolverInterval) return;
-    this._resolverInterval = setInterval(() => this._resolveExpiredMarkets().catch(() => {}), intervalMs);
+    // Boot crash-recovery pass for the ledger path (no-op when KAX unarmed).
+    this.reconcile().catch(() => {});
+    let tick = 0;
+    this._resolverInterval = setInterval(() => {
+      this._resolveExpiredMarkets().catch(() => {});
+      // Piggyback the ledger reconcile+audit every ~6th tick (≈60s by default).
+      if (++tick % 6 === 0) this.reconcile().catch(() => {});
+    }, intervalMs);
   }
 
   stopResolverLoop() {
@@ -646,7 +658,7 @@ class GhostSignalsHub {
       //    Under the per-market mutex the CAS should never fail; if it does, the
       //    debit already landed, so flag for refund reconciliation (PR 2c).
       try {
-        await this._commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
+        await this._commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
       } catch (e) {
         await this._setPendingState(txId, 'refund');
         throw new Error(`shares commit failed after ledger debit (refund queued, tx ${txId}): ${e.message}`);
@@ -659,7 +671,7 @@ class GhostSignalsHub {
   }
 
   /** The SQLite side of a ledger trade: q-CAS + trade row + position. No capital. */
-  _commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
+  _commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
     const self = this;
     return this._serializeTx(async () => {
       await self._run('BEGIN');
@@ -671,8 +683,8 @@ class GhostSignalsHub {
         if (q.changes === 0) throw new Error('market state changed concurrently (q-CAS)');
         await self._run(`UPDATE traders SET trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ?`, [trader_id]);
         await self._run(
-          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks],
+          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks, tx_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, txId],
         );
         await self._run(
           `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
@@ -771,6 +783,105 @@ class GhostSignalsHub {
         `UPDATE traders SET trades_won = trades_won + ?, reputation = reputation * 0.95 + ? * 0.05, last_active = CURRENT_TIMESTAMP WHERE id = ?`,
         [t.yes > 0 ? 1 : 0, accuracy, trader_id],
       );
+    }
+  }
+
+  // ── Reconciliation & solvency audit (ADR-0041 PR 2c) ────────────────
+  /**
+   * Crash-recovery + pool-solvency audit for the ledger path. Idempotent and
+   * safe to run repeatedly (once at boot + piggybacked on the resolver loop).
+   * A no-op when the KAX surfaces aren't armed, so dev is unaffected. Runs the
+   * three passes in order: escrow (open funded markets), trades (settle/refund
+   * ambiguous debits) THEN the audit (so transient debits are resolved first).
+   */
+  async reconcile() {
+    if (!kax.tradeEnabled() || !kax.readEnabled()) return { skipped: true };
+    if (this._reconciling) return { skipped: 'in-flight' };
+    this._reconciling = true;
+    const report = { escrow: 0, trades: 0, audited: 0, alerts: 0 };
+    try {
+      await this._reconcilePendingEscrow(report);
+      await this._reconcilePendingTrades(report);
+      await this._auditOpenPools(report);
+    } catch (e) {
+      console.error('gshub reconcile error:', e.message);
+    } finally {
+      this._reconciling = false;
+    }
+    return report;
+  }
+
+  /** Open markets whose escrow actually landed; retry (idempotent) the absent ones. */
+  async _reconcilePendingEscrow(report) {
+    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'pending_escrow'`);
+    for (const row of rows) {
+      const g = await kax.getTx(kax.txid.escrow(row.id));
+      if (g.ok && g.result && g.result.found === true) { await this._setMarketState(row.id, 'open'); report.escrow++; continue; }
+      if (g.ok && g.result && g.result.found === false) {
+        // Definitively absent → retry the idempotent escrow.
+        try {
+          const r = await kax.escrow({ marketId: row.id, subsidyMinor: row.subsidy_minor, ref: `market:${row.id}` });
+          if (r.ok) { await this._setMarketState(row.id, 'open'); report.escrow++; }
+          else if (r.definitive) { await this._setMarketState(row.id, 'voided'); }
+        } catch (_) { /* ambiguous send — leave for next cycle */ }
+      }
+      // getTx ambiguous → leave pending for next cycle.
+    }
+  }
+
+  /**
+   * Settle ambiguous / crashed trades using the ledger as the source of truth.
+   * tx_id on the committed trade row lets us distinguish the four cases exactly:
+   *   landed + committed  → mark posted (the state update was what crashed)
+   *   absent + !committed → mark failed  (no money moved)
+   *   landed + !committed → REFUND (reverse the debit via a same-cost 'sell')
+   *   absent + committed  → impossible (we only commit after a 2xx) → alert
+   */
+  async _reconcilePendingTrades(report) {
+    const rows = await this._all(
+      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor FROM pending_trades
+        WHERE state IN ('posting', 'reconcile', 'refund')`,
+    );
+    for (const p of rows) {
+      const g = await kax.getTx(p.tx_id);
+      if (!(g.ok && g.result)) continue; // read ambiguous → next cycle
+      const landed = g.result.found === true;
+      const absent = g.result.found === false;
+      const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
+
+      if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; continue; }
+      if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; continue; }
+      if (landed && !committed) {
+        // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
+        const principal = kax.principalFor(p.trader_id);
+        const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
+        if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
+        else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
+        continue;
+      }
+      if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+    }
+  }
+
+  /**
+   * Solvency audit: each open ledger market's pool must hold AT LEAST what its
+   * committed trades funded (subsidy + Σ committed cost_minor). Only UNDER-
+   * funding is dangerous (can't cover payouts); an over-funded pool is a benign
+   * in-flight / pending-refund transient, so we never false-alarm on it. On a
+   * shortfall, halt trading (placeTrade requires state='open') and alert.
+   */
+  async _auditOpenPools(report) {
+    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'open' AND resolved = 0`);
+    for (const row of rows) {
+      const b = await kax.balance(`amm:${row.id}`);
+      if (!b.ok) continue; // read failed — skip rather than false-alarm
+      report.audited++;
+      const expected = await this._poolValueMinor(row.id, row.subsidy_minor);
+      if (b.balance < expected) {
+        console.error(`gshub POOL AUDIT SHORTFALL ${row.id}: ledger ${b.balance} < committed ${expected} — halting trading`);
+        await this._setMarketState(row.id, 'halted');
+        report.alerts++;
+      }
     }
   }
 

--- a/server/kax-ledger.js
+++ b/server/kax-ledger.js
@@ -209,6 +209,22 @@ async function getTx(txId) {
   return httpJson('GET', `/api/ledger/tx/${encodeURIComponent(txId)}`, c.readToken, null);
 }
 
+/**
+ * Derived balance (minor units) of an account for the audit — the pool-solvency
+ * check compares balance(amm:<m>) against subsidy + Σ cost_minor. Read surface.
+ * On a 2xx returns { ok:true, balance: bigint }; otherwise passes the httpJson
+ * result through (definitive/ambiguous) so a failed read never reads as zero.
+ */
+async function balance(account, asset) {
+  if (!readEnabled()) throw new Error('kax read surface not configured');
+  const c = cfg();
+  const r = await httpJson('GET', `/api/ledger/balance?account=${encodeURIComponent(account)}&asset=${encodeURIComponent(asset || c.asset)}`, c.readToken, null);
+  if (r.ok && r.result && typeof r.result.balance === 'string') {
+    return { ok: true, definitive: true, status: r.status, balance: BigInt(r.result.balance) };
+  }
+  return r;
+}
+
 module.exports = {
   MINOR,
   cfg,
@@ -232,4 +248,5 @@ module.exports = {
   trade,
   payout,
   getTx,
+  balance,
 };

--- a/test/kax-ledger-reconcile.test.js
+++ b/test/kax-ledger-reconcile.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+// Crash-recovery + audit tests for the ledger path (ADR-0041 Phase 2, PR 2c).
+// Drives hub.reconcile() through its four exact cases against an in-memory fake
+// KAX ledger that supports getTx + balance and can simulate an
+// "applied-but-client-saw-5xx" ambiguous outcome.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+process.env.KAX_LEDGER_BASE = 'http://kax.test';
+process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
+process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
+process.env.KAX_SERVICE_TOKEN = 'read-tok';
+
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+const kax = require('../server/kax-ledger');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-recon-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+function makeFakeLedger() {
+  const balances = new Map();
+  const txs = new Map();
+  const led = { mode: 'normal', balances, txs };
+  const bal = (a) => balances.get(a) || 0n;
+  led.bal = bal;
+  led.drain = (a, amt) => balances.set(a, bal(a) - BigInt(amt));
+
+  function apply(txId, postings) {
+    if (txs.has(txId)) return { replay: true, ...txs.get(txId) };
+    for (const p of postings) {
+      if (p.amount < 0n && p.account !== 'house' && bal(p.account) + p.amount < 0n) { const e = new Error('insufficient'); e.status = 409; throw e; }
+    }
+    if (postings.reduce((a, p) => a + p.amount, 0n) !== 0n) { const e = new Error('unbalanced'); e.status = 400; throw e; }
+    for (const p of postings) balances.set(p.account, bal(p.account) + p.amount);
+    const rec = { head: 'h' + txs.size, count: postings.length };
+    txs.set(txId, rec);
+    return { replay: false, ...rec };
+  }
+
+  global.fetch = async (url, opts = {}) => {
+    const u = new URL(url);
+    const S = (v) => BigInt(v);
+    // GET reads
+    if ((opts.method || 'GET') === 'GET') {
+      if (u.pathname.startsWith('/api/ledger/tx/')) {
+        const txId = decodeURIComponent(u.pathname.slice('/api/ledger/tx/'.length));
+        const rec = txs.get(txId);
+        return { ok: true, status: 200, json: async () => (rec ? { found: true, txId, ...rec } : { found: false, txId }) };
+      }
+      if (u.pathname === '/api/ledger/balance') {
+        const acct = u.searchParams.get('account');
+        return { ok: true, status: 200, json: async () => ({ account: acct, asset: 'play_credit', balance: bal(acct).toString() }) };
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'no route' }) };
+    }
+    // POST writes
+    const body = JSON.parse(opts.body);
+    let postings = null;
+    if (u.pathname === '/api/ledger/escrow') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    else if (u.pathname === '/api/ledger/grant') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
+    else if (u.pathname === '/api/ledger/trade') {
+      postings = body.side === 'sell'
+        ? [{ account: `amm:${body.marketId}`, amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }]
+        : [{ account: `trader:${body.principal}`, amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    }
+    try {
+      const r = apply(body.txId, postings);
+      if (led.mode === 'applyThenFail') return { ok: false, status: 500, json: async () => ({ ok: false, error: 'simulated 5xx after apply' }) };
+      return { ok: true, status: r.replay ? 200 : 201, json: async () => ({ ok: true, ...r, idempotentReplay: r.replay }) };
+    } catch (e) {
+      return { ok: false, status: e.status || 500, json: async () => ({ ok: false, error: e.message }) };
+    }
+  };
+  return led;
+}
+
+async function run() {
+  const led = makeFakeLedger();
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+  const alice = 'kax:agent:alice';
+  await hub.registerTrader({ id: alice, display_name: 'Alice', kind: 'ai' });
+  await kax.grant({ principal: alice, amountMinor: '100000000', txId: 'grant:register:' + alice });
+
+  // ── A) Escrow reconcile: escrow lands but client sees 5xx → market stuck
+  //       pending_escrow → reconcile() finds the debit and opens it. ──────────
+  led.mode = 'applyThenFail';
+  let stuckId;
+  try {
+    await hub.createMarket({ question: 'stuck escrow', outcomes: ['Y', 'N'], tag: 'labs', source: 'kannaka-labs' });
+    assert.fail('createMarket should throw on ambiguous escrow');
+  } catch (e) { assert.ok(/ambiguous/.test(e.message), 'ambiguous escrow surfaced'); }
+  stuckId = (await hub._all(`SELECT id FROM markets WHERE state = 'pending_escrow'`))[0].id;
+  assert.ok(led.bal(`amm:${stuckId}`) > 0n, 'escrow actually landed on the ledger');
+  led.mode = 'normal';
+  const repA = await hub.reconcile();
+  assert.strictEqual((await hub.getMarket(stuckId)).state, 'open', 'reconcile opened the funded market');
+  assert.ok(repA.escrow >= 1, 'escrow pass acted');
+  console.log('ok  escrow reconcile (ambiguous→landed→opened)');
+
+  // ── B) Orphaned-debit refund: a debit landed but shares never committed →
+  //       reconcile() refunds it (amm→trader) and marks 'refunded'. ──────────
+  const orphanTx = kax.txid.trade('orphan-uuid');
+  const traderBalBefore = led.bal(`trader:${alice}`);
+  await kax.trade({ txId: orphanTx, principal: alice, marketId: stuckId, amountMinor: '250000', side: 'buy' }); // debit lands
+  await hub._journalPending({ txId: orphanTx, market_id: stuckId, trader_id: alice, outcome: 0, shares: 1, costMinor: '250000', shareTicks: 1000000, qBeforeJson: '[0,0]', state: 'posting' });
+  // no trades row committed for orphanTx → landed && !committed
+  const repB = await hub.reconcile();
+  const pend = await hub._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [orphanTx]);
+  assert.strictEqual(pend.state, 'refunded', 'orphaned debit was refunded');
+  assert.strictEqual(led.bal(`trader:${alice}`), traderBalBefore, 'trader made whole by the refund');
+  console.log('ok  orphaned-debit refund (landed & !committed → reversed)');
+
+  // ── C) Never-posted trade: pending row whose debit is absent → 'failed'. ──
+  const ghostTx = kax.txid.trade('ghost-uuid');
+  await hub._journalPending({ txId: ghostTx, market_id: stuckId, trader_id: alice, outcome: 0, shares: 1, costMinor: '250000', shareTicks: 1000000, qBeforeJson: '[0,0]', state: 'reconcile' });
+  await hub.reconcile();
+  const ghost = await hub._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [ghostTx]);
+  assert.strictEqual(ghost.state, 'failed', 'never-posted trade marked failed (no money moved)');
+  console.log('ok  never-posted trade → failed');
+
+  // ── D) Pool audit shortfall: drain the pool below its committed backing →
+  //       audit halts trading on that market. ────────────────────────────────
+  led.drain(`amm:${stuckId}`, '999999999'); // force ledger balance < expected
+  const repD = await hub.reconcile();
+  assert.strictEqual((await hub.getMarket(stuckId)).state, 'halted', 'shortfall halted the market');
+  assert.ok(repD.alerts >= 1, 'audit raised an alert');
+  // A halted market rejects new trades.
+  await assert.rejects(() => hub.placeTrade({ market_id: stuckId, trader_id: alice, outcome: 0, shares: 1 }), /not open/);
+  console.log('ok  pool audit shortfall → halted + trading blocked');
+
+  console.log('\nPASSED kax-ledger-reconcile.test.js');
+}
+
+run().catch((e) => { console.error('\nFAILED kax-ledger-reconcile.test.js:', e.stack || e.message); process.exitCode = 1; });


### PR DESCRIPTION
The **crash-recovery + audit layer** for the labs-tier ledger path — closes the review's ambiguous-outcome window (items 12/13/17). Stacked on #102 (base = `feat/adr-0041-hub-ledger-wiring`). Idempotent; runs once at boot and piggybacks the resolver loop (~60s). No-op when the KAX surfaces aren't armed.

### Changes
- **`kax-ledger` client**: add `balance(account)` (GET `/ledger/balance`) for the audit — a failed read is surfaced as not-ok, never read as zero.
- **`trades.tx_id`** (+ index): lets the reconciler distinguish "debit landed **and** shares committed" from "debit landed, shares did **not** commit".
- **`hub.reconcile()`** — three ordered passes:
  - **pending_escrow**: `getTx(escrow:<id>)` → open the funded ones; retry the idempotent escrow for definitively-absent ones; leave ambiguous for the next cycle.
  - **pending_trades** (`posting|reconcile|refund`): `getTx` + the local `tx_id` lookup give the four exact cases — `landed+committed→posted`, `absent+!committed→failed`, `landed+!committed→**refund**` (reverse the debit via a same-cost `sell`, idempotent `refund:<txId>`), `absent+committed→impossible→alert`.
  - **open-pool audit**: assert `balance(amm:<m>) ≥ subsidy + Σ committed cost_minor`. Only **under-funding** alarms (over-funding is a benign in-flight / pending-refund transient → no false halts); a shortfall **halts** trading (`state='halted'`).

### Test — `test/kax-ledger-reconcile.test.js` (wired into `npm test`)
All four cases against an in-memory fake ledger that can simulate *applied-but-client-saw-5xx*: escrow ambiguous→landed→opened, orphaned-debit refunded (**trader made whole**), never-posted→failed, pool shortfall→halted + trading blocked. Full suite green.

**Completes the funded-AMM money path** (PR 2 = 2a client #101 + 2b wiring #102 + 2c recovery). Next step before "done": an **adversarial review of the 2b+2c diff**.
