### PR TITLE
fix: adversarial-review fixes for the money path (ADR-0041 Phase 2)

### DIFF
--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -598,23 +598,25 @@ class GhostSignalsHub {
   }
 
   // ── Ledger-path helpers (ADR-0041 PR 2) ─────────────────────────────
-  // Small promisified sqlite wrappers keep the money-path code readable; the
-  // shared-connection ordering guarantees still hold (calls queue in order, and
-  // _serializeTx prevents two BEGIN…COMMIT units from interleaving).
+  // Small promisified sqlite wrappers keep the money-path code readable.
   _run(sql, params = []) { return new Promise((res, rej) => this.db.run(sql, params, function (e) { e ? rej(e) : res(this); })); }
   _get(sql, params = []) { return new Promise((res, rej) => this.db.get(sql, params, (e, row) => e ? rej(e) : res(row))); }
   _all(sql, params = []) { return new Promise((res, rej) => this.db.all(sql, params, (e, rows) => e ? rej(e) : res(rows))); }
 
-  _setMarketState(id, state) { return this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id]); }
+  // State-mutating single statements go through _serializeTx so they can never
+  // be dispatched onto the shared connection WHILE another unit's BEGIN…COMMIT
+  // is open (which would enlist them in that transaction and roll them back with
+  // it). Chaining them makes the write land in its own autocommit, in order.
+  _setMarketState(id, state) { return this._serializeTx(() => this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id])); }
   _setPendingState(txId, state) {
-    return this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]);
+    return this._serializeTx(() => this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]));
   }
   _journalPending(r) {
-    return this._run(
+    return this._serializeTx(() => this._run(
       `INSERT INTO pending_trades (tx_id, market_id, trader_id, outcome_idx, shares, cost_minor, share_ticks, q_before, state)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [r.txId, r.market_id, r.trader_id, r.outcome, r.shares, r.costMinor, r.shareTicks, r.qBeforeJson, r.state],
-    );
+    ));
   }
 
   /**
@@ -637,6 +639,11 @@ class GhostSignalsHub {
       const qAfter = qBefore.slice();
       qAfter[outcome] += shares;
       const cost = lmsrCost(qAfter, m.liquidity) - lmsrCost(qBefore, m.liquidity);
+      // Bound the float→int multiply so cost/share minor units can't lose
+      // precision past 2^53 (a huge grant could otherwise corrupt the amounts).
+      if (shares * SHARE_TICK >= Number.MAX_SAFE_INTEGER || cost * kax.MINOR >= Number.MAX_SAFE_INTEGER) {
+        throw new Error('trade too large (would overflow minor-unit precision)');
+      }
       const costMinor = kax.tradeCostMinor(cost);           // ceil, rejects dust <= 0
       const shareTicks = Math.floor(shares * SHARE_TICK);    // floor — pool's favor
       if (!(shareTicks > 0)) throw new Error('shares round to zero ticks');
@@ -655,8 +662,9 @@ class GhostSignalsHub {
       }
 
       // 3) Shares AFTER money: q-CAS + audit-grade trade row + position, one tx.
-      //    Under the per-market mutex the CAS should never fail; if it does, the
-      //    debit already landed, so flag for refund reconciliation (PR 2c).
+      //    Under the per-market mutex the CAS normally holds; it CAN still miss
+      //    if the audit halted the market mid-flight (state flips off 'open') —
+      //    then the debit already landed, so flag for refund reconciliation.
       try {
         await this._commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
       } catch (e) {
@@ -729,10 +737,11 @@ class GhostSignalsHub {
     const market_id = market.id;
     const finalPrices = market.prices.slice();
     return this._serializeMarket(market_id, async () => {
-      // Freeze — only the transaction that flips 0->1 proceeds.
+      // Freeze — only the transaction that flips 0->1 proceeds. state='resolving'
+      // hands the market to the payout reconciler until the payout is confirmed.
       const flip = await this._serializeTx(async () => {
         const u = await this._run(
-          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ? AND resolved = 0`,
+          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ?, state = 'resolving' WHERE id = ? AND resolved = 0`,
           [winning_outcome, method, market_id],
         );
         return u.changes;
@@ -740,30 +749,44 @@ class GhostSignalsHub {
       if (flip === 0) throw new Error('already resolved');
 
       // Trading is frozen. Compute + POST the batched payout (an HTTP call, so
-      // OUTSIDE any SQLite transaction).
-      const winners = await this._winningPayouts(market_id, winning_outcome);
-      const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
-      const poolValue = await this._poolValueMinor(market_id, market.subsidy_minor);
-      let residual = poolValue - totalPayout;
-      if (residual < 0n) {
-        // Should be impossible under pool-favor rounding. Never sweep-then-assert:
-        // alert, sweep nothing, and let the KAX overdraft guard 409 if truly short.
-        console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
-        residual = 0n;
-      }
-      if (winners.length > 0) {
-        const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
-        if (!r.ok && r.definitive) {
-          console.error(`gshub payout rejected market ${market_id} (${r.status}): ${r.error} — frozen, awaiting reconciliation`);
-        } else if (!r.ok) {
-          console.error(`gshub payout ambiguous market ${market_id} (${r.status}): ${r.error} — will reconcile (idempotent resolve:${market_id})`);
-        }
-      }
+      // OUTSIDE any SQLite transaction). A failure leaves state='resolving' for
+      // _reconcilePendingResolve to re-post (idempotent resolve:<id>).
+      const { winners, residual } = await this._computePayout(market_id, winning_outcome, market.subsidy_minor);
+      const r = await this._postPayout(market_id, winners, residual);
+      if (r && r.ok) await this._setMarketState(market_id, 'settled');
       await this._updateLedgerReputation(market_id, winning_outcome).catch(() => {});
       const m = await this.getMarket(market_id);
       this.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices, ledger: true } });
       return m;
     });
+  }
+
+  /** Winners + house residual for a resolved market (pool-favor; never negative). */
+  async _computePayout(market_id, winning_outcome, subsidy_minor) {
+    const winners = await this._winningPayouts(market_id, winning_outcome);
+    const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
+    const poolValue = await this._poolValueMinor(market_id, subsidy_minor);
+    let residual = poolValue - totalPayout;
+    if (residual < 0n) {
+      // Impossible under pool-favor rounding. Never sweep-then-assert: alert,
+      // sweep nothing, let the KAX overdraft guard 409 if the pool is truly short.
+      console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
+      residual = 0n;
+    }
+    return { winners, residual };
+  }
+
+  /**
+   * Post the batched payout. ALWAYS settles the pool — even with zero winners we
+   * sweep the full residual (subsidy + losers' stakes) back to house, so an
+   * upset market can't strand its pool. Returns the client result (or a
+   * synthetic ok when there is genuinely nothing to move).
+   */
+  async _postPayout(market_id, winners, residual) {
+    if (winners.length === 0 && residual === 0n) return { ok: true, empty: true };
+    const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
+    if (!r.ok) console.error(`gshub payout ${r.definitive ? 'rejected' : 'ambiguous'} market ${market_id} (${r.status}): ${r.error}`);
+    return r;
   }
 
   /** Non-monetary reputation/accuracy update for a resolved ledger market. */
@@ -798,10 +821,11 @@ class GhostSignalsHub {
     if (!kax.tradeEnabled() || !kax.readEnabled()) return { skipped: true };
     if (this._reconciling) return { skipped: 'in-flight' };
     this._reconciling = true;
-    const report = { escrow: 0, trades: 0, audited: 0, alerts: 0 };
+    const report = { escrow: 0, trades: 0, resolves: 0, audited: 0, alerts: 0 };
     try {
       await this._reconcilePendingEscrow(report);
       await this._reconcilePendingTrades(report);
+      await this._reconcilePendingResolve(report);
       await this._auditOpenPools(report);
     } catch (e) {
       console.error('gshub reconcile error:', e.message);
@@ -838,28 +862,68 @@ class GhostSignalsHub {
    *   absent + committed  → impossible (we only commit after a 2xx) → alert
    */
   async _reconcilePendingTrades(report) {
+    // A freshly-'posting' row is a LIVE trade mid-flight, not a crash orphan. We
+    // must NOT refund it: its shares may be about to commit, which would leave a
+    // paid-for position with a reversed debit (a mint). Two guards:
+    //  (a) grace window — skip 'posting' rows younger than the grace period (an
+    //      in-flight trade completes well inside it); and
+    //  (b) per-market mutex — process each row UNDER _serializeMarket so it
+    //      queues behind any live trade for that market and re-reads the now-
+    //      terminal state instead of racing it.
+    const graceMs = Number(process.env.KAX_RECONCILE_GRACE_MS ?? 2 * Number(process.env.KAX_LEDGER_TIMEOUT_MS || 8000));
     const rows = await this._all(
-      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor FROM pending_trades
-        WHERE state IN ('posting', 'reconcile', 'refund')`,
+      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor, state,
+              (julianday('now') - julianday(updated_at)) * 86400000 AS age_ms
+         FROM pending_trades WHERE state IN ('posting', 'reconcile', 'refund')`,
     );
     for (const p of rows) {
-      const g = await kax.getTx(p.tx_id);
-      if (!(g.ok && g.result)) continue; // read ambiguous → next cycle
-      const landed = g.result.found === true;
-      const absent = g.result.found === false;
-      const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
+      if (p.state === 'posting' && p.age_ms < graceMs) continue; // live trade — leave to its owner
+      await this._serializeMarket(p.market_id, async () => {
+        // Re-read under the mutex: the owning trade may have finished while we queued.
+        const cur = await this._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [p.tx_id]);
+        if (!cur || !['posting', 'reconcile', 'refund'].includes(cur.state)) return; // already terminal
+        const g = await kax.getTx(p.tx_id);
+        if (!(g.ok && g.result)) return; // read ambiguous → next cycle
+        const landed = g.result.found === true;
+        const absent = g.result.found === false;
+        const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
 
-      if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; continue; }
-      if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; continue; }
-      if (landed && !committed) {
-        // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
-        const principal = kax.principalFor(p.trader_id);
-        const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
-        if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
-        else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
-        continue;
-      }
-      if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+        if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; return; }
+        if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; return; }
+        if (landed && !committed) {
+          // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
+          const principal = kax.principalFor(p.trader_id);
+          const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
+          if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
+          else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
+          return;
+        }
+        if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+      });
+    }
+  }
+
+  /**
+   * Re-drive payouts for markets frozen at state='resolving' (their payout POST
+   * failed or was ambiguous). getTx(resolve:<id>) confirms landing; otherwise
+   * re-post the idempotent payout. Closes the window where winners' funds could
+   * be stranded in the pool after a failed settlement.
+   */
+  async _reconcilePendingResolve(report) {
+    const rows = await this._all(
+      `SELECT id, resolved_outcome, subsidy_minor FROM markets WHERE ledger_backed = 1 AND resolved = 1 AND state = 'resolving'`,
+    );
+    for (const row of rows) {
+      await this._serializeMarket(row.id, async () => {
+        const g = await kax.getTx(kax.txid.resolve(row.id));
+        if (g.ok && g.result && g.result.found === true) { await this._setMarketState(row.id, 'settled'); report.resolves++; return; }
+        if (g.ok && g.result && g.result.found === false) {
+          const { winners, residual } = await this._computePayout(row.id, row.resolved_outcome, row.subsidy_minor);
+          const r = await this._postPayout(row.id, winners, residual);
+          if (r && r.ok) { await this._setMarketState(row.id, 'settled'); report.resolves++; }
+        }
+        // getTx ambiguous → leave 'resolving' for next cycle.
+      });
     }
   }
 
@@ -871,16 +935,21 @@ class GhostSignalsHub {
    * shortfall, halt trading (placeTrade requires state='open') and alert.
    */
   async _auditOpenPools(report) {
-    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'open' AND resolved = 0`);
+    // Audit both 'open' (may need halting) and 'halted' (may recover) markets.
+    const rows = await this._all(`SELECT id, subsidy_minor, state FROM markets WHERE ledger_backed = 1 AND state IN ('open', 'halted') AND resolved = 0`);
     for (const row of rows) {
       const b = await kax.balance(`amm:${row.id}`);
       if (!b.ok) continue; // read failed — skip rather than false-alarm
       report.audited++;
       const expected = await this._poolValueMinor(row.id, row.subsidy_minor);
-      if (b.balance < expected) {
+      if (b.balance < expected && row.state === 'open') {
         console.error(`gshub POOL AUDIT SHORTFALL ${row.id}: ledger ${b.balance} < committed ${expected} — halting trading`);
         await this._setMarketState(row.id, 'halted');
         report.alerts++;
+      } else if (b.balance >= expected && row.state === 'halted') {
+        // Shortfall cleared (e.g. an orphaned debit was refunded) — resume trading.
+        console.error(`gshub POOL AUDIT RECOVERED ${row.id}: ledger ${b.balance} >= committed ${expected} — resuming trading`);
+        await this._setMarketState(row.id, 'open');
       }
     }
   }

--- a/test/kax-ledger-reconcile.test.js
+++ b/test/kax-ledger-reconcile.test.js
@@ -14,6 +14,9 @@ process.env.KAX_LEDGER_BASE = 'http://kax.test';
 process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
 process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
 process.env.KAX_SERVICE_TOKEN = 'read-tok';
+// No grace window in the test so a just-journaled orphan is reconciled at once
+// (in prod the grace period protects live in-flight trades from false refunds).
+process.env.KAX_RECONCILE_GRACE_MS = '0';
 
 const { GhostSignalsHub } = require('../server/ghostsignals-hub');
 const kax = require('../server/kax-ledger');
@@ -62,6 +65,8 @@ function makeFakeLedger() {
     }
     // POST writes
     const body = JSON.parse(opts.body);
+    // Optional gate: block a trade POST mid-flight (to test the reconcile race).
+    if (u.pathname === '/api/ledger/trade' && led.tradeGate) await led.tradeGate;
     let postings = null;
     if (u.pathname === '/api/ledger/escrow') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
     else if (u.pathname === '/api/ledger/grant') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
@@ -69,6 +74,11 @@ function makeFakeLedger() {
       postings = body.side === 'sell'
         ? [{ account: `amm:${body.marketId}`, amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }]
         : [{ account: `trader:${body.principal}`, amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    } else if (u.pathname === '/api/ledger/payout') {
+      const total = (body.winners || []).reduce((a, w) => a + S(w.amount), 0n) + S(body.residual || '0');
+      postings = [{ account: `amm:${body.marketId}`, amount: -total }];
+      for (const w of (body.winners || [])) postings.push({ account: `trader:${w.principal}`, amount: S(w.amount) });
+      if (S(body.residual || '0') > 0n) postings.push({ account: 'house', amount: S(body.residual) });
     }
     try {
       const r = apply(body.txId, postings);
@@ -135,6 +145,42 @@ async function run() {
   // A halted market rejects new trades.
   await assert.rejects(() => hub.placeTrade({ market_id: stuckId, trader_id: alice, outcome: 0, shares: 1 }), /not open/);
   console.log('ok  pool audit shortfall → halted + trading blocked');
+
+  // ── E) BLOCKER-1 regression: reconcile must NOT refund a LIVE in-flight trade.
+  //       Hold a trade's ledger POST open, fire reconcile() concurrently, then
+  //       release — the trade must complete and never be refunded. ────────────
+  const led2 = makeFakeLedger();
+  const hub2 = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub2.init();
+  const carol = 'kax:agent:carol';
+  await hub2.registerTrader({ id: carol, display_name: 'Carol', kind: 'ai' });
+  await kax.grant({ principal: carol, amountMinor: '100000000', txId: 'grant:register:' + carol });
+  const mk = await hub2.createMarket({ question: 'race', outcomes: ['Y', 'N'], tag: 'labs', source: 'kannaka-labs' });
+  let releaseGate;
+  led2.tradeGate = new Promise((res) => { releaseGate = res; });
+  const tradeP = hub2.placeTrade({ market_id: mk.id, trader_id: carol, outcome: 0, shares: 3 }); // holds mutex on the gated POST
+  await new Promise((r) => setTimeout(r, 20)); // let it reach the gated POST
+  const reconcileP = hub2.reconcile();          // queues behind the market mutex
+  await new Promise((r) => setTimeout(r, 20));
+  releaseGate();                                // let the trade finish
+  await Promise.all([tradeP, reconcileP]);
+  const pk = await hub2._get(`SELECT state FROM pending_trades WHERE market_id = ?`, [mk.id]);
+  assert.strictEqual(pk.state, 'posted', 'in-flight trade committed, not refunded');
+  const refundLanded = (await kax.getTx(kax.txid.refund((await hub2._get(`SELECT tx_id FROM pending_trades WHERE market_id = ?`, [mk.id])).tx_id)));
+  assert.ok(refundLanded.ok && refundLanded.result.found === false, 'no refund was posted for the live trade');
+  console.log('ok  reconcile does NOT refund a live in-flight trade (blocker-1)');
+
+  // ── F) BLOCKER-2 regression: a payout that the client saw fail is re-driven
+  //       by reconcile until settled (funds not stranded). ─────────────────────
+  await hub2.placeTrade({ market_id: mk.id, trader_id: carol, outcome: 1, shares: 2 });
+  led2.mode = 'applyThenFail'; // payout lands on the ledger but client sees 5xx
+  await hub2.resolveMarket({ market_id: mk.id, winning_outcome: 0, method: 'manual' });
+  assert.strictEqual((await hub2.getMarket(mk.id)).state, 'resolving', 'failed payout leaves market resolving');
+  led2.mode = 'normal';
+  const repF = await hub2.reconcile();
+  assert.strictEqual((await hub2.getMarket(mk.id)).state, 'settled', 'reconcile settled the resolving market');
+  assert.ok(repF.resolves >= 1, 'payout reconcile pass acted');
+  console.log('ok  failed payout re-driven to settled (blocker-2)');
 
   console.log('\nPASSED kax-ledger-reconcile.test.js');
 }

--- a/test/kax-ledger-wiring.test.js
+++ b/test/kax-ledger-wiring.test.js
@@ -136,6 +136,19 @@ async function run() {
   assert.ok(!p.body.winners.some((w) => w.principal === bob), 'Bob (outcome 1) is not paid');
   console.log(`ok  batched payout (1 tx, ${p.body.winners.length} winner(s), residual ${p.body.residual})`);
 
+  // 3b) Upset market: resolve to a side NOBODY bought → no winners, but the full
+  //     pool (subsidy + losers' stakes) must be swept to house, not stranded.
+  const m2 = await hub.createMarket({ question: 'upset', outcomes: ['Yes', 'No'], ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs' });
+  await hub.placeTrade({ market_id: m2.id, trader_id: alice, outcome: 0, shares: 4 }); // all on outcome 0
+  const pool2 = led.bal(`amm:${m2.id}`);
+  assert.ok(pool2 > 0n, 'upset pool funded');
+  const houseBefore = led.bal('house');
+  await hub.resolveMarket({ market_id: m2.id, winning_outcome: 1, method: 'manual' }); // outcome 1 wins — nobody holds it
+  assert.strictEqual(led.bal(`amm:${m2.id}`), 0n, 'upset pool fully swept (not stranded)');
+  assert.strictEqual(led.bal('house') - houseBefore, pool2, 'full pool returned to house');
+  assert.strictEqual((await hub.getMarket(m2.id)).state, 'settled', 'upset market settled');
+  console.log(`ok  upset market swept to house (${pool2} minor, no winners)`);
+
   // 4) Conservation: every posting summed to zero, so Σ all balances == 0, and
   //    the pool never went negative.
   let total = 0n;


### PR DESCRIPTION
Fixes from a **post-implementation adversarial review** (3 lenses: cross-service consistency, economic conservation, concurrency) of the 2b+2c money-path diff. Stacked on #103. Two blockers + several gaps, all fixed with regression tests before the stack merges.

### Blockers (all three reviewers independently traced #1)
- **#1 — reconcile refunded a LIVE in-flight trade (a mint).** `_reconcilePendingTrades` ran outside the per-market mutex, so it could see a just-landed debit whose shares hadn't committed and refund it — then the shares commit → free position + reversed debit. **Fix:** process each pending row **under `_serializeMarket`** (queues behind any live trade, re-reads the now-terminal state) + a **grace window** so a freshly-`'posting'` row (a live trade) isn't treated as a crash orphan. *Regression: gated trade POST + concurrent `reconcile()` → trade completes, never refunded.*
- **#2 — a failed/ambiguous payout stranded winners' funds forever.** A resolved market fell out of every reconcile pass. **Fix:** resolve flips `state='resolving'` → new `_reconcilePendingResolve` re-drives the idempotent payout (`getTx(resolve:<id>)` → settle, else re-post) → `state='settled'`. *Regression: applied-but-5xx payout → `resolving` → reconcile → `settled`.*

### Also
- **No-winner sweep:** an upset market (winning side unheld) now sweeps the **full pool** (subsidy + losers' stakes) to house instead of stranding it. `_postPayout` always settles; the KAX `/ledger/payout` endpoint (PR #80) now accepts empty winners when `residual > 0`. *Regression: upset market → pool → 0, house made whole, `settled`.*
- **`halted` recovery:** `_auditOpenPools` re-audits halted markets and resumes (`open`) once the shortfall clears — no terminal trap.
- **Overflow guard:** reject a trade whose `cost`/`shares × MINOR` would exceed 2^53.
- **Isolation (Finding 3):** state-mutating single statements go through `_serializeTx` so they can't be enlisted in another unit's open `BEGIN…COMMIT` and rolled back.
- Corrected the overstated "q-CAS should never fail" comment.

**Confirmed-correct (not regressed):** money-first ordering, deterministic idempotency keys, single-flip resolve, escrow-ambiguity fail-safe, LMSR subsidy = max-loss bound, pool-favor rounding solvency, `_serializeMarket`/`_serializeTx` chaining, re-entrancy guards, TTL-excludes-labs.

Full radio suite green (incl. 2 new blocker regressions + the upset-sweep case). **This completes the funded-AMM money path** — the review gate is closed.
