### PR TITLE
feat: funded-AMM money path — client + hub wiring + reconciler + review fixes (ADR-0041 Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-ledger.test.js"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -598,23 +598,25 @@ class GhostSignalsHub {
   }
 
   // ── Ledger-path helpers (ADR-0041 PR 2) ─────────────────────────────
-  // Small promisified sqlite wrappers keep the money-path code readable; the
-  // shared-connection ordering guarantees still hold (calls queue in order, and
-  // _serializeTx prevents two BEGIN…COMMIT units from interleaving).
+  // Small promisified sqlite wrappers keep the money-path code readable.
   _run(sql, params = []) { return new Promise((res, rej) => this.db.run(sql, params, function (e) { e ? rej(e) : res(this); })); }
   _get(sql, params = []) { return new Promise((res, rej) => this.db.get(sql, params, (e, row) => e ? rej(e) : res(row))); }
   _all(sql, params = []) { return new Promise((res, rej) => this.db.all(sql, params, (e, rows) => e ? rej(e) : res(rows))); }
 
-  _setMarketState(id, state) { return this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id]); }
+  // State-mutating single statements go through _serializeTx so they can never
+  // be dispatched onto the shared connection WHILE another unit's BEGIN…COMMIT
+  // is open (which would enlist them in that transaction and roll them back with
+  // it). Chaining them makes the write land in its own autocommit, in order.
+  _setMarketState(id, state) { return this._serializeTx(() => this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id])); }
   _setPendingState(txId, state) {
-    return this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]);
+    return this._serializeTx(() => this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]));
   }
   _journalPending(r) {
-    return this._run(
+    return this._serializeTx(() => this._run(
       `INSERT INTO pending_trades (tx_id, market_id, trader_id, outcome_idx, shares, cost_minor, share_ticks, q_before, state)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [r.txId, r.market_id, r.trader_id, r.outcome, r.shares, r.costMinor, r.shareTicks, r.qBeforeJson, r.state],
-    );
+    ));
   }
 
   /**
@@ -637,6 +639,11 @@ class GhostSignalsHub {
       const qAfter = qBefore.slice();
       qAfter[outcome] += shares;
       const cost = lmsrCost(qAfter, m.liquidity) - lmsrCost(qBefore, m.liquidity);
+      // Bound the float→int multiply so cost/share minor units can't lose
+      // precision past 2^53 (a huge grant could otherwise corrupt the amounts).
+      if (shares * SHARE_TICK >= Number.MAX_SAFE_INTEGER || cost * kax.MINOR >= Number.MAX_SAFE_INTEGER) {
+        throw new Error('trade too large (would overflow minor-unit precision)');
+      }
       const costMinor = kax.tradeCostMinor(cost);           // ceil, rejects dust <= 0
       const shareTicks = Math.floor(shares * SHARE_TICK);    // floor — pool's favor
       if (!(shareTicks > 0)) throw new Error('shares round to zero ticks');
@@ -655,8 +662,9 @@ class GhostSignalsHub {
       }
 
       // 3) Shares AFTER money: q-CAS + audit-grade trade row + position, one tx.
-      //    Under the per-market mutex the CAS should never fail; if it does, the
-      //    debit already landed, so flag for refund reconciliation (PR 2c).
+      //    Under the per-market mutex the CAS normally holds; it CAN still miss
+      //    if the audit halted the market mid-flight (state flips off 'open') —
+      //    then the debit already landed, so flag for refund reconciliation.
       try {
         await this._commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
       } catch (e) {
@@ -729,10 +737,11 @@ class GhostSignalsHub {
     const market_id = market.id;
     const finalPrices = market.prices.slice();
     return this._serializeMarket(market_id, async () => {
-      // Freeze — only the transaction that flips 0->1 proceeds.
+      // Freeze — only the transaction that flips 0->1 proceeds. state='resolving'
+      // hands the market to the payout reconciler until the payout is confirmed.
       const flip = await this._serializeTx(async () => {
         const u = await this._run(
-          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ? AND resolved = 0`,
+          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ?, state = 'resolving' WHERE id = ? AND resolved = 0`,
           [winning_outcome, method, market_id],
         );
         return u.changes;
@@ -740,30 +749,44 @@ class GhostSignalsHub {
       if (flip === 0) throw new Error('already resolved');
 
       // Trading is frozen. Compute + POST the batched payout (an HTTP call, so
-      // OUTSIDE any SQLite transaction).
-      const winners = await this._winningPayouts(market_id, winning_outcome);
-      const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
-      const poolValue = await this._poolValueMinor(market_id, market.subsidy_minor);
-      let residual = poolValue - totalPayout;
-      if (residual < 0n) {
-        // Should be impossible under pool-favor rounding. Never sweep-then-assert:
-        // alert, sweep nothing, and let the KAX overdraft guard 409 if truly short.
-        console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
-        residual = 0n;
-      }
-      if (winners.length > 0) {
-        const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
-        if (!r.ok && r.definitive) {
-          console.error(`gshub payout rejected market ${market_id} (${r.status}): ${r.error} — frozen, awaiting reconciliation`);
-        } else if (!r.ok) {
-          console.error(`gshub payout ambiguous market ${market_id} (${r.status}): ${r.error} — will reconcile (idempotent resolve:${market_id})`);
-        }
-      }
+      // OUTSIDE any SQLite transaction). A failure leaves state='resolving' for
+      // _reconcilePendingResolve to re-post (idempotent resolve:<id>).
+      const { winners, residual } = await this._computePayout(market_id, winning_outcome, market.subsidy_minor);
+      const r = await this._postPayout(market_id, winners, residual);
+      if (r && r.ok) await this._setMarketState(market_id, 'settled');
       await this._updateLedgerReputation(market_id, winning_outcome).catch(() => {});
       const m = await this.getMarket(market_id);
       this.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices, ledger: true } });
       return m;
     });
+  }
+
+  /** Winners + house residual for a resolved market (pool-favor; never negative). */
+  async _computePayout(market_id, winning_outcome, subsidy_minor) {
+    const winners = await this._winningPayouts(market_id, winning_outcome);
+    const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
+    const poolValue = await this._poolValueMinor(market_id, subsidy_minor);
+    let residual = poolValue - totalPayout;
+    if (residual < 0n) {
+      // Impossible under pool-favor rounding. Never sweep-then-assert: alert,
+      // sweep nothing, let the KAX overdraft guard 409 if the pool is truly short.
+      console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
+      residual = 0n;
+    }
+    return { winners, residual };
+  }
+
+  /**
+   * Post the batched payout. ALWAYS settles the pool — even with zero winners we
+   * sweep the full residual (subsidy + losers' stakes) back to house, so an
+   * upset market can't strand its pool. Returns the client result (or a
+   * synthetic ok when there is genuinely nothing to move).
+   */
+  async _postPayout(market_id, winners, residual) {
+    if (winners.length === 0 && residual === 0n) return { ok: true, empty: true };
+    const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
+    if (!r.ok) console.error(`gshub payout ${r.definitive ? 'rejected' : 'ambiguous'} market ${market_id} (${r.status}): ${r.error}`);
+    return r;
   }
 
   /** Non-monetary reputation/accuracy update for a resolved ledger market. */
@@ -798,10 +821,11 @@ class GhostSignalsHub {
     if (!kax.tradeEnabled() || !kax.readEnabled()) return { skipped: true };
     if (this._reconciling) return { skipped: 'in-flight' };
     this._reconciling = true;
-    const report = { escrow: 0, trades: 0, audited: 0, alerts: 0 };
+    const report = { escrow: 0, trades: 0, resolves: 0, audited: 0, alerts: 0 };
     try {
       await this._reconcilePendingEscrow(report);
       await this._reconcilePendingTrades(report);
+      await this._reconcilePendingResolve(report);
       await this._auditOpenPools(report);
     } catch (e) {
       console.error('gshub reconcile error:', e.message);
@@ -838,28 +862,68 @@ class GhostSignalsHub {
    *   absent + committed  → impossible (we only commit after a 2xx) → alert
    */
   async _reconcilePendingTrades(report) {
+    // A freshly-'posting' row is a LIVE trade mid-flight, not a crash orphan. We
+    // must NOT refund it: its shares may be about to commit, which would leave a
+    // paid-for position with a reversed debit (a mint). Two guards:
+    //  (a) grace window — skip 'posting' rows younger than the grace period (an
+    //      in-flight trade completes well inside it); and
+    //  (b) per-market mutex — process each row UNDER _serializeMarket so it
+    //      queues behind any live trade for that market and re-reads the now-
+    //      terminal state instead of racing it.
+    const graceMs = Number(process.env.KAX_RECONCILE_GRACE_MS ?? 2 * Number(process.env.KAX_LEDGER_TIMEOUT_MS || 8000));
     const rows = await this._all(
-      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor FROM pending_trades
-        WHERE state IN ('posting', 'reconcile', 'refund')`,
+      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor, state,
+              (julianday('now') - julianday(updated_at)) * 86400000 AS age_ms
+         FROM pending_trades WHERE state IN ('posting', 'reconcile', 'refund')`,
     );
     for (const p of rows) {
-      const g = await kax.getTx(p.tx_id);
-      if (!(g.ok && g.result)) continue; // read ambiguous → next cycle
-      const landed = g.result.found === true;
-      const absent = g.result.found === false;
-      const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
+      if (p.state === 'posting' && p.age_ms < graceMs) continue; // live trade — leave to its owner
+      await this._serializeMarket(p.market_id, async () => {
+        // Re-read under the mutex: the owning trade may have finished while we queued.
+        const cur = await this._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [p.tx_id]);
+        if (!cur || !['posting', 'reconcile', 'refund'].includes(cur.state)) return; // already terminal
+        const g = await kax.getTx(p.tx_id);
+        if (!(g.ok && g.result)) return; // read ambiguous → next cycle
+        const landed = g.result.found === true;
+        const absent = g.result.found === false;
+        const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
 
-      if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; continue; }
-      if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; continue; }
-      if (landed && !committed) {
-        // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
-        const principal = kax.principalFor(p.trader_id);
-        const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
-        if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
-        else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
-        continue;
-      }
-      if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+        if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; return; }
+        if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; return; }
+        if (landed && !committed) {
+          // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
+          const principal = kax.principalFor(p.trader_id);
+          const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
+          if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
+          else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
+          return;
+        }
+        if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+      });
+    }
+  }
+
+  /**
+   * Re-drive payouts for markets frozen at state='resolving' (their payout POST
+   * failed or was ambiguous). getTx(resolve:<id>) confirms landing; otherwise
+   * re-post the idempotent payout. Closes the window where winners' funds could
+   * be stranded in the pool after a failed settlement.
+   */
+  async _reconcilePendingResolve(report) {
+    const rows = await this._all(
+      `SELECT id, resolved_outcome, subsidy_minor FROM markets WHERE ledger_backed = 1 AND resolved = 1 AND state = 'resolving'`,
+    );
+    for (const row of rows) {
+      await this._serializeMarket(row.id, async () => {
+        const g = await kax.getTx(kax.txid.resolve(row.id));
+        if (g.ok && g.result && g.result.found === true) { await this._setMarketState(row.id, 'settled'); report.resolves++; return; }
+        if (g.ok && g.result && g.result.found === false) {
+          const { winners, residual } = await this._computePayout(row.id, row.resolved_outcome, row.subsidy_minor);
+          const r = await this._postPayout(row.id, winners, residual);
+          if (r && r.ok) { await this._setMarketState(row.id, 'settled'); report.resolves++; }
+        }
+        // getTx ambiguous → leave 'resolving' for next cycle.
+      });
     }
   }
 
@@ -871,16 +935,21 @@ class GhostSignalsHub {
    * shortfall, halt trading (placeTrade requires state='open') and alert.
    */
   async _auditOpenPools(report) {
-    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'open' AND resolved = 0`);
+    // Audit both 'open' (may need halting) and 'halted' (may recover) markets.
+    const rows = await this._all(`SELECT id, subsidy_minor, state FROM markets WHERE ledger_backed = 1 AND state IN ('open', 'halted') AND resolved = 0`);
     for (const row of rows) {
       const b = await kax.balance(`amm:${row.id}`);
       if (!b.ok) continue; // read failed — skip rather than false-alarm
       report.audited++;
       const expected = await this._poolValueMinor(row.id, row.subsidy_minor);
-      if (b.balance < expected) {
+      if (b.balance < expected && row.state === 'open') {
         console.error(`gshub POOL AUDIT SHORTFALL ${row.id}: ledger ${b.balance} < committed ${expected} — halting trading`);
         await this._setMarketState(row.id, 'halted');
         report.alerts++;
+      } else if (b.balance >= expected && row.state === 'halted') {
+        // Shortfall cleared (e.g. an orphaned debit was refunded) — resume trading.
+        console.error(`gshub POOL AUDIT RECOVERED ${row.id}: ledger ${b.balance} >= committed ${expected} — resuming trading`);
+        await this._setMarketState(row.id, 'open');
       }
     }
   }

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -17,6 +17,15 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const os = require('os');
+// ADR-0041 Phase 2 (funded-AMM PR 2): labs-tier markets move REAL conserved
+// credits on the KAX ledger. INERT until KAX_LEDGER_BASE + tokens are set —
+// kax.mintEnabled()/tradeEnabled() gate everything, so with no env every market
+// is ledger_backed=0 and the existing SQLite economy runs exactly as before.
+const kax = require('./kax-ledger');
+
+// Integer share ticks per share (mirror of kax.MINOR). A winning position pays
+// $1/share, so its payout in ledger minor units is exactly its share_ticks.
+const SHARE_TICK = kax.MINOR;
 
 // We require the stem-server's sqlite3 install if available — both apps
 // run on the same host so they share the binary. Falls back to the local
@@ -72,6 +81,34 @@ class GhostSignalsHub {
     // "cannot start a transaction within a transaction". This chain guarantees
     // one at a time.
     this._txChain = Promise.resolve();
+    // Per-market serialization for the ledger path (ADR-0041 PR 2). A labs
+    // market's trade unit is price → POST /ledger/trade → q-CAS → position; all
+    // of it must be serialized PER MARKET so the q we priced against is still
+    // current when we commit (the q-CAS then becomes a should-never-fire assert)
+    // and two trades can't both be mid-flight against the same pool.
+    this._marketChains = new Map();
+  }
+
+  /** Serialize `work` against a single market id (see _marketChains). */
+  _serializeMarket(marketId, work) {
+    const prev = this._marketChains.get(marketId) || Promise.resolve();
+    const result = prev.then(() => work(), () => work());
+    // Keep the chain alive regardless of outcome; prune when it drains.
+    const link = result.then(() => {}, () => {});
+    this._marketChains.set(marketId, link);
+    link.then(() => {
+      if (this._marketChains.get(marketId) === link) this._marketChains.delete(marketId);
+    });
+    return result;
+  }
+
+  /**
+   * A market is ledger-backed iff it was created as labs-tier WHILE the KAX
+   * mint+trade surfaces were configured. Dormant by default: with no env, no
+   * market is ever ledger_backed, so the SQLite path below is untouched.
+   */
+  _isLabsLedger(marketRow) {
+    return !!(marketRow && marketRow.ledger_backed) && kax.tradeEnabled();
   }
 
   /**
@@ -144,6 +181,34 @@ class GhostSignalsHub {
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_markets_active ON markets(resolved, expires_at)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_markets_volume ON markets(volume)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_market ON trades(market_id)`);
+        // ── ADR-0041 Phase 2 (funded-AMM PR 2) additive migration ──────────
+        // Ledger-backed labs markets carry a lifecycle state + funded subsidy;
+        // trades carry audit-grade integer minor units alongside the float; a
+        // pending_trades journal records intent BEFORE each ledger POST so an
+        // ambiguous outcome is reconcilable. Run unconditionally and swallow the
+        // "duplicate column" error so the migration is idempotent across boots.
+        const addCol = (sql) => this.db.run(sql, (e) => {
+          if (e && !/duplicate column/i.test(e.message)) console.error('gshub migrate:', e.message);
+        });
+        addCol(`ALTER TABLE markets ADD COLUMN state TEXT NOT NULL DEFAULT 'open'`);
+        addCol(`ALTER TABLE markets ADD COLUMN subsidy_minor TEXT`);
+        addCol(`ALTER TABLE markets ADD COLUMN ledger_backed INTEGER NOT NULL DEFAULT 0`);
+        addCol(`ALTER TABLE trades ADD COLUMN cost_minor TEXT`);
+        addCol(`ALTER TABLE trades ADD COLUMN share_ticks INTEGER`);
+        this.db.run(`CREATE TABLE IF NOT EXISTS pending_trades (
+          tx_id TEXT PRIMARY KEY,
+          market_id TEXT NOT NULL,
+          trader_id TEXT NOT NULL,
+          outcome_idx INTEGER NOT NULL,
+          shares REAL NOT NULL,
+          cost_minor TEXT NOT NULL,
+          share_ticks INTEGER NOT NULL,
+          q_before TEXT NOT NULL,
+          state TEXT NOT NULL DEFAULT 'posting',
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )`);
+        this.db.run(`CREATE INDEX IF NOT EXISTS idx_pending_trades_state ON pending_trades(state)`);
         this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_trader ON trades(trader_id)`, (err) => {
           if (err) return reject(err);
           // Seed system trader if not present
@@ -230,30 +295,48 @@ class GhostSignalsHub {
   }
 
   // ── Market API ───────────────────────────────────────────────────
-  createMarket({ question, outcomes = ['Yes', 'No'], ttl_sec = 3600, liquidity, tag = 'custom', source = 'system', source_app, metadata }) {
-    return new Promise((resolve, reject) => {
-      const id = 'm_' + crypto.randomBytes(6).toString('hex');
-      const lq = liquidity || this.defaultLiquidity;
-      const q = new Array(outcomes.length).fill(0);
-      const expiresAt = new Date(Date.now() + ttl_sec * 1000).toISOString();
-      this.db.run(
-        `INSERT INTO markets
-          (id, question, outcomes, liquidity, q, source, source_app, tag, metadata, expires_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          id, question, JSON.stringify(outcomes), lq, JSON.stringify(q),
-          source, source_app || null, tag, metadata ? JSON.stringify(metadata) : null,
-          expiresAt,
-        ],
-        (err) => {
-          if (err) return reject(err);
-          this.getMarket(id).then(m => {
-            this.broadcast({ type: 'gs_market_created', data: m });
-            resolve(m);
-          }).catch(reject);
-        }
-      );
-    });
+  async createMarket({ question, outcomes = ['Yes', 'No'], ttl_sec = 3600, liquidity, tag = 'custom', source = 'system', source_app, metadata }) {
+    const id = 'm_' + crypto.randomBytes(6).toString('hex');
+    const lq = liquidity || this.defaultLiquidity;
+    const q = new Array(outcomes.length).fill(0);
+    const expiresAt = new Date(Date.now() + ttl_sec * 1000).toISOString();
+    // Ledger-backed ONLY when created labs-tier AND the KAX mint+trade surfaces
+    // are both armed. Dormant otherwise → a plain SQLite market, unchanged.
+    const labsLedger = (tag === 'labs' || source === 'kannaka-labs') && kax.mintEnabled() && kax.tradeEnabled();
+    const subsidyMinor = labsLedger ? kax.subsidyMinor(lq, outcomes.length) : null;
+    const state = labsLedger ? 'pending_escrow' : 'open';
+
+    await this._run(
+      `INSERT INTO markets
+        (id, question, outcomes, liquidity, q, source, source_app, tag, metadata, expires_at, state, subsidy_minor, ledger_backed)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id, question, JSON.stringify(outcomes), lq, JSON.stringify(q),
+        source, source_app || null, tag, metadata ? JSON.stringify(metadata) : null,
+        expiresAt, state, subsidyMinor, labsLedger ? 1 : 0,
+      ],
+    );
+
+    if (labsLedger) {
+      // Fund the LMSR subsidy into the pool BEFORE opening (idempotent escrow:<id>).
+      // A definitive rejection voids the market; an ambiguous outcome leaves it
+      // pending_escrow for the reconciler — either way it never opens unfunded.
+      let r;
+      try { r = await kax.escrow({ marketId: id, subsidyMinor, ref: `market:${id}` }); }
+      catch (e) { await this._setMarketState(id, 'voided'); throw new Error(`escrow failed to send: ${e.message}`); }
+      if (r.ok) {
+        await this._setMarketState(id, 'open');
+      } else if (r.definitive) {
+        await this._setMarketState(id, 'voided');
+        throw new Error(`escrow rejected (${r.status}): ${r.error}`);
+      } else {
+        throw new Error(`escrow ambiguous (${r.status}): ${r.error} — market ${id} pending reconciliation`);
+      }
+    }
+
+    const m = await this.getMarket(id);
+    this.broadcast({ type: 'gs_market_created', data: m });
+    return m;
   }
 
   getMarket(id) {
@@ -288,6 +371,11 @@ class GhostSignalsHub {
       resolved_at: row.resolved_at,
       resolution_method: row.resolution_method,
       volume: row.volume,
+      // ADR-0041 PR 2: ledger lifecycle. Defaults ('open'/0/null) mean the
+      // pre-ledger SQLite economy, so existing markets read back unchanged.
+      state: row.state || 'open',
+      ledger_backed: !!row.ledger_backed,
+      subsidy_minor: row.subsidy_minor || null,
       ttl_remaining_sec: Math.max(0, Math.floor((new Date(row.expires_at).getTime() - Date.now()) / 1000)),
     };
   }
@@ -325,6 +413,12 @@ class GhostSignalsHub {
     if (outcome >= market.outcomes.length) throw new Error('outcome out of range');
     const trader = await this.getTrader(trader_id);
     if (!trader) throw new Error('trader not registered');
+
+    // ADR-0041 PR 2: labs-tier ledger markets move real credits on KAX instead
+    // of SQLite capital. Dormant unless the market was created ledger-backed.
+    if (this._isLabsLedger(market)) {
+      return this._placeTradeLedger({ market, trader_id, outcome, shares });
+    }
 
     // The q we read is the state our cost is priced against. The write below
     // is a compare-and-swap on exactly this value (`WHERE q = qBeforeJson`),
@@ -417,6 +511,10 @@ class GhostSignalsHub {
     if (winning_outcome < 0 || winning_outcome >= market.outcomes.length) {
       throw new Error('winning_outcome out of range');
     }
+    // ADR-0041 PR 2: ledger-backed markets settle on KAX (batched payout).
+    if (this._isLabsLedger(market)) {
+      return this._resolveMarketLedger({ market, winning_outcome, method });
+    }
     const finalPrices = market.prices.slice();
     return this._serializeTx(() => new Promise((resolve, reject) => {
         self.db.serialize(() => {
@@ -485,6 +583,195 @@ class GhostSignalsHub {
           );
         });
       }));
+  }
+
+  // ── Ledger-path helpers (ADR-0041 PR 2) ─────────────────────────────
+  // Small promisified sqlite wrappers keep the money-path code readable; the
+  // shared-connection ordering guarantees still hold (calls queue in order, and
+  // _serializeTx prevents two BEGIN…COMMIT units from interleaving).
+  _run(sql, params = []) { return new Promise((res, rej) => this.db.run(sql, params, function (e) { e ? rej(e) : res(this); })); }
+  _get(sql, params = []) { return new Promise((res, rej) => this.db.get(sql, params, (e, row) => e ? rej(e) : res(row))); }
+  _all(sql, params = []) { return new Promise((res, rej) => this.db.all(sql, params, (e, rows) => e ? rej(e) : res(rows))); }
+
+  _setMarketState(id, state) { return this._run(`UPDATE markets SET state = ? WHERE id = ?`, [state, id]); }
+  _setPendingState(txId, state) {
+    return this._run(`UPDATE pending_trades SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE tx_id = ?`, [state, txId]);
+  }
+  _journalPending(r) {
+    return this._run(
+      `INSERT INTO pending_trades (tx_id, market_id, trader_id, outcome_idx, shares, cost_minor, share_ticks, q_before, state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [r.txId, r.market_id, r.trader_id, r.outcome, r.shares, r.costMinor, r.shareTicks, r.qBeforeJson, r.state],
+    );
+  }
+
+  /**
+   * Place a labs-tier trade against the KAX ledger. Serialized PER MARKET:
+   * re-price under the mutex, journal intent, POST the debit (money first),
+   * then commit the shares (q-CAS + position). Ledger-backed traders never
+   * touch SQLite capital.
+   */
+  async _placeTradeLedger({ market, trader_id, outcome, shares }) {
+    const market_id = market.id;
+    const principal = kax.principalFor(trader_id);
+    return this._serializeMarket(market_id, async () => {
+      // Re-read INSIDE the mutex so the q we price against is current.
+      const m = await this.getMarket(market_id);
+      if (!m || m.resolved) throw new Error('market already resolved');
+      if (m.state !== 'open') throw new Error(`market not open for trading (state=${m.state})`);
+      if (outcome >= m.outcomes.length) throw new Error('outcome out of range');
+      const qBefore = m.q.slice();
+      const qBeforeJson = JSON.stringify(qBefore);
+      const qAfter = qBefore.slice();
+      qAfter[outcome] += shares;
+      const cost = lmsrCost(qAfter, m.liquidity) - lmsrCost(qBefore, m.liquidity);
+      const costMinor = kax.tradeCostMinor(cost);           // ceil, rejects dust <= 0
+      const shareTicks = Math.floor(shares * SHARE_TICK);    // floor — pool's favor
+      if (!(shareTicks > 0)) throw new Error('shares round to zero ticks');
+      const txId = kax.txid.trade(kax.newTradeUuid());
+
+      // 1) Journal intent BEFORE the POST (so an ambiguous outcome is recoverable).
+      await this._journalPending({ txId, market_id, trader_id, outcome, shares, costMinor, shareTicks, qBeforeJson, state: 'posting' });
+
+      // 2) Money FIRST — debit trader, credit pool. (q-first would mint free
+      //    shares on a crash between shares and money.)
+      const r = await kax.trade({ txId, principal, marketId: market_id, amountMinor: costMinor, side: 'buy', ref: `trade:${market_id}` });
+      if (!r.ok) {
+        if (r.definitive) { await this._setPendingState(txId, 'failed'); throw new Error(`ledger trade rejected (${r.status}): ${r.error}`); }
+        await this._setPendingState(txId, 'reconcile');
+        throw new Error(`ledger trade ambiguous (${r.status}): ${r.error} — pending reconciliation`);
+      }
+
+      // 3) Shares AFTER money: q-CAS + audit-grade trade row + position, one tx.
+      //    Under the per-market mutex the CAS should never fail; if it does, the
+      //    debit already landed, so flag for refund reconciliation (PR 2c).
+      try {
+        await this._commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
+      } catch (e) {
+        await this._setPendingState(txId, 'refund');
+        throw new Error(`shares commit failed after ledger debit (refund queued, tx ${txId}): ${e.message}`);
+      }
+      await this._setPendingState(txId, 'posted');
+      const updated = await this.getMarket(market_id);
+      this.broadcast({ type: 'gs_trade', data: { market_id, trader_id, outcome, shares, cost, cost_minor: costMinor, ledger: true, prices: updated.prices } });
+      return { cost, cost_minor: costMinor, prices: updated.prices, market: updated };
+    });
+  }
+
+  /** The SQLite side of a ledger trade: q-CAS + trade row + position. No capital. */
+  _commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
+    const self = this;
+    return this._serializeTx(async () => {
+      await self._run('BEGIN');
+      try {
+        const q = await self._run(
+          `UPDATE markets SET q = ?, volume = volume + ? WHERE id = ? AND q = ? AND resolved = 0 AND state = 'open'`,
+          [qAfterJson, shares, market_id, qBeforeJson],
+        );
+        if (q.changes === 0) throw new Error('market state changed concurrently (q-CAS)');
+        await self._run(`UPDATE traders SET trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ?`, [trader_id]);
+        await self._run(
+          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks],
+        );
+        await self._run(
+          `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
+           ON CONFLICT(market_id, trader_id, outcome_idx) DO UPDATE SET shares = shares + ?`,
+          [market_id, trader_id, outcome, shares, shares],
+        );
+        await self._run('COMMIT');
+      } catch (e) {
+        await self._run('ROLLBACK').catch(() => {});
+        throw e;
+      }
+    });
+  }
+
+  /** Winning payouts for a ledger market: Σ share_ticks per trader, in minor units. */
+  async _winningPayouts(market_id, winning_outcome) {
+    const rows = await this._all(
+      `SELECT trader_id, COALESCE(SUM(share_ticks), 0) AS ticks
+         FROM trades WHERE market_id = ? AND outcome_idx = ? AND share_ticks IS NOT NULL
+         GROUP BY trader_id HAVING ticks > 0`,
+      [market_id, winning_outcome],
+    );
+    return rows.map((r) => ({ principal: kax.principalFor(r.trader_id), amountMinor: String(r.ticks) }));
+  }
+
+  /** Pool value in minor units = subsidy + Σ cost_minor collected on this market. */
+  async _poolValueMinor(market_id, subsidyMinor) {
+    const rows = await this._all(`SELECT cost_minor FROM trades WHERE market_id = ? AND cost_minor IS NOT NULL`, [market_id]);
+    let sum = BigInt(subsidyMinor || '0');
+    for (const r of rows) sum += BigInt(r.cost_minor);
+    return sum;
+  }
+
+  /**
+   * Resolve a ledger-backed market. Freeze trading (single-flip resolved=1)
+   * FIRST, then pay all winners out of the pool + sweep residual to house in ONE
+   * balanced KAX transaction (txId=resolve:<id>, idempotent). Payout progress is
+   * decoupled from the resolved flag: a definitive rejection or ambiguity leaves
+   * the (frozen) market for the PR-2c reconciler rather than paying twice.
+   */
+  async _resolveMarketLedger({ market, winning_outcome, method }) {
+    const market_id = market.id;
+    const finalPrices = market.prices.slice();
+    return this._serializeMarket(market_id, async () => {
+      // Freeze — only the transaction that flips 0->1 proceeds.
+      const flip = await this._serializeTx(async () => {
+        const u = await this._run(
+          `UPDATE markets SET resolved = 1, resolved_outcome = ?, resolved_at = CURRENT_TIMESTAMP, resolution_method = ? WHERE id = ? AND resolved = 0`,
+          [winning_outcome, method, market_id],
+        );
+        return u.changes;
+      });
+      if (flip === 0) throw new Error('already resolved');
+
+      // Trading is frozen. Compute + POST the batched payout (an HTTP call, so
+      // OUTSIDE any SQLite transaction).
+      const winners = await this._winningPayouts(market_id, winning_outcome);
+      const totalPayout = winners.reduce((a, w) => a + BigInt(w.amountMinor), 0n);
+      const poolValue = await this._poolValueMinor(market_id, market.subsidy_minor);
+      let residual = poolValue - totalPayout;
+      if (residual < 0n) {
+        // Should be impossible under pool-favor rounding. Never sweep-then-assert:
+        // alert, sweep nothing, and let the KAX overdraft guard 409 if truly short.
+        console.error(`gshub SOLVENCY ALERT market ${market_id}: payout ${totalPayout} > pool ${poolValue}`);
+        residual = 0n;
+      }
+      if (winners.length > 0) {
+        const r = await kax.payout({ marketId: market_id, winners, residualMinor: residual.toString(), ref: `resolve:${market_id}` });
+        if (!r.ok && r.definitive) {
+          console.error(`gshub payout rejected market ${market_id} (${r.status}): ${r.error} — frozen, awaiting reconciliation`);
+        } else if (!r.ok) {
+          console.error(`gshub payout ambiguous market ${market_id} (${r.status}): ${r.error} — will reconcile (idempotent resolve:${market_id})`);
+        }
+      }
+      await this._updateLedgerReputation(market_id, winning_outcome).catch(() => {});
+      const m = await this.getMarket(market_id);
+      this.broadcast({ type: 'gs_market_resolved', data: { ...m, finalPrices, ledger: true } });
+      return m;
+    });
+  }
+
+  /** Non-monetary reputation/accuracy update for a resolved ledger market. */
+  async _updateLedgerReputation(market_id, winning_outcome) {
+    const positions = await this._all(`SELECT trader_id, outcome_idx, shares FROM positions WHERE market_id = ?`, [market_id]);
+    const traders = new Map();
+    for (const p of positions) {
+      if (!traders.has(p.trader_id)) traders.set(p.trader_id, { yes: 0, total: 0 });
+      const t = traders.get(p.trader_id);
+      t.total += p.shares;
+      if (p.outcome_idx === winning_outcome) t.yes += p.shares;
+    }
+    for (const [trader_id, t] of traders.entries()) {
+      const impliedYes = t.total > 0 ? t.yes / t.total : 0.5;
+      const accuracy = brierAccuracy(impliedYes, 1);
+      await this._run(
+        `UPDATE traders SET trades_won = trades_won + ?, reputation = reputation * 0.95 + ? * 0.05, last_active = CURRENT_TIMESTAMP WHERE id = ?`,
+        [t.yes > 0 ? 1 : 0, accuracy, trader_id],
+      );
+    }
   }
 
   /**

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -195,6 +195,11 @@ class GhostSignalsHub {
         addCol(`ALTER TABLE markets ADD COLUMN ledger_backed INTEGER NOT NULL DEFAULT 0`);
         addCol(`ALTER TABLE trades ADD COLUMN cost_minor TEXT`);
         addCol(`ALTER TABLE trades ADD COLUMN share_ticks INTEGER`);
+        // tx_id correlates a committed trade row with its ledger debit, so the
+        // reconciler can tell "debit landed AND shares committed" (row exists)
+        // from "debit landed, shares did NOT commit" (needs refund).
+        addCol(`ALTER TABLE trades ADD COLUMN tx_id TEXT`);
+        this.db.run(`CREATE INDEX IF NOT EXISTS idx_trades_txid ON trades(tx_id)`);
         this.db.run(`CREATE TABLE IF NOT EXISTS pending_trades (
           tx_id TEXT PRIMARY KEY,
           market_id TEXT NOT NULL,
@@ -227,7 +232,14 @@ class GhostSignalsHub {
 
   startResolverLoop(intervalMs = 10000) {
     if (this._resolverInterval) return;
-    this._resolverInterval = setInterval(() => this._resolveExpiredMarkets().catch(() => {}), intervalMs);
+    // Boot crash-recovery pass for the ledger path (no-op when KAX unarmed).
+    this.reconcile().catch(() => {});
+    let tick = 0;
+    this._resolverInterval = setInterval(() => {
+      this._resolveExpiredMarkets().catch(() => {});
+      // Piggyback the ledger reconcile+audit every ~6th tick (≈60s by default).
+      if (++tick % 6 === 0) this.reconcile().catch(() => {});
+    }, intervalMs);
   }
 
   stopResolverLoop() {
@@ -646,7 +658,7 @@ class GhostSignalsHub {
       //    Under the per-market mutex the CAS should never fail; if it does, the
       //    debit already landed, so flag for refund reconciliation (PR 2c).
       try {
-        await this._commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
+        await this._commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson: JSON.stringify(qAfter), qBeforeJson });
       } catch (e) {
         await this._setPendingState(txId, 'refund');
         throw new Error(`shares commit failed after ledger debit (refund queued, tx ${txId}): ${e.message}`);
@@ -659,7 +671,7 @@ class GhostSignalsHub {
   }
 
   /** The SQLite side of a ledger trade: q-CAS + trade row + position. No capital. */
-  _commitLedgerTradeShares({ market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
+  _commitLedgerTradeShares({ txId, market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, qAfterJson, qBeforeJson }) {
     const self = this;
     return this._serializeTx(async () => {
       await self._run('BEGIN');
@@ -671,8 +683,8 @@ class GhostSignalsHub {
         if (q.changes === 0) throw new Error('market state changed concurrently (q-CAS)');
         await self._run(`UPDATE traders SET trades_total = trades_total + 1, last_active = CURRENT_TIMESTAMP WHERE id = ?`, [trader_id]);
         await self._run(
-          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks],
+          `INSERT INTO trades (market_id, trader_id, outcome_idx, shares, cost, cost_minor, share_ticks, tx_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [market_id, trader_id, outcome, shares, cost, costMinor, shareTicks, txId],
         );
         await self._run(
           `INSERT INTO positions (market_id, trader_id, outcome_idx, shares) VALUES (?, ?, ?, ?)
@@ -771,6 +783,105 @@ class GhostSignalsHub {
         `UPDATE traders SET trades_won = trades_won + ?, reputation = reputation * 0.95 + ? * 0.05, last_active = CURRENT_TIMESTAMP WHERE id = ?`,
         [t.yes > 0 ? 1 : 0, accuracy, trader_id],
       );
+    }
+  }
+
+  // ── Reconciliation & solvency audit (ADR-0041 PR 2c) ────────────────
+  /**
+   * Crash-recovery + pool-solvency audit for the ledger path. Idempotent and
+   * safe to run repeatedly (once at boot + piggybacked on the resolver loop).
+   * A no-op when the KAX surfaces aren't armed, so dev is unaffected. Runs the
+   * three passes in order: escrow (open funded markets), trades (settle/refund
+   * ambiguous debits) THEN the audit (so transient debits are resolved first).
+   */
+  async reconcile() {
+    if (!kax.tradeEnabled() || !kax.readEnabled()) return { skipped: true };
+    if (this._reconciling) return { skipped: 'in-flight' };
+    this._reconciling = true;
+    const report = { escrow: 0, trades: 0, audited: 0, alerts: 0 };
+    try {
+      await this._reconcilePendingEscrow(report);
+      await this._reconcilePendingTrades(report);
+      await this._auditOpenPools(report);
+    } catch (e) {
+      console.error('gshub reconcile error:', e.message);
+    } finally {
+      this._reconciling = false;
+    }
+    return report;
+  }
+
+  /** Open markets whose escrow actually landed; retry (idempotent) the absent ones. */
+  async _reconcilePendingEscrow(report) {
+    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'pending_escrow'`);
+    for (const row of rows) {
+      const g = await kax.getTx(kax.txid.escrow(row.id));
+      if (g.ok && g.result && g.result.found === true) { await this._setMarketState(row.id, 'open'); report.escrow++; continue; }
+      if (g.ok && g.result && g.result.found === false) {
+        // Definitively absent → retry the idempotent escrow.
+        try {
+          const r = await kax.escrow({ marketId: row.id, subsidyMinor: row.subsidy_minor, ref: `market:${row.id}` });
+          if (r.ok) { await this._setMarketState(row.id, 'open'); report.escrow++; }
+          else if (r.definitive) { await this._setMarketState(row.id, 'voided'); }
+        } catch (_) { /* ambiguous send — leave for next cycle */ }
+      }
+      // getTx ambiguous → leave pending for next cycle.
+    }
+  }
+
+  /**
+   * Settle ambiguous / crashed trades using the ledger as the source of truth.
+   * tx_id on the committed trade row lets us distinguish the four cases exactly:
+   *   landed + committed  → mark posted (the state update was what crashed)
+   *   absent + !committed → mark failed  (no money moved)
+   *   landed + !committed → REFUND (reverse the debit via a same-cost 'sell')
+   *   absent + committed  → impossible (we only commit after a 2xx) → alert
+   */
+  async _reconcilePendingTrades(report) {
+    const rows = await this._all(
+      `SELECT tx_id, market_id, trader_id, outcome_idx, cost_minor FROM pending_trades
+        WHERE state IN ('posting', 'reconcile', 'refund')`,
+    );
+    for (const p of rows) {
+      const g = await kax.getTx(p.tx_id);
+      if (!(g.ok && g.result)) continue; // read ambiguous → next cycle
+      const landed = g.result.found === true;
+      const absent = g.result.found === false;
+      const committed = !!(await this._get(`SELECT 1 AS x FROM trades WHERE tx_id = ? LIMIT 1`, [p.tx_id]));
+
+      if (landed && committed) { await this._setPendingState(p.tx_id, 'posted'); report.trades++; continue; }
+      if (absent && !committed) { await this._setPendingState(p.tx_id, 'failed'); report.trades++; continue; }
+      if (landed && !committed) {
+        // Reverse the orphaned debit: a 'sell' of the same cost moves amm→trader.
+        const principal = kax.principalFor(p.trader_id);
+        const r = await kax.trade({ txId: kax.txid.refund(p.tx_id), principal, marketId: p.market_id, amountMinor: p.cost_minor, side: 'sell', ref: `refund:${p.tx_id}` });
+        if (r.ok) { await this._setPendingState(p.tx_id, 'refunded'); report.trades++; }
+        else if (r.definitive) { console.error(`gshub refund rejected ${p.tx_id}: ${r.error}`); }
+        continue;
+      }
+      if (absent && committed) { console.error(`gshub INCONSISTENCY ${p.tx_id}: shares committed but ledger has no debit`); report.alerts++; }
+    }
+  }
+
+  /**
+   * Solvency audit: each open ledger market's pool must hold AT LEAST what its
+   * committed trades funded (subsidy + Σ committed cost_minor). Only UNDER-
+   * funding is dangerous (can't cover payouts); an over-funded pool is a benign
+   * in-flight / pending-refund transient, so we never false-alarm on it. On a
+   * shortfall, halt trading (placeTrade requires state='open') and alert.
+   */
+  async _auditOpenPools(report) {
+    const rows = await this._all(`SELECT id, subsidy_minor FROM markets WHERE ledger_backed = 1 AND state = 'open' AND resolved = 0`);
+    for (const row of rows) {
+      const b = await kax.balance(`amm:${row.id}`);
+      if (!b.ok) continue; // read failed — skip rather than false-alarm
+      report.audited++;
+      const expected = await this._poolValueMinor(row.id, row.subsidy_minor);
+      if (b.balance < expected) {
+        console.error(`gshub POOL AUDIT SHORTFALL ${row.id}: ledger ${b.balance} < committed ${expected} — halting trading`);
+        await this._setMarketState(row.id, 'halted');
+        report.alerts++;
+      }
     }
   }
 

--- a/server/kax-ledger.js
+++ b/server/kax-ledger.js
@@ -1,0 +1,235 @@
+'use strict';
+
+/**
+ * kax-ledger.js — client + economic math for the KAX double-entry credit
+ * ledger (ADR-0041 Phase 2, funded-AMM PR 2).
+ *
+ * Labs-tier GhostSignals markets move REAL conserved credits on the KAX ledger
+ * (Agent-Kax, Postgres) instead of unbacked local SQLite capital. This module
+ * is (a) the integer economic math that keeps the funded AMM provably solvent
+ * and (b) the thin HTTP client that posts server-built transactions to the
+ * typed KAX endpoints (/api/ledger/grant|escrow|trade|payout, GET /tx/:txId).
+ *
+ * INERT UNTIL CONFIGURED. The mint / trade / read surfaces are each "enabled"
+ * only when KAX_LEDGER_BASE and the corresponding token are set, so the hub
+ * behaves EXACTLY as today until Nick arms the env in prod. Nothing here runs
+ * on the non-labs / ambient TTL path — those keep SQLite capital untouched.
+ *
+ * Two adversarial-review blockers live here and are unit-tested without a
+ * network (see test/kax-ledger.test.js):
+ *   #10 rounding in the POOL's favor — costMinor = ceil, payoutMinor = floor —
+ *       so amm = subsidy + Σceil(cost) − Σfloor(payout) ≥ 0; a split-buy can't
+ *       drain the pool via accumulated sub-unit dust.
+ *   #12 ambiguous ≠ failed — only a definitive 4xx means "not posted". A
+ *       timeout / 5xx stays ambiguous (the tx MAY have committed) and the
+ *       caller must reconcile via getTx before telling the trader anything.
+ */
+
+const crypto = require('crypto');
+
+// Integer minor units per credit. 6 dp (like USDC) keeps small LMSR costs from
+// being swamped by the ceil rounding, while staying well inside 2^53 for the
+// float→int multiply: credits stay < ~10^6, so credits*MINOR < ~10^12 << 2^53.
+const MINOR = 1_000_000;
+
+/** Env-derived config, read fresh each call so tests / redeploys pick up changes. */
+function cfg() {
+  return {
+    base: (process.env.KAX_LEDGER_BASE || '').replace(/\/+$/, ''),
+    mintToken: process.env.KAX_LEDGER_MINT_TOKEN || '',
+    tradeToken: process.env.KAX_LEDGER_TRADE_TOKEN || '',
+    readToken: process.env.KAX_SERVICE_TOKEN || process.env.KAX_LEDGER_READ_TOKEN || '',
+    asset: process.env.KAX_LEDGER_ASSET || 'play_credit',
+    timeoutMs: Number(process.env.KAX_LEDGER_TIMEOUT_MS || 8000),
+  };
+}
+
+function tradeEnabled() { const c = cfg(); return !!(c.base && c.tradeToken); }
+function mintEnabled() { const c = cfg(); return !!(c.base && c.mintToken); }
+function readEnabled() { const c = cfg(); return !!(c.base && c.readToken); }
+
+// ── Economic math (pure, exported for tests) ─────────────────────────────
+
+/** ceil(credits · MINOR) as a decimal integer STRING of minor units. */
+function toMinorCeil(credits) {
+  if (!Number.isFinite(credits) || credits < 0) throw new Error('credits must be a finite number >= 0');
+  return String(Math.ceil(credits * MINOR));
+}
+
+/** floor(credits · MINOR) as a decimal integer STRING of minor units. */
+function toMinorFloor(credits) {
+  if (!Number.isFinite(credits) || credits < 0) throw new Error('credits must be a finite number >= 0');
+  return String(Math.floor(credits * MINOR));
+}
+
+/**
+ * The LMSR worst-case subsidy the pool must be funded with before it opens:
+ * ceil(b · ln(n) · MINOR). This is the maximum the market maker can lose across
+ * all outcomes, so escrowing it guarantees every payout is backed.
+ */
+function subsidyMinor(b, n) {
+  if (!(b > 0) || !Number.isInteger(n) || n < 2) throw new Error('b>0 and integer n>=2 required');
+  return toMinorCeil(b * Math.log(n));
+}
+
+/**
+ * A trade's cost rounded UP into minor units (charge the trader the ceil), and
+ * a rejection of dust trades that round to 0 — a free share is a mint. Returns a
+ * decimal integer string; throws on cost that rounds to <= 0.
+ */
+function tradeCostMinor(costCredits) {
+  if (!Number.isFinite(costCredits)) throw new Error('cost must be finite');
+  const m = Math.ceil(costCredits * MINOR);
+  if (!(m > 0)) throw new Error('trade cost rounds to <= 0 minor units (dust)');
+  return String(m);
+}
+
+/** A winning position's payout rounded DOWN into minor units (floor toward the pool). */
+function payoutMinor(shares) {
+  return toMinorFloor(shares);
+}
+
+// ── Deterministic transaction ids (idempotency keys) ─────────────────────
+// Same logical event → same txId → the KAX idempotency registry applies it at
+// most once, so a retry after an ambiguous outcome is always safe.
+const txid = {
+  escrow: (m) => `escrow:${m}`,
+  resolve: (m) => `resolve:${m}`,
+  voidMarket: (m) => `void:${m}`,
+  grantRegister: (p) => `grant:register:${p}`,
+  trade: (uuid) => `trade:${uuid}`,
+  refund: (orig) => `refund:${orig}`,
+  sweep: (m) => `sweep:${m}`,
+};
+
+/** A fresh trade uuid to persist in the pending_trades journal BEFORE posting. */
+function newTradeUuid() { return crypto.randomUUID(); }
+
+// Ledger principal grammar mirror (KAX PRINCIPAL_RE). A labs trader_id is the
+// KAX token subject (e.g. "kax:agent:<bot>"); the ledger account is
+// `trader:<principal>`. Reject anything that wouldn't validate server-side so we
+// fail locally with a clear error instead of a 400.
+const PRINCIPAL_RE = /^[a-z0-9][a-z0-9:_.-]{2,127}$/i;
+function principalFor(traderId) {
+  if (typeof traderId !== 'string' || !PRINCIPAL_RE.test(traderId)) {
+    throw new Error(`trader_id "${traderId}" is not a valid ledger principal`);
+  }
+  return traderId;
+}
+
+// ── HTTP core ────────────────────────────────────────────────────────────
+
+/**
+ * POST/GET JSON with a bounded timeout and the review's ambiguity contract:
+ *   { ok:true,  definitive:true,  status, result }   — committed (2xx)
+ *   { ok:false, definitive:true,  status, error }    — NOT posted (4xx: bad
+ *       request / auth / 409 conflict / 429 cap); retrying the same body won't help
+ *   { ok:false, definitive:false, status, error }    — AMBIGUOUS (5xx / timeout /
+ *       network): the tx MAY have committed — reconcile via getTx, do not assume
+ */
+async function httpJson(method, pathname, token, body) {
+  if (typeof fetch !== 'function') {
+    return { ok: false, definitive: false, status: 0, error: 'global fetch unavailable (need Node >= 18)' };
+  }
+  const c = cfg();
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), c.timeoutMs);
+  try {
+    const res = await fetch(c.base + pathname, {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: ctrl.signal,
+    });
+    let json = null;
+    try { json = await res.json(); } catch (_) { json = null; }
+    if (res.ok) return { ok: true, definitive: true, status: res.status, result: json };
+    if (res.status >= 400 && res.status < 500) {
+      return { ok: false, definitive: true, status: res.status, error: (json && json.error) || `http ${res.status}` };
+    }
+    return { ok: false, definitive: false, status: res.status, error: (json && json.error) || `http ${res.status}` };
+  } catch (err) {
+    // AbortError (timeout) and network failures are ambiguous, never "not posted".
+    return { ok: false, definitive: false, status: 0, error: (err && err.message) || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Typed transaction methods ────────────────────────────────────────────
+
+/** Fund a market's AMM pool with its LMSR subsidy (house → amm). Mint surface. */
+async function escrow({ marketId, subsidyMinor: sub, ref }) {
+  if (!mintEnabled()) throw new Error('kax mint surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/escrow', c.mintToken, {
+    txId: txid.escrow(marketId), marketId, amount: String(sub), asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Grant play credits to a trader (house → trader). Mint surface. Idempotent on txId. */
+async function grant({ principal, amountMinor, txId: id, ref }) {
+  if (!mintEnabled()) throw new Error('kax mint surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/grant', c.mintToken, {
+    txId: id || txid.grantRegister(principal), principal, amount: String(amountMinor), asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Move a trade's cost between a trader and a pool (buy: trader→amm; sell: amm→trader). Trade surface. */
+async function trade({ txId: id, principal, marketId, amountMinor, side, ref }) {
+  if (!tradeEnabled()) throw new Error('kax trade surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/trade', c.tradeToken, {
+    txId: id, principal, marketId, amount: String(amountMinor), side: side === 'sell' ? 'sell' : 'buy', asset: c.asset, ref: ref || null,
+  });
+}
+
+/** Pay all winners out of a pool + sweep residual to house, in ONE balanced tx. Trade surface. */
+async function payout({ marketId, winners, residualMinor, ref }) {
+  if (!tradeEnabled()) throw new Error('kax trade surface not configured');
+  const c = cfg();
+  return httpJson('POST', '/api/ledger/payout', c.tradeToken, {
+    txId: txid.resolve(marketId),
+    marketId,
+    winners: (winners || []).map((w) => ({ principal: w.principal, amount: String(w.amountMinor) })),
+    residual: String(residualMinor || '0'),
+    asset: c.asset,
+    ref: ref || null,
+  });
+}
+
+/** Look up a committed tx by id for reconciliation of an ambiguous outcome. Read surface. */
+async function getTx(txId) {
+  if (!readEnabled()) throw new Error('kax read surface not configured');
+  const c = cfg();
+  return httpJson('GET', `/api/ledger/tx/${encodeURIComponent(txId)}`, c.readToken, null);
+}
+
+module.exports = {
+  MINOR,
+  cfg,
+  tradeEnabled,
+  mintEnabled,
+  readEnabled,
+  // math
+  toMinorCeil,
+  toMinorFloor,
+  subsidyMinor,
+  tradeCostMinor,
+  payoutMinor,
+  // ids
+  txid,
+  newTradeUuid,
+  principalFor,
+  // http
+  httpJson,
+  escrow,
+  grant,
+  trade,
+  payout,
+  getTx,
+};

--- a/server/kax-ledger.js
+++ b/server/kax-ledger.js
@@ -209,6 +209,22 @@ async function getTx(txId) {
   return httpJson('GET', `/api/ledger/tx/${encodeURIComponent(txId)}`, c.readToken, null);
 }
 
+/**
+ * Derived balance (minor units) of an account for the audit — the pool-solvency
+ * check compares balance(amm:<m>) against subsidy + Σ cost_minor. Read surface.
+ * On a 2xx returns { ok:true, balance: bigint }; otherwise passes the httpJson
+ * result through (definitive/ambiguous) so a failed read never reads as zero.
+ */
+async function balance(account, asset) {
+  if (!readEnabled()) throw new Error('kax read surface not configured');
+  const c = cfg();
+  const r = await httpJson('GET', `/api/ledger/balance?account=${encodeURIComponent(account)}&asset=${encodeURIComponent(asset || c.asset)}`, c.readToken, null);
+  if (r.ok && r.result && typeof r.result.balance === 'string') {
+    return { ok: true, definitive: true, status: r.status, balance: BigInt(r.result.balance) };
+  }
+  return r;
+}
+
 module.exports = {
   MINOR,
   cfg,
@@ -232,4 +248,5 @@ module.exports = {
   trade,
   payout,
   getTx,
+  balance,
 };

--- a/test/kax-ledger-reconcile.test.js
+++ b/test/kax-ledger-reconcile.test.js
@@ -14,6 +14,9 @@ process.env.KAX_LEDGER_BASE = 'http://kax.test';
 process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
 process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
 process.env.KAX_SERVICE_TOKEN = 'read-tok';
+// No grace window in the test so a just-journaled orphan is reconciled at once
+// (in prod the grace period protects live in-flight trades from false refunds).
+process.env.KAX_RECONCILE_GRACE_MS = '0';
 
 const { GhostSignalsHub } = require('../server/ghostsignals-hub');
 const kax = require('../server/kax-ledger');
@@ -62,6 +65,8 @@ function makeFakeLedger() {
     }
     // POST writes
     const body = JSON.parse(opts.body);
+    // Optional gate: block a trade POST mid-flight (to test the reconcile race).
+    if (u.pathname === '/api/ledger/trade' && led.tradeGate) await led.tradeGate;
     let postings = null;
     if (u.pathname === '/api/ledger/escrow') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
     else if (u.pathname === '/api/ledger/grant') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
@@ -69,6 +74,11 @@ function makeFakeLedger() {
       postings = body.side === 'sell'
         ? [{ account: `amm:${body.marketId}`, amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }]
         : [{ account: `trader:${body.principal}`, amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    } else if (u.pathname === '/api/ledger/payout') {
+      const total = (body.winners || []).reduce((a, w) => a + S(w.amount), 0n) + S(body.residual || '0');
+      postings = [{ account: `amm:${body.marketId}`, amount: -total }];
+      for (const w of (body.winners || [])) postings.push({ account: `trader:${w.principal}`, amount: S(w.amount) });
+      if (S(body.residual || '0') > 0n) postings.push({ account: 'house', amount: S(body.residual) });
     }
     try {
       const r = apply(body.txId, postings);
@@ -135,6 +145,42 @@ async function run() {
   // A halted market rejects new trades.
   await assert.rejects(() => hub.placeTrade({ market_id: stuckId, trader_id: alice, outcome: 0, shares: 1 }), /not open/);
   console.log('ok  pool audit shortfall → halted + trading blocked');
+
+  // ── E) BLOCKER-1 regression: reconcile must NOT refund a LIVE in-flight trade.
+  //       Hold a trade's ledger POST open, fire reconcile() concurrently, then
+  //       release — the trade must complete and never be refunded. ────────────
+  const led2 = makeFakeLedger();
+  const hub2 = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub2.init();
+  const carol = 'kax:agent:carol';
+  await hub2.registerTrader({ id: carol, display_name: 'Carol', kind: 'ai' });
+  await kax.grant({ principal: carol, amountMinor: '100000000', txId: 'grant:register:' + carol });
+  const mk = await hub2.createMarket({ question: 'race', outcomes: ['Y', 'N'], tag: 'labs', source: 'kannaka-labs' });
+  let releaseGate;
+  led2.tradeGate = new Promise((res) => { releaseGate = res; });
+  const tradeP = hub2.placeTrade({ market_id: mk.id, trader_id: carol, outcome: 0, shares: 3 }); // holds mutex on the gated POST
+  await new Promise((r) => setTimeout(r, 20)); // let it reach the gated POST
+  const reconcileP = hub2.reconcile();          // queues behind the market mutex
+  await new Promise((r) => setTimeout(r, 20));
+  releaseGate();                                // let the trade finish
+  await Promise.all([tradeP, reconcileP]);
+  const pk = await hub2._get(`SELECT state FROM pending_trades WHERE market_id = ?`, [mk.id]);
+  assert.strictEqual(pk.state, 'posted', 'in-flight trade committed, not refunded');
+  const refundLanded = (await kax.getTx(kax.txid.refund((await hub2._get(`SELECT tx_id FROM pending_trades WHERE market_id = ?`, [mk.id])).tx_id)));
+  assert.ok(refundLanded.ok && refundLanded.result.found === false, 'no refund was posted for the live trade');
+  console.log('ok  reconcile does NOT refund a live in-flight trade (blocker-1)');
+
+  // ── F) BLOCKER-2 regression: a payout that the client saw fail is re-driven
+  //       by reconcile until settled (funds not stranded). ─────────────────────
+  await hub2.placeTrade({ market_id: mk.id, trader_id: carol, outcome: 1, shares: 2 });
+  led2.mode = 'applyThenFail'; // payout lands on the ledger but client sees 5xx
+  await hub2.resolveMarket({ market_id: mk.id, winning_outcome: 0, method: 'manual' });
+  assert.strictEqual((await hub2.getMarket(mk.id)).state, 'resolving', 'failed payout leaves market resolving');
+  led2.mode = 'normal';
+  const repF = await hub2.reconcile();
+  assert.strictEqual((await hub2.getMarket(mk.id)).state, 'settled', 'reconcile settled the resolving market');
+  assert.ok(repF.resolves >= 1, 'payout reconcile pass acted');
+  console.log('ok  failed payout re-driven to settled (blocker-2)');
 
   console.log('\nPASSED kax-ledger-reconcile.test.js');
 }

--- a/test/kax-ledger-reconcile.test.js
+++ b/test/kax-ledger-reconcile.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+// Crash-recovery + audit tests for the ledger path (ADR-0041 Phase 2, PR 2c).
+// Drives hub.reconcile() through its four exact cases against an in-memory fake
+// KAX ledger that supports getTx + balance and can simulate an
+// "applied-but-client-saw-5xx" ambiguous outcome.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+process.env.KAX_LEDGER_BASE = 'http://kax.test';
+process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
+process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
+process.env.KAX_SERVICE_TOKEN = 'read-tok';
+
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+const kax = require('../server/kax-ledger');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-recon-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+function makeFakeLedger() {
+  const balances = new Map();
+  const txs = new Map();
+  const led = { mode: 'normal', balances, txs };
+  const bal = (a) => balances.get(a) || 0n;
+  led.bal = bal;
+  led.drain = (a, amt) => balances.set(a, bal(a) - BigInt(amt));
+
+  function apply(txId, postings) {
+    if (txs.has(txId)) return { replay: true, ...txs.get(txId) };
+    for (const p of postings) {
+      if (p.amount < 0n && p.account !== 'house' && bal(p.account) + p.amount < 0n) { const e = new Error('insufficient'); e.status = 409; throw e; }
+    }
+    if (postings.reduce((a, p) => a + p.amount, 0n) !== 0n) { const e = new Error('unbalanced'); e.status = 400; throw e; }
+    for (const p of postings) balances.set(p.account, bal(p.account) + p.amount);
+    const rec = { head: 'h' + txs.size, count: postings.length };
+    txs.set(txId, rec);
+    return { replay: false, ...rec };
+  }
+
+  global.fetch = async (url, opts = {}) => {
+    const u = new URL(url);
+    const S = (v) => BigInt(v);
+    // GET reads
+    if ((opts.method || 'GET') === 'GET') {
+      if (u.pathname.startsWith('/api/ledger/tx/')) {
+        const txId = decodeURIComponent(u.pathname.slice('/api/ledger/tx/'.length));
+        const rec = txs.get(txId);
+        return { ok: true, status: 200, json: async () => (rec ? { found: true, txId, ...rec } : { found: false, txId }) };
+      }
+      if (u.pathname === '/api/ledger/balance') {
+        const acct = u.searchParams.get('account');
+        return { ok: true, status: 200, json: async () => ({ account: acct, asset: 'play_credit', balance: bal(acct).toString() }) };
+      }
+      return { ok: false, status: 404, json: async () => ({ error: 'no route' }) };
+    }
+    // POST writes
+    const body = JSON.parse(opts.body);
+    let postings = null;
+    if (u.pathname === '/api/ledger/escrow') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    else if (u.pathname === '/api/ledger/grant') postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
+    else if (u.pathname === '/api/ledger/trade') {
+      postings = body.side === 'sell'
+        ? [{ account: `amm:${body.marketId}`, amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }]
+        : [{ account: `trader:${body.principal}`, amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+    }
+    try {
+      const r = apply(body.txId, postings);
+      if (led.mode === 'applyThenFail') return { ok: false, status: 500, json: async () => ({ ok: false, error: 'simulated 5xx after apply' }) };
+      return { ok: true, status: r.replay ? 200 : 201, json: async () => ({ ok: true, ...r, idempotentReplay: r.replay }) };
+    } catch (e) {
+      return { ok: false, status: e.status || 500, json: async () => ({ ok: false, error: e.message }) };
+    }
+  };
+  return led;
+}
+
+async function run() {
+  const led = makeFakeLedger();
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+  const alice = 'kax:agent:alice';
+  await hub.registerTrader({ id: alice, display_name: 'Alice', kind: 'ai' });
+  await kax.grant({ principal: alice, amountMinor: '100000000', txId: 'grant:register:' + alice });
+
+  // ── A) Escrow reconcile: escrow lands but client sees 5xx → market stuck
+  //       pending_escrow → reconcile() finds the debit and opens it. ──────────
+  led.mode = 'applyThenFail';
+  let stuckId;
+  try {
+    await hub.createMarket({ question: 'stuck escrow', outcomes: ['Y', 'N'], tag: 'labs', source: 'kannaka-labs' });
+    assert.fail('createMarket should throw on ambiguous escrow');
+  } catch (e) { assert.ok(/ambiguous/.test(e.message), 'ambiguous escrow surfaced'); }
+  stuckId = (await hub._all(`SELECT id FROM markets WHERE state = 'pending_escrow'`))[0].id;
+  assert.ok(led.bal(`amm:${stuckId}`) > 0n, 'escrow actually landed on the ledger');
+  led.mode = 'normal';
+  const repA = await hub.reconcile();
+  assert.strictEqual((await hub.getMarket(stuckId)).state, 'open', 'reconcile opened the funded market');
+  assert.ok(repA.escrow >= 1, 'escrow pass acted');
+  console.log('ok  escrow reconcile (ambiguous→landed→opened)');
+
+  // ── B) Orphaned-debit refund: a debit landed but shares never committed →
+  //       reconcile() refunds it (amm→trader) and marks 'refunded'. ──────────
+  const orphanTx = kax.txid.trade('orphan-uuid');
+  const traderBalBefore = led.bal(`trader:${alice}`);
+  await kax.trade({ txId: orphanTx, principal: alice, marketId: stuckId, amountMinor: '250000', side: 'buy' }); // debit lands
+  await hub._journalPending({ txId: orphanTx, market_id: stuckId, trader_id: alice, outcome: 0, shares: 1, costMinor: '250000', shareTicks: 1000000, qBeforeJson: '[0,0]', state: 'posting' });
+  // no trades row committed for orphanTx → landed && !committed
+  const repB = await hub.reconcile();
+  const pend = await hub._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [orphanTx]);
+  assert.strictEqual(pend.state, 'refunded', 'orphaned debit was refunded');
+  assert.strictEqual(led.bal(`trader:${alice}`), traderBalBefore, 'trader made whole by the refund');
+  console.log('ok  orphaned-debit refund (landed & !committed → reversed)');
+
+  // ── C) Never-posted trade: pending row whose debit is absent → 'failed'. ──
+  const ghostTx = kax.txid.trade('ghost-uuid');
+  await hub._journalPending({ txId: ghostTx, market_id: stuckId, trader_id: alice, outcome: 0, shares: 1, costMinor: '250000', shareTicks: 1000000, qBeforeJson: '[0,0]', state: 'reconcile' });
+  await hub.reconcile();
+  const ghost = await hub._get(`SELECT state FROM pending_trades WHERE tx_id = ?`, [ghostTx]);
+  assert.strictEqual(ghost.state, 'failed', 'never-posted trade marked failed (no money moved)');
+  console.log('ok  never-posted trade → failed');
+
+  // ── D) Pool audit shortfall: drain the pool below its committed backing →
+  //       audit halts trading on that market. ────────────────────────────────
+  led.drain(`amm:${stuckId}`, '999999999'); // force ledger balance < expected
+  const repD = await hub.reconcile();
+  assert.strictEqual((await hub.getMarket(stuckId)).state, 'halted', 'shortfall halted the market');
+  assert.ok(repD.alerts >= 1, 'audit raised an alert');
+  // A halted market rejects new trades.
+  await assert.rejects(() => hub.placeTrade({ market_id: stuckId, trader_id: alice, outcome: 0, shares: 1 }), /not open/);
+  console.log('ok  pool audit shortfall → halted + trading blocked');
+
+  console.log('\nPASSED kax-ledger-reconcile.test.js');
+}
+
+run().catch((e) => { console.error('\nFAILED kax-ledger-reconcile.test.js:', e.stack || e.message); process.exitCode = 1; });

--- a/test/kax-ledger-wiring.test.js
+++ b/test/kax-ledger-wiring.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+// Integration test for the labs-tier LEDGER PATH in the GhostSignals hub
+// (ADR-0041 Phase 2, funded-AMM PR 2b). Arms the KAX surfaces via env and
+// stubs global.fetch with an in-memory fake ledger, then drives a full market
+// lifecycle and asserts the money-flow invariants:
+//   - escrow-before-open (pool funded, market state → 'open')
+//   - trades post ceil-rounded cost to /ledger/trade and DON'T touch SQLite capital
+//   - resolve pays winners in ONE batched /ledger/payout
+//   - the fake ledger stays conserved (Σ postings == 0) and no account goes negative
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+// Arm the KAX surfaces BEFORE requiring the hub (cfg() reads env fresh anyway).
+process.env.KAX_LEDGER_BASE = 'http://kax.test';
+process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
+process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
+process.env.KAX_SERVICE_TOKEN = 'read-tok';
+
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-wiring-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+// ── In-memory fake KAX ledger (double-entry, conserved, overdraft-guarded) ──
+function makeFakeLedger() {
+  const balances = new Map(); // account -> bigint
+  const txs = new Map();      // txId -> { head, count }
+  const calls = [];           // {path, body}
+  const bal = (a) => balances.get(a) || 0n;
+
+  function apply(txId, postings) {
+    if (txs.has(txId)) return { replay: true, ...txs.get(txId) }; // idempotent
+    // overdraft guard: non-house debits can't go negative
+    for (const p of postings) {
+      if (p.amount < 0n && p.account !== 'house' && bal(p.account) + p.amount < 0n) {
+        const e = new Error('insufficient funds'); e.status = 409; throw e;
+      }
+    }
+    const sum = postings.reduce((a, p) => a + p.amount, 0n);
+    if (sum !== 0n) { const e = new Error('not balanced'); e.status = 400; throw e; }
+    for (const p of postings) balances.set(p.account, bal(p.account) + p.amount);
+    const rec = { head: 'h' + txs.size, count: postings.length };
+    txs.set(txId, rec);
+    return { replay: false, ...rec };
+  }
+
+  global.fetch = async (url, opts = {}) => {
+    const u = new URL(url);
+    const body = opts.body ? JSON.parse(opts.body) : {};
+    calls.push({ path: u.pathname, body });
+    const S = (v) => BigInt(v);
+    try {
+      let postings = null;
+      if (u.pathname === '/api/ledger/escrow') {
+        postings = [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }];
+      } else if (u.pathname === '/api/ledger/grant') {
+        postings = [{ account: 'house', amount: -S(body.amount) }, { account: `trader:${body.principal}`, amount: S(body.amount) }];
+      } else if (u.pathname === '/api/ledger/trade') {
+        const amm = { account: `amm:${body.marketId}`, amount: S(body.amount) };
+        const trader = { account: `trader:${body.principal}`, amount: -S(body.amount) };
+        postings = body.side === 'sell' ? [{ ...amm, amount: -S(body.amount) }, { ...trader, amount: S(body.amount) }] : [trader, amm];
+      } else if (u.pathname === '/api/ledger/payout') {
+        const total = (body.winners || []).reduce((a, w) => a + S(w.amount), 0n) + S(body.residual || '0');
+        postings = [{ account: `amm:${body.marketId}`, amount: -total }];
+        for (const w of body.winners) postings.push({ account: `trader:${w.principal}`, amount: S(w.amount) });
+        if (S(body.residual || '0') > 0n) postings.push({ account: 'house', amount: S(body.residual) });
+      }
+      if (postings) {
+        const r = apply(body.txId, postings);
+        return { ok: true, status: r.replay ? 200 : 201, json: async () => ({ ok: true, ...r, idempotentReplay: r.replay }) };
+      }
+      return { ok: false, status: 404, json: async () => ({ ok: false, error: 'no route' }) };
+    } catch (e) {
+      const status = e.status || 500;
+      return { ok: status >= 200 && status < 300, status, json: async () => ({ ok: false, error: e.message }) };
+    }
+  };
+
+  return { balances, txs, calls, bal };
+}
+
+async function run() {
+  const led = makeFakeLedger();
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+
+  // Seed the two labs traders with ledger credits (grant) so they can trade.
+  const alice = 'kax:agent:alice';
+  const bob = 'kax:agent:bob';
+  await hub.registerTrader({ id: alice, display_name: 'Alice', kind: 'ai' });
+  await hub.registerTrader({ id: bob, display_name: 'Bob', kind: 'ai' });
+  await require('../server/kax-ledger').grant({ principal: alice, amountMinor: '100000000', txId: 'grant:register:' + alice });
+  await require('../server/kax-ledger').grant({ principal: bob, amountMinor: '100000000', txId: 'grant:register:' + bob });
+
+  // 1) Create a labs market → escrow-before-open.
+  const m = await hub.createMarket({ question: 'ledger path?', outcomes: ['Yes', 'No'], ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs' });
+  assert.strictEqual(m.state, 'open', 'market should be open after successful escrow');
+  assert.strictEqual(m.ledger_backed, true, 'market should be ledger-backed');
+  const escrowCall = led.calls.find((c) => c.path === '/api/ledger/escrow');
+  assert.ok(escrowCall, 'escrow POST must have happened');
+  assert.strictEqual(escrowCall.body.marketId, m.id, 'escrow funds THIS market');
+  assert.ok(led.bal(`amm:${m.id}`) > 0n, 'pool funded with subsidy');
+  console.log(`ok  escrow-before-open (pool = ${led.bal(`amm:${m.id}`)} minor units, market open)`);
+
+  // 2) Trades post to the ledger, ceil-rounded, and DON'T touch SQLite capital.
+  const capBefore = (await hub.getTrader(alice)).capital;
+  const t = await hub.placeTrade({ market_id: m.id, trader_id: alice, outcome: 0, shares: 5 });
+  const tradeCall = led.calls.find((c) => c.path === '/api/ledger/trade');
+  assert.ok(tradeCall, 'trade POST must have happened');
+  assert.strictEqual(tradeCall.body.principal, alice);
+  assert.strictEqual(typeof tradeCall.body.amount, 'string', 'amount is a decimal string');
+  assert.strictEqual(tradeCall.body.amount, String(Math.ceil(t.cost * 1e6)), 'cost charged is ceil(cost·MINOR)');
+  const capAfter = (await hub.getTrader(alice)).capital;
+  assert.strictEqual(capAfter, capBefore, 'SQLite capital untouched on the ledger path');
+  assert.ok(led.bal(`trader:${alice}`) < 100000000n, 'ledger debited the trader');
+  console.log(`ok  ledger trade (charged ${tradeCall.body.amount} minor, SQLite capital untouched)`);
+
+  // A second trader takes the other side.
+  await hub.placeTrade({ market_id: m.id, trader_id: bob, outcome: 1, shares: 3 });
+
+  // 3) Resolve → ONE batched payout.
+  const poolBefore = led.bal(`amm:${m.id}`);
+  await hub.resolveMarket({ market_id: m.id, winning_outcome: 0, method: 'manual' });
+  const payoutCalls = led.calls.filter((c) => c.path === '/api/ledger/payout');
+  assert.strictEqual(payoutCalls.length, 1, 'exactly ONE batched payout');
+  const p = payoutCalls[0];
+  assert.ok(Array.isArray(p.body.winners) && p.body.winners.length >= 1, 'winners present');
+  assert.ok(p.body.winners.some((w) => w.principal === alice), 'Alice (outcome 0) is a winner');
+  assert.ok(!p.body.winners.some((w) => w.principal === bob), 'Bob (outcome 1) is not paid');
+  console.log(`ok  batched payout (1 tx, ${p.body.winners.length} winner(s), residual ${p.body.residual})`);
+
+  // 4) Conservation: every posting summed to zero, so Σ all balances == 0, and
+  //    the pool never went negative.
+  let total = 0n;
+  for (const v of led.balances.values()) total += v;
+  assert.strictEqual(total, 0n, 'ledger conserved (Σ balances == 0)');
+  assert.ok(led.bal(`amm:${m.id}`) >= 0n, `pool solvent (${led.bal(`amm:${m.id}`)} >= 0)`);
+  assert.ok(poolBefore >= 0n);
+  console.log('ok  conservation (Σ balances == 0, pool never negative)');
+
+  console.log('\nPASSED kax-ledger-wiring.test.js');
+}
+
+run().catch((e) => {
+  console.error('\nFAILED kax-ledger-wiring.test.js:', e.stack || e.message);
+  process.exitCode = 1;
+});

--- a/test/kax-ledger-wiring.test.js
+++ b/test/kax-ledger-wiring.test.js
@@ -136,6 +136,19 @@ async function run() {
   assert.ok(!p.body.winners.some((w) => w.principal === bob), 'Bob (outcome 1) is not paid');
   console.log(`ok  batched payout (1 tx, ${p.body.winners.length} winner(s), residual ${p.body.residual})`);
 
+  // 3b) Upset market: resolve to a side NOBODY bought → no winners, but the full
+  //     pool (subsidy + losers' stakes) must be swept to house, not stranded.
+  const m2 = await hub.createMarket({ question: 'upset', outcomes: ['Yes', 'No'], ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs' });
+  await hub.placeTrade({ market_id: m2.id, trader_id: alice, outcome: 0, shares: 4 }); // all on outcome 0
+  const pool2 = led.bal(`amm:${m2.id}`);
+  assert.ok(pool2 > 0n, 'upset pool funded');
+  const houseBefore = led.bal('house');
+  await hub.resolveMarket({ market_id: m2.id, winning_outcome: 1, method: 'manual' }); // outcome 1 wins — nobody holds it
+  assert.strictEqual(led.bal(`amm:${m2.id}`), 0n, 'upset pool fully swept (not stranded)');
+  assert.strictEqual(led.bal('house') - houseBefore, pool2, 'full pool returned to house');
+  assert.strictEqual((await hub.getMarket(m2.id)).state, 'settled', 'upset market settled');
+  console.log(`ok  upset market swept to house (${pool2} minor, no winners)`);
+
   // 4) Conservation: every posting summed to zero, so Σ all balances == 0, and
   //    the pool never went negative.
   let total = 0n;

--- a/test/kax-ledger.test.js
+++ b/test/kax-ledger.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+// Unit tests for the KAX ledger client + economic math (ADR-0041 Phase 2,
+// funded-AMM PR 2a). No network, no DB — exercises the two review blockers that
+// live in this module:
+//   #10 rounding in the pool's favor (solvency), and
+//   #12 ambiguous ≠ failed (the httpJson classification contract).
+
+const assert = require('assert');
+const kax = require('../server/kax-ledger');
+
+function testRoundingDirection() {
+  // ceil charges the trader up; floor pays the winner down. Same fractional
+  // input must round in OPPOSITE directions (the pool keeps the sub-unit).
+  assert.strictEqual(kax.toMinorCeil(1.0000004), '1000001', 'ceil rounds up');
+  assert.strictEqual(kax.toMinorFloor(1.0000004), '1000000', 'floor rounds down');
+  assert.strictEqual(kax.toMinorCeil(2), '2000000', 'integer credits exact (ceil)');
+  assert.strictEqual(kax.toMinorFloor(2), '2000000', 'integer credits exact (floor)');
+  console.log('ok  rounding direction (ceil up / floor down)');
+}
+
+function testDustRejected() {
+  // A trade whose cost rounds to <= 0 minor units would be a free share. Because
+  // we ceil, any strictly-positive cost charges at least 1 minor unit (in the
+  // pool's favor), so only cost <= 0 is dust.
+  assert.throws(() => kax.tradeCostMinor(0), /dust/, 'zero cost rejected');
+  assert.throws(() => kax.tradeCostMinor(-0.5), /dust/, 'negative cost rejected');
+  assert.strictEqual(kax.tradeCostMinor(1e-9), '1', 'tiny positive cost still charges 1 minor unit');
+  assert.strictEqual(kax.tradeCostMinor(1e-6), '1', 'exactly one minor unit');
+  assert.strictEqual(kax.tradeCostMinor(0.5), '500000', 'half credit');
+  console.log('ok  dust trades rejected (no free shares); tiny costs charge >= 1');
+}
+
+function testSubsidyFormula() {
+  // subsidy = ceil(b·ln(n)·MINOR). b=10, n=2 → 10·0.6931… = 6.931… credits.
+  const s = kax.subsidyMinor(10, 2);
+  assert.strictEqual(s, String(Math.ceil(10 * Math.log(2) * kax.MINOR)), 'subsidy = ceil(b·ln n·MINOR)');
+  assert.ok(BigInt(s) > 6_931_000n && BigInt(s) < 6_932_000n, `subsidy ~6.931 credits, got ${s}`);
+  assert.throws(() => kax.subsidyMinor(10, 1), /n>=2/, 'n<2 rejected');
+  assert.throws(() => kax.subsidyMinor(0, 2), /b>0/, 'b<=0 rejected');
+  console.log('ok  subsidy formula');
+}
+
+function testSolvencyInvariant() {
+  // The core conservation claim: for ANY sequence of trades then payouts, with
+  // ceil charging and floor paying, the pool never goes negative. Construct the
+  // worst case: costs and payouts that (unrounded) would net the pool to exactly
+  // 0, then show integer rounding leaves it >= 0.
+  const b = 10, n = 2;
+  const subsidy = BigInt(kax.subsidyMinor(b, n));
+  // 200 trades with fractional per-unit costs.
+  let charged = 0n;
+  const trueCosts = [];
+  for (let i = 0; i < 200; i++) {
+    const c = 0.0000005 + (i % 7) * 0.13; // fractional credits
+    trueCosts.push(c);
+    charged += BigInt(kax.tradeCostMinor(c));
+  }
+  // Winners are paid the floor of some share amounts whose TRUE total value
+  // equals subsidy(true) + Σ trueCosts — i.e. the market maker's break-even.
+  const trueInflow = trueCosts.reduce((a, c) => a + c, 0) + b * Math.log(n);
+  // Split the break-even inflow across 50 winners as share payouts.
+  let paid = 0n;
+  const per = trueInflow / 50;
+  for (let i = 0; i < 50; i++) paid += BigInt(kax.payoutMinor(per));
+  const poolAfter = subsidy + charged - paid;
+  assert.ok(poolAfter >= 0n, `pool must stay solvent; got ${poolAfter}`);
+  console.log(`ok  solvency invariant (pool residual ${poolAfter} minor units >= 0)`);
+}
+
+function testTxidDeterminism() {
+  assert.strictEqual(kax.txid.escrow('m_abc'), 'escrow:m_abc');
+  assert.strictEqual(kax.txid.resolve('m_abc'), 'resolve:m_abc');
+  assert.strictEqual(kax.txid.grantRegister('kax:agent:alias'), 'grant:register:kax:agent:alias');
+  // Same logical event → identical id (idempotency key stability).
+  assert.strictEqual(kax.txid.resolve('m_abc'), kax.txid.resolve('m_abc'));
+  console.log('ok  deterministic txids');
+}
+
+function testPrincipalValidation() {
+  assert.strictEqual(kax.principalFor('kax:agent:alias'), 'kax:agent:alias');
+  assert.throws(() => kax.principalFor(''), /valid ledger principal/);
+  assert.throws(() => kax.principalFor('has space'), /valid ledger principal/);
+  assert.throws(() => kax.principalFor('a'), /valid ledger principal/, 'too short');
+  console.log('ok  principal validation mirrors server grammar');
+}
+
+// #12: the ambiguity contract. Stub global.fetch to drive each branch.
+async function testAmbiguityContract() {
+  const origFetch = global.fetch;
+  const stub = (status, jsonBody, opts = {}) => {
+    global.fetch = async () => {
+      if (opts.throwErr) throw new Error('network down');
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => jsonBody,
+      };
+    };
+  };
+  try {
+    // 2xx → committed, definitive.
+    stub(201, { ok: true, head: 'h', count: 2 });
+    let r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [true, true], '2xx committed+definitive');
+
+    // 409 (conflict / insufficient) → NOT posted, definitive.
+    stub(409, { ok: false, error: 'insufficient funds' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [false, true], '409 not-posted+definitive');
+
+    // 400 → definitive.
+    stub(400, { ok: false, error: 'bad request' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.strictEqual(r.definitive, true, '400 definitive');
+
+    // 429 (grant cap) → definitive.
+    stub(429, { ok: false, error: 'daily grant cap exceeded' });
+    r = await kax.httpJson('POST', '/api/ledger/grant', 't', { a: 1 });
+    assert.strictEqual(r.definitive, true, '429 definitive');
+
+    // 500 → AMBIGUOUS (may have committed) — must NOT be treated as failed.
+    stub(500, { ok: false, error: 'boom' });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive], [false, false], '5xx ambiguous');
+
+    // network error / timeout → AMBIGUOUS.
+    stub(0, null, { throwErr: true });
+    r = await kax.httpJson('POST', '/api/ledger/trade', 't', { a: 1 });
+    assert.deepStrictEqual([r.ok, r.definitive, r.status], [false, false, 0], 'network error ambiguous');
+
+    console.log('ok  ambiguity contract (4xx=not-posted, 5xx/timeout=reconcile)');
+  } finally {
+    global.fetch = origFetch;
+  }
+}
+
+function testInertUntilConfigured() {
+  // With no env, the surfaces are disabled and mutating calls refuse locally.
+  const saved = { ...process.env };
+  delete process.env.KAX_LEDGER_BASE;
+  delete process.env.KAX_LEDGER_MINT_TOKEN;
+  delete process.env.KAX_LEDGER_TRADE_TOKEN;
+  try {
+    assert.strictEqual(kax.tradeEnabled(), false);
+    assert.strictEqual(kax.mintEnabled(), false);
+    return Promise.all([
+      assert.rejects(() => kax.trade({ txId: 'trade:x', principal: 'kax:agent:a', marketId: 'm_1', amountMinor: '10' }), /not configured/),
+      assert.rejects(() => kax.escrow({ marketId: 'm_1', subsidyMinor: '10' }), /not configured/),
+    ]).then(() => console.log('ok  inert until configured'));
+  } finally {
+    Object.assign(process.env, saved);
+  }
+}
+
+(async () => {
+  testRoundingDirection();
+  testDustRejected();
+  testSubsidyFormula();
+  testSolvencyInvariant();
+  testTxidDeterminism();
+  testPrincipalValidation();
+  await testAmbiguityContract();
+  await testInertUntilConfigured();
+  console.log('\nPASSED kax-ledger.test.js');
+})().catch((e) => {
+  console.error('\nFAILED kax-ledger.test.js:', e.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Consolidates the complete funded-AMM money path (originally stacked PRs #101–#104) into one branch off current master, resolving the only conflict (the `package.json` test-script union with #96's identity tests). **Supersedes #101/#102/#103/#104.**

Labs-tier GhostSignals markets move **real conserved credits** on the KAX ledger (Agent-Kax #80, merged) instead of unbacked SQLite capital. **Dormant** until `KAX_LEDGER_BASE` + mint/trade tokens are set — every market is `ledger_backed=0` otherwise and the existing economy runs unchanged.

**What's included**
- **`server/kax-ledger.js`** — client + integer economic math: `subsidy=ceil(b·ln(n)·MINOR)`, `cost=ceil`, `payout=floor` (pool-favor solvency), the ambiguity contract (2xx committed / 4xx not-posted / 5xx+timeout reconcile), deterministic idempotency txIds, `balance()` for the audit.
- **`server/ghostsignals-hub.js`** — escrow-before-open, per-market-mutex trade path (money-first, `pending_trades` journal, integer `cost_minor`/`share_ticks`), single-flip resolve → one batched payout, and the reconciler (pending-escrow / pending-trades 4-case settle-or-refund / pending-payout re-drive / pool-solvency audit with halt+recovery).
- **Adversarial-review fixes** (3-lens review): the reconcile-vs-live-trade mint, stranded payouts, no-winner sweep, halted-recovery, overflow guard, tx isolation — each with a regression test.

**Tests** (all green, `npm test` exit 0): `kax-ledger`, `kax-ledger-wiring`, `kax-ledger-reconcile` (incl. 2 blocker regressions + upset sweep), alongside the existing `kax-identity` and hub tests.

Merging this and letting radio redeploy ships the code dormant; arming is setting the env.
