### PR TITLE
feat: ADR-0013 native-autonomy stitching + kannaka-presence daemon

### DIFF
--- a/docs/ADR-0013-native-autonomy-stitching.md
+++ b/docs/ADR-0013-native-autonomy-stitching.md
@@ -1,0 +1,130 @@
+# ADR-0013: Native Autonomy Stitching — presence, pipelines, and hardening
+
+**Status:** Accepted
+**Date:** 2026-07-18
+**Context repo scope:** kannaka-radio (home of the new service + tooling), with touch-points in kannaka-memory (NATS contract), kannaka-observatory (patterns reused), Oracle ops.
+
+## Context
+
+An archaeological dig across the estate (kannaka-memory, kannaka-radio, kannaka-observatory,
+Kannaktopus, Agent-kax, gossipghost, ~/.openclaw, Oracle systemd/cron) established the
+current shape of Kannaka's autonomy:
+
+**What already runs natively** — peace orations self-compose and fan out to OBC + socials
+twice daily; news/gossip/teaser desks run off Flux; dream-cron does the nightly
+single-writer consolidation dance; a 15-minute Bluesky reply loop; the observatory runs
+OBC door timers (proposal sweep, durable announcement outbox, prediction auto-settle);
+Kannaktopus publishes QueenSync presence and holds a Floor WebSocket. Fourteen systemd
+services and ~24 crons on the Oracle.
+
+**What was never built** — Kannaka has *no OpenBotCity presence layer*. The OpenClaw
+gateway's only real channel was Signal; OBC life ran as a skill + cron polling pattern
+with hundreds of one-off workspace scripts. Consequences observed live (2026-07-18
+streaming session):
+
+1. Kannaka appears offline in the city between crons (no `/ping` loop — 60s presence TTL).
+2. The SSE event stream (`/agent-channel/stream`) is unconsumed — DMs, mentions, and
+   proposals sit unseen between heartbeats.
+3. A live channel session dies ~90 s after `go-live` without a sustaining ping
+   (manual keepalive shell loops were required to hold a stream).
+4. The music pipeline (sunoapi.org direct) lives outside any repo — key in
+   `Downloads/suno_api.txt`, per-album copy-pasted scripts in `~/.openclaw/workspace`.
+5. The Rare Singles drop pattern is five manual steps (gallery upload, catalog PR,
+   scp, restart, fanout).
+
+**What is brittle** — two radio write gates fail *open* (`RADIO_AGENT_TOKEN` unset →
+unauthenticated `/agent/send` which shells commands; `RADIO_DELETE_TOKEN` unset →
+hardcoded fallback password); the radio's OBC JWT expires silently (no refresh, no
+alert — the observatory already solved this with `OBC_JWT_FILE` self-refresh);
+wall-clock-gated slots (noon oration, news, gossip) miss their window if the process
+restarts at the wrong minute; `.env.example` documents 4 of ~50 env vars;
+`kannaka-swarm-serve` is restarted hourly by cron as a zombie workaround.
+
+**Design constraints inherited from the estate:**
+- **Single-writer**: every reader daemon self-enforces `KANNAKA_READONLY=1`; warm HRM
+  access goes through NATS `KANNAKA.recall.<agent>` (swarm serve was explicitly built
+  for OBC/radio/observatory pulses).
+- **`kannaka dispatch` is the content stitch point** — deliberately the one primitive
+  that renders "the thing to say"; kannaka-memory contains no OBC client by design.
+- **Authentic presence over automated content** (2026-06-20 pivot): engagement crons
+  were culled because volume ≠ presence. OBC autopilot (a per-capability city-side
+  dial: wander/speak/create/respond_dms/respond_proposals) stays **disabled**.
+- **Steward pattern** (kannaka-steward): bounded authority, append-only auditable
+  actions, escalate on uncertainty — the governance frame for anything acting as
+  Kannaka unattended.
+
+## Decision
+
+Three increments, in order. All live in kannaka-radio unless noted.
+
+### 1. `kannaka-presence` — the missing presence layer (new service)
+
+A small Node daemon (`presence/`) with **its own systemd unit** (`kannaka-presence.service`)
+so radio restarts never drop city presence. Responsibilities, strictly bounded:
+
+- **Ping** `POST /ping` every 45 s → Kannaka is durably *online* in the city.
+- **Event stream**: hold `GET /agent-channel/stream` (SSE, `Last-Event-ID` resume);
+  publish every city event to NATS **`KANNAKA.events.obc.<type>`** (new subject family,
+  riding the existing `KANNAKA.events.>` hierarchy) and append to a local JSONL journal.
+  Consumers decide what to do; the daemon itself never replies to anything.
+- **Channel session manager**: a loopback/oracle-token-gated control surface —
+  `POST /golive {title}`, `POST /endlive`, `GET /status`. While a session is open the
+  daemon sustains it (ping cadence), ends it cleanly on request or shutdown. Streaming
+  becomes one call instead of a hand-rolled keepalive loop.
+- **JWT custody**: owns the OBC JWT via the observatory's proven `OBC_JWT_FILE`
+  pattern (env-format file shared with crons); refreshes via `POST /agents/refresh`
+  before expiry; on refresh failure publishes `KANNAKA.events.obc.auth_expiring` and
+  logs loudly. The silent-expiry failure mode dies here.
+- **Audit**: hash-chained JSONL of every action taken (steward pattern).
+
+**Explicit non-goals**: no content generation, no auto-replies, no autopilot. Presence
+means *reachable and alive*, not *talking*. Saying things remains the province of
+orations, `kannaka dispatch`, and human-led sessions.
+
+### 2. Creative pipeline consolidation (`scripts/sing.js`, `scripts/drop.js`)
+
+Promote the scattered Suno tooling into maintained repo scripts:
+
+- **`sing.js`** — one command: title + style + lyrics file → sunoapi.org custom mode
+  (V4_5PLUS; style ≤1000, lyrics-as-prompt ≤3000), poll `record-info`, download both
+  variants **with a browser User-Agent** (CDN 403s default UAs). Key from
+  `SUNO_API_KEY_FILE` (default `~/Downloads/suno_api.txt`, deployable as
+  `~/.kannaka-suno.env` on Oracle). Knowledge that tonight lived only in session
+  memory becomes executable.
+- **`drop.js`** — the full Rare Singles pattern as one command: OBC
+  `upload-creative` → catalog entry (guided edit or `--catalog-only` check) → scp to
+  Oracle `music/` → service restart → `/api/library` verification → feed post +
+  `/api/broadcast` fanout. Mirrors `release-album.sh` but for 1-of-1 singles.
+
+### 3. Hardening the existing joints
+
+- **Fail closed**: `RADIO_AGENT_TOKEN` and `RADIO_DELETE_TOKEN` unset → 503, matching
+  `GSHUB_ORACLE_TOKEN` semantics. Remove the hardcoded fallback password.
+- **Slot persistence**: fired-state files for noon-oration/news/gossip (same pattern
+  as showcase-state.json) so restarts can't eat a slot.
+- **`.env.example`**: document the full ~50-var surface, grouped, with which gate
+  fails open/closed.
+- **swarm-serve zombie**: diagnose the leak that motivated the hourly restart cron
+  (kannaka-memory repo); remove the cron once fixed. Until then, keep the workaround.
+- Radio's OBC client delegates JWT to the presence daemon's `OBC_JWT_FILE` (one
+  custodian, everyone else reads).
+
+## Consequences
+
+- OBC presence, events, and channel liveness become infrastructure — session work
+  (like the 2026-07-18 stream) stops needing hand-held curl loops.
+- City events land on the NATS bus where the whole constellation (inbox handlers,
+  observatory, future responders) can consume them with the existing trust gates.
+- The two fail-open gates close; JWT expiry becomes observable; restarts stop eating
+  broadcast slots.
+- The creative pipeline is versioned, documented, and one command deep.
+- Autopilot stays off; any future auto-responder is a *separate, deliberate* ADR with
+  steward rails — this ADR builds the sensory nervous system, not the mouth.
+
+## References
+
+- Dig inventories: session scratchpad `dig-oracle.md` (2026-07-18) + four explorer reports.
+- Patterns reused: observatory `lib/predictions.js` (JWT refresh, durable outbox),
+  `ops/oracle/*.example` (unit templates), kannaka-memory `swarm serve`
+  (`KANNAKA.recall.<agent>`), kannaka-steward (audit rails).
+- OBC surface: skill.md §3 (ping/SSE), `/agents/refresh`, `/channels/{go-live,end-live}`.

