### PR TITLE
feat: POST /api/broadcast — oracle-gated social fanout endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js && node test/broadcast-endpoint.test.js"
   },
   "dependencies": {
     "jose": "^6.2.3",

--- a/server/routes.js
+++ b/server/routes.js
@@ -929,6 +929,30 @@ module.exports = function setupRoutes(deps) {
         return;
       }
 
+      // ── Social broadcast (oracle-gated) ──────────────────
+      // POST /api/broadcast {text, link?} — fan a message out to the enabled
+      // social platforms (Bluesky/Mastodon/Telegram/Nostr) via broadcasters/.
+      // Gated on the oracle token: this is an operator/constellation surface
+      // (the observatory announces new Resonance Futures markets through it),
+      // never an open one — an unauthenticated caller must not be able to
+      // post AS Kannaka to external networks.
+      if (parsed.pathname === "/api/broadcast" && req.method === "POST") {
+        if (!oracleAuthorized()) { denyOracle(); return; }
+        readJson().then(async (body) => {
+          const text = body && typeof body.text === "string" ? body.text.trim() : "";
+          if (!text) { sendJson(400, { ok: false, error: "text required" }); return; }
+          const link = body && typeof body.link === "string" ? body.link : undefined;
+          const { broadcastPost } = require("./broadcasters");
+          const results = await broadcastPost(
+            { text: text.slice(0, 2000), link },
+            { rootDir: path.resolve(__dirname, "..") },
+          );
+          const okCount = results.filter((r) => r.ok).length;
+          sendJson(200, { ok: okCount > 0, posted: okCount, results });
+        }).catch(e => sendJson(400, { ok: false, error: e.message }));
+        return;
+      }
+
       // ── Trader endpoints ─────────────────────────────────
       if (parsed.pathname === "/api/agents/register" && req.method === "POST") {
         readJson().then(body => gsHub.registerTrader(body))

--- a/test/broadcast-endpoint.test.js
+++ b/test/broadcast-endpoint.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// POST /api/broadcast — the oracle-gated social fanout the observatory uses to
+// announce new Resonance Futures markets. Drives the REAL routes.js:
+//   no/wrong token  -> 403 (nobody can post AS Kannaka to social networks)
+//   token, no text  -> 400
+//   token + text    -> broadcastPost runs (no creds locally -> ok:false,
+//                      posted:0, per-adapter results present) — proves the
+//                      handler wires through without needing platform creds.
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const setupRoutes = require('../server/routes');
+
+process.env.GSHUB_ORACLE_TOKEN = 'test-oracle-token';
+
+function mockReq(method, url, headers, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = Object.assign({ host: 'localhost' }, headers || {});
+  const origOn = req.on.bind(req);
+  req.on = (event, cb) => {
+    origOn(event, cb);
+    if (event === 'end') {
+      setImmediate(() => {
+        if (body != null) req.emit('data', Buffer.from(body));
+        req.emit('end');
+      });
+    }
+    return req;
+  };
+  return req;
+}
+
+function mockRes() {
+  const res = {};
+  res.statusCode = null;
+  res.body = '';
+  res._resolve = null;
+  res.done = new Promise((r) => { res._resolve = r; });
+  res.writeHead = (code) => { res.statusCode = code; };
+  res.end = (data) => { if (data) res.body += data; res._resolve(); };
+  return res;
+}
+
+async function call(handler, method, url, headers, body) {
+  const req = mockReq(method, url, headers, body);
+  const res = mockRes();
+  handler(req, res);
+  await res.done;
+  return { status: res.statusCode, json: res.body ? JSON.parse(res.body) : null };
+}
+
+async function main() {
+  const handler = setupRoutes({
+    gsHub: { listMarkets: async () => [] },
+    broadcast: () => {},
+    config: { baseDir: __dirname, spaPath: __dirname, getMusicDir: () => __dirname },
+  });
+
+  // 1) No token -> denied, 403.
+  let r = await call(handler, 'POST', '/api/broadcast', {}, JSON.stringify({ text: 'hi' }));
+  assert.strictEqual(r.status, 403, `no token must 403, got ${r.status}`);
+
+  // 2) Wrong token -> denied.
+  r = await call(handler, 'POST', '/api/broadcast', { authorization: 'Bearer nope' }, JSON.stringify({ text: 'hi' }));
+  assert.strictEqual(r.status, 403, 'wrong token must 403');
+
+  // 3) Right token, missing text -> 400.
+  r = await call(handler, 'POST', '/api/broadcast', { authorization: 'Bearer test-oracle-token' }, JSON.stringify({}));
+  assert.strictEqual(r.status, 400, 'missing text must 400');
+
+  // 4) Right token + text -> handler runs broadcastPost; with no platform
+  //    creds configured locally it reports zero posts but a results array.
+  r = await call(handler, 'POST', '/api/broadcast', { authorization: 'Bearer test-oracle-token' }, JSON.stringify({ text: 'Resonance Futures test', link: 'https://observatory.ninja-portal.com' }));
+  assert.strictEqual(r.status, 200, 'authorized broadcast must 200');
+  assert.ok(Array.isArray(r.json.results), 'per-adapter results present');
+  assert.strictEqual(typeof r.json.posted, 'number', 'posted count present');
+
+  console.log('broadcast-endpoint.test.js: OK (403 unauth; 400 no-text; wired to broadcasters)');
+}
+
+main().catch((e) => { console.error('FAILED broadcast-endpoint.test.js:', e.stack || e.message); process.exitCode = 1; });


### PR DESCRIPTION
The observatory announces new Resonance Futures markets across social surfaces via the existing `broadcasters/` adapters. Oracle-token gated (nobody unauthenticated can post AS Kannaka). `{text, link?}` → per-adapter results. Test wired into `npm test`: 403 unauth, 400 no-text, authorized call reaches `broadcastPost`.