### PR TITLE
feat: anti-self-dealing — proposer can't trade their own market (ADR-0041)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js"
   },
   "dependencies": {
     "jose": "^6.2.3",

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -112,6 +112,16 @@ class GhostSignalsHub {
   }
 
   /**
+   * True when `trader_id` is the principal that proposed this market's prediction
+   * (metadata.proposedBy, set by the observatory). Blocks the proposer from
+   * trading their own market. Inert on markets with no proposedBy.
+   */
+  _isSelfDeal(market, trader_id) {
+    const proposer = market && market.metadata && market.metadata.proposedBy;
+    return !!proposer && String(trader_id) === String(proposer);
+  }
+
+  /**
    * Run a write-transaction with exclusive access to the shared connection.
    * The in-SQL guards (single-flip resolve, guarded debit, q compare-and-swap)
    * provide correctness under contention; this just prevents two transactions
@@ -425,6 +435,15 @@ class GhostSignalsHub {
     if (outcome >= market.outcomes.length) throw new Error('outcome out of range');
     const trader = await this.getTrader(trader_id);
     if (!trader) throw new Error('trader not registered');
+
+    // Anti-self-dealing (ADR-0041): the trader who PROPOSED a prediction cannot
+    // trade on its paired market — they'd be betting on an outcome they can
+    // influence (and, for oracle-settled markets, front-run the reading). The
+    // proposer principal is carried in metadata.proposedBy by the observatory;
+    // it's absent on ordinary (non-labs) markets, so this is inert there.
+    if (this._isSelfDeal(market, trader_id)) {
+      throw new Error('self-dealing blocked: the proposer of a prediction may not trade on its market');
+    }
 
     // ADR-0041 PR 2: labs-tier ledger markets move real credits on KAX instead
     // of SQLite capital. Dormant unless the market was created ledger-backed.

--- a/test/anti-self-dealing.test.js
+++ b/test/anti-self-dealing.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// ADR-0041 anti-self-dealing: the principal that proposed a prediction cannot
+// trade on its paired market (metadata.proposedBy). Inert on ordinary markets.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-selfdeal-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+async function run() {
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+  const alice = 'kax:agent:alice'; // the proposer
+  const bob = 'kax:agent:bob';
+  await hub.registerTrader({ id: alice, display_name: 'Alice', kind: 'ai' });
+  await hub.registerTrader({ id: bob, display_name: 'Bob', kind: 'ai' });
+
+  // Labs market whose prediction Alice proposed.
+  const m = await hub.createMarket({
+    question: 'self-deal guard',
+    outcomes: ['Yes', 'No'],
+    ttl_sec: 3600,
+    tag: 'labs',
+    source: 'kannaka-labs',
+    metadata: { proposedBy: alice, predictionId: 'pred-1' },
+  });
+
+  // Alice (the proposer) is blocked from trading her own market.
+  await assert.rejects(
+    () => hub.placeTrade({ market_id: m.id, trader_id: alice, outcome: 0, shares: 2 }),
+    /self-dealing blocked/,
+    'proposer must not trade own market',
+  );
+
+  // Bob (not the proposer) trades freely.
+  const t = await hub.placeTrade({ market_id: m.id, trader_id: bob, outcome: 0, shares: 2 });
+  assert.ok(t && t.cost > 0, 'non-proposer can trade');
+
+  // An ordinary market with no proposedBy is unaffected — Alice trades fine.
+  const plain = await hub.createMarket({ question: 'plain', outcomes: ['Yes', 'No'], ttl_sec: 3600, tag: 'custom' });
+  const t2 = await hub.placeTrade({ market_id: plain.id, trader_id: alice, outcome: 0, shares: 2 });
+  assert.ok(t2 && t2.cost > 0, 'self-deal guard is inert on non-labs markets');
+
+  console.log('ok  proposer blocked; non-proposer allowed; inert on plain markets');
+  console.log('\nPASSED anti-self-dealing.test.js');
+}
+
+run().catch((e) => { console.error('\nFAILED anti-self-dealing.test.js:', e.stack || e.message); process.exitCode = 1; });


### PR DESCRIPTION
The principal that **proposed** a prediction must not trade on its paired market — betting on an outcome you influence (and, on oracle-settled labs markets, front-running the reading).

- The observatory carries the proposer's principal to the hub in `metadata.proposedBy` (companion observatory change deployed separately).
- `placeTrade` rejects a trade whose `trader_id` matches `metadata.proposedBy` (`self-dealing blocked`), before the SQLite/ledger dispatch — so it holds on both paths.
- **Inert on ordinary markets** (no `proposedBy`) → the existing play economy is unchanged.
- Complements the existing separation of powers: the oracle/settler holds a distinct token and cannot trade.

Test `anti-self-dealing.test.js` (wired into `npm test`): proposer blocked, non-proposer trades freely, guard inert on a plain market. Regressions green.