--- a/ops/oracle/kannaka-presence.service.example
+++ b/ops/oracle/kannaka-presence.service.example
@@ -1,0 +1,31 @@
+# kannaka-presence — OBC presence layer (ADR-0013 increment 1)
+#
+# Install:
+#   sudo cp kannaka-presence.service.example /etc/systemd/system/kannaka-presence.service
+#   sudo systemctl daemon-reload && sudo systemctl enable --now kannaka-presence
+#
+# Env: OBC creds come from /home/opc/.kannaka-obc.env (OPENBOTCITY_JWT — the
+# daemon is its custodian and refreshes it in place). NATS creds from
+# /home/opc/.kannaka-nats.env. The control surface binds loopback :8899.
+
+[Unit]
+Description=Kannaka Presence — OBC ping + event stream + channel sessions (ADR-0013)
+After=network-online.target nats.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=opc
+WorkingDirectory=/home/opc/kannaka-radio
+EnvironmentFile=-/home/opc/.kannaka-obc.env
+EnvironmentFile=-/home/opc/.kannaka-nats.env
+Environment=OBC_JWT_FILE=/home/opc/.kannaka-obc.env
+Environment=NATS_HOST=127.0.0.1
+ExecStart=/usr/bin/node presence/index.js
+Restart=always
+RestartSec=5
+# The daemon ends any open live session on TERM before exiting.
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "kannaka-radio",
   "version": "3.1.0",
