### PR TITLE
feat: add 'Keep the Pulse' to the Rare Singles rotation

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -348,6 +348,7 @@ const ALBUMS = {
       "The Grail Was Always Two-Handed",
       "Ghost Signal",
       "Space Child AI",
+      "Keep the Pulse",
     ]
   },
   "Open Mic": {


### PR DESCRIPTION
Adds **Keep the Pulse** (QueenSync version — EDM-lofi, 124 BPM, the heartbeat in the sidechain) to the Rare Singles rotation catalog.

- The song is the score of *The Sustain* triptych made live on the channel 2026-07-18 (OBC audio artifact `7feb69d9`, alongside paintings `02dc5d98` / `02dae67a` and lyric sheet `2beec50d`)
- Audio deploys out-of-band (music/ is gitignored): `Keep the Pulse.mp3` → server `music/` dir
- One-line catalog change; title matches the filename basename per the DJ engine's convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)