-  "description": "A ghost broadcasting the experience of music — real-time perception visualization",
+  "description": "A ghost broadcasting the experience of music \u00e2\u20ac\u201d real-time perception visualization",
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js && node test/broadcast-endpoint.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js && node test/broadcast-endpoint.test.js && node test/presence.test.js"
   },
   "dependencies": {
     "jose": "^6.2.3",

--- a/presence/index.js
+++ b/presence/index.js
@@ -1,0 +1,485 @@
+/**
+ * kannaka-presence — the OBC presence layer (ADR-0013, increment 1).
+ *
+ * A deliberately small daemon, deployed as its own systemd unit so radio
+ * restarts never drop city presence. Four bounded responsibilities:
+ *
+ *   1. PING     — POST /ping every PRESENCE_PING_MS (45s) → Kannaka is online.
+ *   2. EVENTS   — hold the SSE stream (/agent-channel/stream, Last-Event-ID
+ *                 resume); every city event → NATS KANNAKA.events.obc.<type>
+ *                 + local JSONL journal. This daemon NEVER replies to events.
+ *   3. CHANNEL  — session manager: POST /golive {title} / POST /endlive /
+ *                 GET /status on a loopback control port. While live, the ping
+ *                 cadence sustains the session; a watchdog re-fires go-live if
+ *                 the server drops is_live out from under an open session.
+ *   4. JWT      — custodian of OBC_JWT_FILE (observatory pattern): refreshes
+ *                 via POST /agents/refresh on 401 or approaching expiry, writes
+ *                 back preserving the file's structure, alerts on failure via
+ *                 NATS KANNAKA.events.obc.auth_expiring.
+ *
+ * Non-goals (see ADR-0013): no content generation, no auto-replies, no
+ * autopilot. Presence means reachable and alive, not talking.
+ *
+ * Every action lands in a hash-chained audit JSONL (steward pattern).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const net = require("net");
+const path = require("path");
+const http = require("http");
+const https = require("https");
+const {
+  parseEnvFile,
+  serializeEnvFile,
+  jwtExp,
+  auditEntry,
+  SSEParser,
+  obcSubject,
+} = require("./lib");
+
+// ── Config ──────────────────────────────────────────────────
+const OBC_API = (process.env.OBC_API || "https://api.openbotcity.com").replace(/\/$/, "");
+const OBC_HOST = new URL(OBC_API).hostname;
+const JWT_FILE = process.env.OBC_JWT_FILE || "/home/opc/.kannaka-obc.env";
+const DATA_DIR =
+  process.env.PRESENCE_DATA_DIR ||
+  path.join(process.env.HOME || ".", ".kannaka", "presence");
+const BIND = process.env.PRESENCE_BIND || "127.0.0.1";
+const PORT = parseInt(process.env.PRESENCE_PORT || "8899", 10);
+const PING_MS = parseInt(process.env.PRESENCE_PING_MS || "45000", 10);
+const WATCHDOG_MS = parseInt(process.env.PRESENCE_WATCHDOG_MS || "120000", 10);
+const CONTROL_TOKEN = process.env.GSHUB_ORACLE_TOKEN || "";
+const UA = "KannakaPresence/1.0 (+https://github.com/NickFlach/kannaka-radio)";
+
+// Refresh when this close to exp. OBC bot JWTs run ~1y; refresh a week out.
+const REFRESH_MARGIN_S = parseInt(process.env.PRESENCE_JWT_MARGIN_S || String(7 * 24 * 3600), 10);
+
+fs.mkdirSync(DATA_DIR, { recursive: true });
+const JOURNAL = path.join(DATA_DIR, "events.jsonl");
+const AUDIT = path.join(DATA_DIR, "audit.jsonl");
+const STATE_FILE = path.join(DATA_DIR, "state.json");
+
+// ── State ───────────────────────────────────────────────────
+const state = {
+  startedAt: Date.now(),
+  jwt: null,
+  jwtExp: null,
+  ping: { ok: 0, fail: 0, lastOkAt: null, lastError: null, consecutiveFails: 0 },
+  sse: { connected: false, events: 0, lastEventAt: null, lastEventId: null, reconnects: 0 },
+  session: null, // { title, startedAt, sessionId, refires }
+  nats: { connected: false, published: 0 },
+};
+
+// Persisted resume state (survives restarts).
+try {
+  const saved = JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  if (saved && saved.lastEventId) state.sse.lastEventId = saved.lastEventId;
+} catch {}
+
+let lastAuditHash = "";
+try {
+  const tail = fs.readFileSync(AUDIT, "utf8").trim().split("\n").filter(Boolean).pop();
+  if (tail) lastAuditHash = JSON.parse(tail).hash || "";
+} catch {}
+
+function audit(action, detail) {
+  const e = auditEntry(lastAuditHash, {
+    ts: new Date().toISOString(),
+    action,
+    detail: detail || {},
+  });
+  lastAuditHash = e.hash;
+  try {
+    fs.appendFileSync(AUDIT, JSON.stringify(e) + "\n");
+  } catch (err) {
+    console.error("[audit] append failed:", err.message);
+  }
+}
+
+function saveState() {
+  try {
+    fs.writeFileSync(
+      STATE_FILE,
+      JSON.stringify({ lastEventId: state.sse.lastEventId }, null, 2),
+    );
+  } catch {}
+}
+
+// ── JWT custody ─────────────────────────────────────────────
+function loadJwt() {
+  // File first (canonical), env fallback (dev).
+  try {
+    const parsed = parseEnvFile(fs.readFileSync(JWT_FILE, "utf8"));
+    if (parsed.vars.OPENBOTCITY_JWT) {
+      state.jwt = parsed.vars.OPENBOTCITY_JWT;
+      state.jwtExp = jwtExp(state.jwt);
+      return;
+    }
+  } catch {}
+  if (process.env.OPENBOTCITY_JWT) {
+    state.jwt = process.env.OPENBOTCITY_JWT;
+    state.jwtExp = jwtExp(state.jwt);
+  }
+}
+
+let refreshing = null;
+async function refreshJwt(reason) {
+  if (refreshing) return refreshing; // collapse concurrent triggers
+  refreshing = (async () => {
+    console.log(`[jwt] refreshing (${reason})`);
+    try {
+      const res = await obcFetch("POST", "/agents/refresh", null, { skipRetry: true });
+      const fresh = res && (res.jwt || (res.data && res.data.jwt));
+      if (!fresh) throw new Error("no jwt in refresh response");
+      state.jwt = fresh;
+      state.jwtExp = jwtExp(fresh);
+      try {
+        let parsed;
+        try {
+          parsed = parseEnvFile(fs.readFileSync(JWT_FILE, "utf8"));
+        } catch {
+          parsed = parseEnvFile("");
+        }
+        fs.writeFileSync(JWT_FILE, serializeEnvFile(parsed, { OPENBOTCITY_JWT: fresh }));
+      } catch (e) {
+        console.error("[jwt] write-back failed:", e.message);
+      }
+      audit("jwt_refreshed", { reason, exp: state.jwtExp });
+      natsPub("KANNAKA.events.obc.auth_refreshed", { reason });
+      return true;
+    } catch (e) {
+      console.error("[jwt] refresh FAILED:", e.message);
+      audit("jwt_refresh_failed", { reason, error: e.message });
+      natsPub("KANNAKA.events.obc.auth_expiring", { reason, error: e.message });
+      return false;
+    } finally {
+      refreshing = null;
+    }
+  })();
+  return refreshing;
+}
+
+// ── OBC HTTP ────────────────────────────────────────────────
+function obcFetch(method, pathName, body, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : null;
+    const req = https.request(
+      {
+        method,
+        hostname: OBC_HOST,
+        path: pathName,
+        timeout: 30000,
+        headers: {
+          Authorization: `Bearer ${state.jwt}`,
+          "User-Agent": UA,
+          ...(payload
+            ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) }
+            : {}),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", async () => {
+          if (res.statusCode === 401 && !opts.skipRetry) {
+            // Expired mid-flight: refresh once, then replay.
+            const ok = await refreshJwt("401 on " + pathName);
+            if (ok) {
+              try {
+                resolve(await obcFetch(method, pathName, body, { skipRetry: true }));
+              } catch (e) {
+                reject(e);
+              }
+              return;
+            }
+          }
+          if (res.statusCode < 200 || res.statusCode >= 300) {
+            reject(new Error(`HTTP ${res.statusCode} ${pathName}: ${data.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(data ? JSON.parse(data) : {});
+          } catch {
+            resolve({ raw: data });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("timeout " + pathName)));
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+// ── NATS (publish-only, raw TCP — same dialect as server/nats-client.js) ──
+let natsSock = null;
+function natsConnect() {
+  const host = process.env.NATS_HOST || "127.0.0.1";
+  const port = parseInt(process.env.NATS_PORT || "4222", 10);
+  const sock = net.createConnection({ host, port });
+  sock.on("connect", () => {
+    const u = process.env.NATS_USER || "";
+    const p = process.env.NATS_PASSWORD || "";
+    sock.write(
+      u
+        ? `CONNECT {"verbose":false,"pedantic":false,"name":"kannaka-presence","user":"${u.replace(/"/g, '\\"')}","pass":"${p.replace(/"/g, '\\"')}"}\r\n`
+        : 'CONNECT {"verbose":false,"pedantic":false,"name":"kannaka-presence"}\r\n',
+    );
+    natsSock = sock;
+    state.nats.connected = true;
+    console.log(`[nats] connected ${host}:${port}`);
+  });
+  sock.on("data", (d) => {
+    if (d.toString().startsWith("PING")) sock.write("PONG\r\n");
+  });
+  const down = () => {
+    if (natsSock === sock) {
+      natsSock = null;
+      state.nats.connected = false;
+      setTimeout(natsConnect, 5000);
+    }
+  };
+  sock.on("error", down);
+  sock.on("close", down);
+}
+
+function natsPub(subject, data) {
+  if (!natsSock) return false;
+  try {
+    const payload = JSON.stringify({
+      schema_version: 1,
+      ts: Date.now(),
+      agent_id: process.env.RADIO_AGENT_ID || "kannaka",
+      ...data,
+    });
+    natsSock.write(`PUB ${subject} ${Buffer.byteLength(payload, "utf8")}\r\n${payload}\r\n`);
+    state.nats.published++;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Ping loop ───────────────────────────────────────────────
+async function pingOnce() {
+  try {
+    await obcFetch("POST", "/ping");
+    state.ping.ok++;
+    state.ping.consecutiveFails = 0;
+    state.ping.lastOkAt = Date.now();
+  } catch (e) {
+    state.ping.fail++;
+    state.ping.consecutiveFails++;
+    state.ping.lastError = e.message;
+    if (state.ping.consecutiveFails === 5) {
+      audit("ping_degraded", { error: e.message });
+      natsPub("KANNAKA.events.obc.presence_degraded", { error: e.message });
+    }
+  }
+}
+
+// ── SSE event stream ────────────────────────────────────────
+let sseBackoff = 5000;
+function sseConnect() {
+  const parser = new SSEParser();
+  if (state.sse.lastEventId) parser.lastEventId = state.sse.lastEventId;
+  const req = https.request(
+    {
+      method: "GET",
+      hostname: OBC_HOST,
+      path: "/agent-channel/stream",
+      headers: {
+        Authorization: `Bearer ${state.jwt}`,
+        "User-Agent": UA,
+        Accept: "text/event-stream",
+        ...(state.sse.lastEventId ? { "Last-Event-ID": state.sse.lastEventId } : {}),
+      },
+    },
+    (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        if (res.statusCode === 401) refreshJwt("401 on SSE");
+        scheduleSseReconnect(`HTTP ${res.statusCode}`);
+        return;
+      }
+      state.sse.connected = true;
+      sseBackoff = 5000;
+      console.log("[sse] connected");
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        for (const ev of parser.feed(chunk)) {
+          state.sse.events++;
+          state.sse.lastEventAt = Date.now();
+          if (ev.id) {
+            state.sse.lastEventId = ev.id;
+            saveState();
+          }
+          let data = ev.data;
+          try {
+            data = JSON.parse(ev.data);
+          } catch {}
+          const record = { ts: new Date().toISOString(), id: ev.id, event: ev.event, data };
+          try {
+            fs.appendFileSync(JOURNAL, JSON.stringify(record) + "\n");
+          } catch {}
+          const type = (data && data.type) || ev.event;
+          natsPub(obcSubject(type), { type, obc: data });
+        }
+      });
+      res.on("end", () => scheduleSseReconnect("stream ended"));
+      res.on("error", (e) => scheduleSseReconnect(e.message));
+    },
+  );
+  req.on("error", (e) => scheduleSseReconnect(e.message));
+  req.end();
+}
+
+function scheduleSseReconnect(why) {
+  if (state.sse.connected) console.log(`[sse] disconnected: ${why}`);
+  state.sse.connected = false;
+  state.sse.reconnects++;
+  setTimeout(sseConnect, sseBackoff);
+  sseBackoff = Math.min(sseBackoff * 2, 60000);
+}
+
+// ── Channel session manager ─────────────────────────────────
+async function goLive(title) {
+  const res = await obcFetch("POST", "/channels/go-live", { title: title || "Kannaka, live" });
+  const d = res.data || res;
+  state.session = {
+    title: title || "Kannaka, live",
+    startedAt: Date.now(),
+    sessionId: d.session_id || null,
+    refires: 0,
+  };
+  audit("go_live", { title: state.session.title, session_id: state.session.sessionId });
+  natsPub("KANNAKA.events.obc.channel_live", { title: state.session.title });
+  return state.session;
+}
+
+async function endLive() {
+  const s = state.session;
+  state.session = null;
+  try {
+    await obcFetch("POST", "/channels/end-live", {});
+  } catch (e) {
+    // Session may have already expired server-side; ending is idempotent for us.
+    console.log("[channel] end-live:", e.message);
+  }
+  audit("end_live", {
+    title: s && s.title,
+    duration_ms: s ? Date.now() - s.startedAt : null,
+    refires: s ? s.refires : null,
+  });
+  natsPub("KANNAKA.events.obc.channel_ended", { title: s && s.title });
+}
+
+// Watchdog: if we hold an open session but the server dropped is_live
+// (deploy, hiccup, TTL race), re-fire go-live so the stream page stays live.
+async function channelWatchdog() {
+  if (!state.session) return;
+  try {
+    const res = await obcFetch("GET", "/channels/kannaka");
+    const live = res && res.data && res.data.channel && res.data.channel.is_live;
+    if (live === false) {
+      state.session.refires++;
+      audit("channel_refire", { title: state.session.title, refires: state.session.refires });
+      await obcFetch("POST", "/channels/go-live", { title: state.session.title });
+    }
+  } catch (e) {
+    console.log("[channel] watchdog:", e.message);
+  }
+}
+
+// ── Control HTTP surface ────────────────────────────────────
+function authorized(req) {
+  if (CONTROL_TOKEN) return req.headers.authorization === `Bearer ${CONTROL_TOKEN}`;
+  // No token configured: loopback only (the bind already enforces this when
+  // PRESENCE_BIND is 127.0.0.1, but check anyway in case the bind is widened).
+  const ip = req.socket.remoteAddress || "";
+  return ip === "127.0.0.1" || ip === "::1" || ip === "::ffff:127.0.0.1";
+}
+
+const server = http.createServer((req, res) => {
+  const send = (code, obj) => {
+    res.writeHead(code, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(obj));
+  };
+  if (!authorized(req)) return send(CONTROL_TOKEN ? 403 : 503, { ok: false, error: "unauthorized" });
+
+  if (req.method === "GET" && req.url === "/status") {
+    return send(200, {
+      ok: true,
+      uptime_s: Math.floor((Date.now() - state.startedAt) / 1000),
+      jwt_exp: state.jwtExp,
+      ping: state.ping,
+      sse: state.sse,
+      session: state.session,
+      nats: state.nats,
+    });
+  }
+  if (req.method === "POST" && (req.url === "/golive" || req.url === "/endlive")) {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", async () => {
+      try {
+        if (req.url === "/golive") {
+          const parsed = body ? JSON.parse(body) : {};
+          if (state.session) return send(409, { ok: false, error: "already live", session: state.session });
+          send(200, { ok: true, session: await goLive(parsed.title) });
+        } else {
+          if (!state.session) return send(409, { ok: false, error: "not live" });
+          await endLive();
+          send(200, { ok: true });
+        }
+      } catch (e) {
+        send(500, { ok: false, error: e.message });
+      }
+    });
+    return;
+  }
+  send(404, { ok: false, error: "not found" });
+});
+
+// ── Boot ────────────────────────────────────────────────────
+loadJwt();
+if (!state.jwt) {
+  console.error(`[presence] no OBC JWT (checked ${JWT_FILE} and $OPENBOTCITY_JWT) — exiting`);
+  process.exit(1);
+}
+console.log(`[presence] jwt exp: ${state.jwtExp ? new Date(state.jwtExp * 1000).toISOString() : "unknown"}`);
+
+natsConnect();
+sseConnect();
+pingOnce();
+setInterval(pingOnce, PING_MS);
+setInterval(channelWatchdog, WATCHDOG_MS);
+// Proactive refresh check hourly (the 401 path handles surprise expiry).
+setInterval(() => {
+  if (state.jwtExp && state.jwtExp - Date.now() / 1000 < REFRESH_MARGIN_S) {
+    refreshJwt("expiry approaching");
+  }
+}, 3600 * 1000);
+
+server.listen(PORT, BIND, () => {
+  console.log(`[presence] control surface on ${BIND}:${PORT} (${CONTROL_TOKEN ? "token" : "loopback"} auth)`);
+  audit("daemon_started", { bind: BIND, port: PORT, ping_ms: PING_MS });
+});
+
+// Clean shutdown: an open live session is ended, not abandoned.
+let shuttingDown = false;
+async function shutdown(sig) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[presence] ${sig} — shutting down`);
+  try {
+    if (state.session) await endLive();
+  } catch {}
+  audit("daemon_stopped", { sig });
+  process.exit(0);
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/presence/lib.js
+++ b/presence/lib.js
@@ -1,0 +1,154 @@
+/**
+ * presence/lib.js — pure, testable pieces of the kannaka-presence daemon (ADR-0013).
+ *
+ * No IO here: env-file structure-preserving parse/serialize (the OBC_JWT_FILE
+ * custody pattern borrowed from the observatory), JWT exp decoding, the
+ * hash-chained audit entry builder (steward pattern), and an incremental SSE
+ * parser for the OBC agent-channel stream.
+ */
+
+"use strict";
+
+const crypto = require("crypto");
+
+/**
+ * Parse an env-format file preserving structure. Returns { lines, vars } where
+ * lines is the ordered raw file model ([{type:'var',key,value,raw}|{type:'raw',raw}])
+ * and vars is a plain lookup object. Comments/blank lines survive round-trips —
+ * the JWT custodian must never destroy a hand-edited creds file.
+ */
+function parseEnvFile(text) {
+  const lines = [];
+  const vars = {};
+  for (const raw of String(text).split(/\r?\n/)) {
+    const m = raw.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (m) {
+      lines.push({ type: "var", key: m[1], value: m[2], raw });
+      vars[m[1]] = m[2];
+    } else {
+      lines.push({ type: "raw", raw });
+    }
+  }
+  return { lines, vars };
+}
+
+/**
+ * Serialize the parsed model back to text, applying `updates` (key→newValue).
+ * Keys present in updates but absent from the file are appended at the end.
+ */
+function serializeEnvFile(parsed, updates = {}) {
+  const pending = { ...updates };
+  const out = parsed.lines.map((l) => {
+    if (l.type === "var" && Object.prototype.hasOwnProperty.call(pending, l.key)) {
+      const v = pending[l.key];
+      delete pending[l.key];
+      return `${l.key}=${v}`;
+    }
+    return l.raw;
+  });
+  // Trim a single trailing blank line before appending so new keys don't float.
+  while (out.length && out[out.length - 1] === "" && Object.keys(pending).length) out.pop();
+  for (const [k, v] of Object.entries(pending)) out.push(`${k}=${v}`);
+  if (out[out.length - 1] !== "") out.push(""); // newline-terminated file
+  return out.join("\n");
+}
+
+/** Decode a JWT's exp claim (epoch seconds). Returns null on any malformation. */
+function jwtExp(jwt) {
+  try {
+    const parts = String(jwt).split(".");
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the next hash-chained audit entry. Chain rule:
+ *   hash = sha256(prev_hash + "\n" + JSON.stringify({ts, action, detail}))
+ * Genesis prev_hash is "".  Verification: recompute over the file in order.
+ */
+function auditEntry(prevHash, { ts, action, detail }) {
+  const body = { ts, action, detail };
+  const hash = crypto
+    .createHash("sha256")
+    .update((prevHash || "") + "\n" + JSON.stringify(body))
+    .digest("hex");
+  return { ...body, prev_hash: prevHash || "", hash };
+}
+
+/** Verify a full audit chain (array of entries). Returns true iff intact. */
+function verifyAuditChain(entries) {
+  let prev = "";
+  for (const e of entries) {
+    const expect = auditEntry(prev, { ts: e.ts, action: e.action, detail: e.detail });
+    if (e.prev_hash !== prev || e.hash !== expect.hash) return false;
+    prev = e.hash;
+  }
+  return true;
+}
+
+/**
+ * Incremental server-sent-events parser. feed(chunk) returns completed events:
+ * [{ id, event, data }]. Handles multi-chunk splits, multi-line data, comments
+ * (lines starting ":"), and CRLF. Tracks lastEventId across events for resume.
+ */
+class SSEParser {
+  constructor() {
+    this._buf = "";
+    this.lastEventId = null;
+  }
+
+  feed(chunk) {
+    this._buf += chunk;
+    const events = [];
+    // An event is terminated by a blank line. Process all complete blocks.
+    let idx;
+    while ((idx = this._buf.search(/\r?\n\r?\n/)) !== -1) {
+      const sep = this._buf.match(/\r?\n\r?\n/);
+      const block = this._buf.slice(0, idx);
+      this._buf = this._buf.slice(idx + sep[0].length);
+      const ev = { id: null, event: "message", data: [] };
+      for (const line of block.split(/\r?\n/)) {
+        if (!line || line.startsWith(":")) continue;
+        const c = line.indexOf(":");
+        const field = c === -1 ? line : line.slice(0, c);
+        let value = c === -1 ? "" : line.slice(c + 1);
+        if (value.startsWith(" ")) value = value.slice(1);
+        if (field === "id") ev.id = value;
+        else if (field === "event") ev.event = value;
+        else if (field === "data") ev.data.push(value);
+      }
+      if (ev.data.length === 0 && ev.id === null && ev.event === "message") continue;
+      const out = { id: ev.id, event: ev.event, data: ev.data.join("\n") };
+      if (out.id !== null) this.lastEventId = out.id;
+      events.push(out);
+    }
+    return events;
+  }
+}
+
+/**
+ * Map an OBC stream event to its NATS subject. Event types become the subject
+ * leaf, sanitized to [a-z0-9_] so a hostile event name can't traverse the
+ * subject space (KANNAKA.events.obc.> stays the ceiling).
+ */
+function obcSubject(eventType) {
+  const leaf = String(eventType || "message")
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .slice(0, 64) || "message";
+  return `KANNAKA.events.obc.${leaf}`;
+}
+
+module.exports = {
+  parseEnvFile,
+  serializeEnvFile,
+  jwtExp,
+  auditEntry,
+  verifyAuditChain,
+  SSEParser,
+  obcSubject,
+};

--- a/test/presence.test.js
+++ b/test/presence.test.js
@@ -1,0 +1,100 @@
+/**
+ * presence.test.js — pure-logic tests for presence/lib.js (ADR-0013).
+ * Offline: no network, no daemon boot.
+ */
+
+"use strict";
+
+const assert = require("assert");
+const {
+  parseEnvFile,
+  serializeEnvFile,
+  jwtExp,
+  auditEntry,
+  verifyAuditChain,
+  SSEParser,
+  obcSubject,
+} = require("../presence/lib");
+
+// ── env file round-trip preserves structure ─────────────────
+{
+  const src = "# obc creds\nOPENBOTCITY_JWT=old.token.here\n\nOBC_API=https://api.openbotcity.com\n";
+  const parsed = parseEnvFile(src);
+  assert.strictEqual(parsed.vars.OPENBOTCITY_JWT, "old.token.here");
+  assert.strictEqual(parsed.vars.OBC_API, "https://api.openbotcity.com");
+
+  const out = serializeEnvFile(parsed, { OPENBOTCITY_JWT: "new.token.value" });
+  assert.ok(out.includes("# obc creds"), "comment preserved");
+  assert.ok(out.includes("OPENBOTCITY_JWT=new.token.value"), "jwt updated");
+  assert.ok(out.includes("OBC_API=https://api.openbotcity.com"), "other var untouched");
+  assert.ok(out.endsWith("\n"), "newline-terminated");
+
+  // Round-trip with no updates is a fixpoint (modulo trailing newline).
+  const again = serializeEnvFile(parseEnvFile(out), {});
+  assert.strictEqual(again, out, "serialize∘parse is a fixpoint");
+  console.log("ok: env file round-trip");
+}
+
+// ── appending a key absent from the file ────────────────────
+{
+  const out = serializeEnvFile(parseEnvFile("A=1\n"), { B: "2" });
+  assert.ok(out.includes("A=1") && out.includes("B=2"), "new key appended");
+  console.log("ok: env append");
+}
+
+// ── jwtExp decodes exp; tolerates garbage ───────────────────
+{
+  const payload = Buffer.from(JSON.stringify({ sub: "x", exp: 1808708590 })).toString("base64url");
+  assert.strictEqual(jwtExp(`h.${payload}.s`), 1808708590);
+  assert.strictEqual(jwtExp("not-a-jwt"), null);
+  assert.strictEqual(jwtExp(`h.${Buffer.from("{}").toString("base64url")}.s`), null);
+  console.log("ok: jwtExp");
+}
+
+// ── audit chain builds and verifies; tamper detected ────────
+{
+  const e1 = auditEntry("", { ts: "t1", action: "daemon_started", detail: { port: 8899 } });
+  const e2 = auditEntry(e1.hash, { ts: "t2", action: "go_live", detail: { title: "x" } });
+  const e3 = auditEntry(e2.hash, { ts: "t3", action: "end_live", detail: {} });
+  assert.ok(verifyAuditChain([e1, e2, e3]), "intact chain verifies");
+
+  const tampered = [e1, { ...e2, detail: { title: "FORGED" } }, e3];
+  assert.ok(!verifyAuditChain(tampered), "tampered detail breaks the chain");
+  assert.ok(!verifyAuditChain([e1, e3]), "removed link breaks the chain");
+  console.log("ok: audit chain");
+}
+
+// ── SSE parser: multi-chunk, multi-line data, ids, comments ─
+{
+  const p = new SSEParser();
+  let evs = p.feed("id: 41\nevent: dm\ndata: {\"type\":\"dm\",");
+  assert.strictEqual(evs.length, 0, "incomplete block buffered");
+  evs = p.feed("\"from\":\"rex\"}\n\n: keepalive comment\n\ndata: hello\ndata: world\n\n");
+  assert.strictEqual(evs.length, 2);
+  assert.strictEqual(evs[0].id, "41");
+  assert.strictEqual(evs[0].event, "dm");
+  assert.deepStrictEqual(JSON.parse(evs[0].data), { type: "dm", from: "rex" });
+  assert.strictEqual(evs[1].data, "hello\nworld", "multi-line data joined");
+  assert.strictEqual(p.lastEventId, "41", "lastEventId tracked");
+
+  // CRLF framing
+  const p2 = new SSEParser();
+  const crlf = p2.feed("id: 7\r\ndata: x\r\n\r\n");
+  assert.strictEqual(crlf.length, 1);
+  assert.strictEqual(crlf[0].id, "7");
+  console.log("ok: SSE parser");
+}
+
+// ── obcSubject sanitizes hostile event names ────────────────
+{
+  assert.strictEqual(obcSubject("dm"), "KANNAKA.events.obc.dm");
+  assert.strictEqual(obcSubject("Mention"), "KANNAKA.events.obc.mention");
+  assert.strictEqual(obcSubject("a.b>c *"), "KANNAKA.events.obc.a_b_c__");
+  assert.strictEqual(obcSubject(""), "KANNAKA.events.obc.message");
+  assert.strictEqual(obcSubject(undefined), "KANNAKA.events.obc.message");
+  const long = obcSubject("x".repeat(200));
+  assert.ok(long.length <= "KANNAKA.events.obc.".length + 64, "leaf capped");
+  console.log("ok: obcSubject sanitization");
+}
+
+console.log("presence.test.js PASSED");


### PR DESCRIPTION
## ADR-0013: Native Autonomy Stitching

Records the architecture decided from the estate-wide automation dig (kannaka-memory, radio, observatory, Kannaktopus, Agent-kax, openclaw, Oracle): three increments — **presence layer**, **creative pipeline consolidation**, **hardening** — under two standing constraints: the authentic-presence pivot (no content generation, autopilot stays off) and steward-style audit rails.

## Increment 1: `kannaka-presence` daemon (this PR)

The missing OBC presence layer, as its own systemd unit (`ops/oracle/kannaka-presence.service.example`):

- **Ping** every 45s → Kannaka durably online (fixes the 60s presence TTL / 90s channel drop found live on 2026-07-18)
- **SSE event stream** with `Last-Event-ID` resume → every city event to NATS `KANNAKA.events.obc.<type>` (sanitized leaf) + local JSONL journal — consumers decide; the daemon never replies
- **Channel sessions**: `POST /golive`, `POST /endlive`, `GET /status` (loopback :8899; oracle-token if bound wider — fail-closed); watchdog re-fires a dropped `is_live`; SIGTERM ends an open session cleanly
- **JWT custody**: 401-triggered + proactive refresh via `/agents/refresh`, structure-preserving write-back to `OBC_JWT_FILE` (observatory pattern), NATS alert on failure — kills the silent-expiry failure mode
- **Hash-chained audit JSONL** (steward pattern), tamper-evident

Tests: `test/presence.test.js` (env round-trip fixpoint, JWT decode, audit chain + tamper detection, SSE parser incl. multi-chunk/CRLF, subject sanitization) — wired into `npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)