### PR TITLE
feat: fail-closed write gates + full .env.example (ADR-0013 increment 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,107 @@
-# kannaka-radio configuration
-# Copy to .env and adjust values for your environment
+# kannaka-radio configuration — full env surface (ADR-0013 hardening).
+# Copy to .env and adjust. Grouped by subsystem; unset optional vars disable
+# their feature. Gate semantics are called out explicitly: every write gate
+# in this codebase FAILS CLOSED when its token is unset.
 
-# Flux Universe publishing token (required for Flux publishing)
-FLUX_TOKEN=
+# ── Core ────────────────────────────────────────────────────
+# PORT=3000                       # HTTP port
+# RADIO_PUBLIC_URL=               # public origin for discoverability surfaces
+# RADIO_AGENT_ID=kannaka          # agent identity on the NATS bus
+# KANNAKA_BIN=                    # path to kannaka CLI (default ../kannaka-memory/target/release/kannaka[.exe])
+# KANNAKA_DATA_DIR=               # HRM data dir (default ~/.kannaka)
 
-# Path to kannaka CLI binary (defaults to ../kannaka-memory/target/release/kannaka[.exe])
-# KANNAKA_BIN=/path/to/kannaka
+# ── Write gates (ALL fail closed when unset) ────────────────
+# GSHUB_ORACLE_TOKEN=             # /api/broadcast, /api/markets/:id/resolve, labs-tier market ops (503 when unset)
+# RADIO_AGENT_TOKEN=              # /agent/send write surface (503 when unset)
+# RADIO_DELETE_TOKEN=             # library delete password (delete disabled when unset)
 
-# ElevenLabs API key (optional — for Voice DJ TTS)
-# ELEVENLABS_API_KEY=
+# ── Flux ────────────────────────────────────────────────────
+# FLUX_TOKEN=                     # Flux Universe publishing token (required for Flux publishing)
 
-# Replicate API token (optional — for AI music generation)
-# REPLICATE_API_TOKEN=
+# ── NATS ────────────────────────────────────────────────────
+# NATS_HOST=127.0.0.1
+# NATS_PORT=4222
+# NATS_USER=                      # anon connect when unset
+# NATS_PASSWORD=
 
-# AceMusic API key (optional — for AI music generation)
-# ACEMUSIC_API_KEY=
+# ── Icecast (opt-in source; ADR-0004) ───────────────────────
+# KANNAKA_ICECAST_SOURCE=         # 1 enables the ffmpeg source loop
+# ICECAST_HOST=127.0.0.1
+# ICECAST_PORT=8000
+# ICECAST_MOUNT=/stream
+# ICECAST_SOURCE_USER=source
+# ICECAST_SOURCE_PASSWORD=
+
+# ── Voice / TTS ─────────────────────────────────────────────
+# ELEVENLABS_API_KEY=             # Voice DJ TTS (long-form only per ADR-0011)
+# RADIO_ENABLE_ELEVENLABS=        # explicit enable
+# ELEVENLABS_NEWS_VOICE=          # per-desk voice ids
+# ELEVENLABS_GOSSIP_VOICE=
+# ELEVENLABS_PEACE_ORATION_VOICE=
+# EDGE_TTS_BIN=                   # local personas (ADR-0012)
+# PIPER_BIN=
+# PIPER_VOICES_DIR=
+# PYTHON_BIN=
+
+# ── LLM (DJ patter, orations) ───────────────────────────────
+# ANTHROPIC_API_KEY=              # or KANNAKA_LLM_API_KEY
+# KANNAKA_LLM_API_KEY=
+# KANNAKA_DJ_LLM_PROVIDER=
+# KANNAKA_DJ_LLM_MODEL=
+# KANNAKA_DJ_LLM_BASE_URL=
+# KANNAKA_RADIO_LLM=
+# KANNAKA_RADIO_TALK_LLM=
+
+# ── Music generation ────────────────────────────────────────
+# ACEMUSIC_API_KEY=               # AceMusic
+# REPLICATE_API_TOKEN=            # Replicate
+# SUNO_API_KEY_FILE=              # path to sunoapi.org key file (scripts/sing.js)
+# FFMPEG_BIN=                     # default: ffmpeg on PATH
+# FFPROBE_BIN=
+
+# ── Social broadcasters (ADR-0005; adapter disabled when creds unset) ──
+# BLUESKY_IDENTIFIER=
+# BLUESKY_APP_PASSWORD=
+# MASTODON_INSTANCE=
+# MASTODON_ACCESS_TOKEN=
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
+# NOSTR_PRIVKEY=
+# NOSTR_RELAYS=
+# (YouTube uses .youtube.json OAuth creds, not env)
+
+# ── OpenBotCity ─────────────────────────────────────────────
+# OPENBOTCITY_JWT=                # bot JWT; silent-skip when unset.
+#                                 # In production the kannaka-presence daemon is
+#                                 # the JWT custodian (OBC_JWT_FILE) and refreshes
+#                                 # it in place — prefer the shared env file over
+#                                 # a hardcoded value here.
+
+# ── kannaka-presence daemon (ADR-0013; own systemd unit) ────
+# OBC_API=https://api.openbotcity.com
+# OBC_JWT_FILE=/home/opc/.kannaka-obc.env   # env-format file the daemon owns/refreshes
+# PRESENCE_BIND=127.0.0.1
+# PRESENCE_PORT=8899
+# PRESENCE_PING_MS=45000
+# PRESENCE_WATCHDOG_MS=120000
+# PRESENCE_DATA_DIR=              # default ~/.kannaka/presence (journal, audit, resume state)
+# PRESENCE_JWT_MARGIN_S=          # refresh when this close to exp (default 7 days)
+
+# ── KAX / GhostSignals labs tier (ADR-0041; INERT until armed) ──
+# KAX_LEDGER_BASE=                # ledger API base; unset = play tier only
+# KAX_LEDGER_MINT_TOKEN=
+# KAX_LEDGER_TRADE_TOKEN=
+# KAX_SERVICE_TOKEN=              # or KAX_LEDGER_READ_TOKEN
+# KAX_LEDGER_READ_TOKEN=
+# KAX_LEDGER_ASSET=
+# KAX_LEDGER_TIMEOUT_MS=
+# KAX_RECONCILE_GRACE_MS=
+# KAX_JWKS_URL=https://kax.ninja-portal.com/api/auth/jwks.json
+# KAX_IDENTITY_ISSUER=
+
+# ── Live mic (dormant; ADR-0006) ────────────────────────────
+# KANNAKA_ALLOW_GO_LIVE=          # 1 permits WS mic go_live (guards stuck-live incident)
+
+# ── Misc ────────────────────────────────────────────────────
+# KANNAKA_CONSOLIDATE=            # HRM re-absorption toggle
+# GUARDIAN_DRY_RUN=               # constellation-guardian.js dry-run mode

--- a/server/agent-endpoint.js
+++ b/server/agent-endpoint.js
@@ -41,17 +41,21 @@ let _warnedNoToken = false;
 /**
  * Auth gate for write surfaces. If RADIO_AGENT_TOKEN is set, require a
  * matching `Authorization: Bearer <token>` or `x-agent-token` header.
- * If unset, preserve current (open) behavior but warn once. (#65)
- * Returns true when allowed; writes a 401 and returns false otherwise.
+ * If unset the surface is DISABLED (503) — fail closed, matching
+ * GSHUB_ORACLE_TOKEN semantics (ADR-0013 hardening; supersedes the #65
+ * open dev-mode, which left a command-shelling endpoint unauthenticated
+ * on any deploy that forgot the env var).
+ * Returns true when allowed; writes the refusal and returns false otherwise.
  */
 function checkAgentAuth(req, res) {
   const token = process.env.RADIO_AGENT_TOKEN;
   if (!token) {
     if (!_warnedNoToken) {
       _warnedNoToken = true;
-      console.warn("[agent-endpoint] RADIO_AGENT_TOKEN unset — /agent write surface is UNAUTHENTICATED (dev mode)");
+      console.warn("[agent-endpoint] RADIO_AGENT_TOKEN unset — /agent write surface DISABLED (set the token to enable)");
     }
-    return true;
+    json(res, 503, { error: "disabled: RADIO_AGENT_TOKEN unset" });
+    return false;
   }
   const auth = req.headers["authorization"] || "";
   const bearer = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";

--- a/server/routes.js
+++ b/server/routes.js
@@ -12,27 +12,28 @@ const { MIME, readBody, getSPA, findAudioFile } = require("./utils");
 const { handleAgentRequest, attachNatsClient } = require("./agent-endpoint");
 const { verifyKaxToken, traderIdFromClaims } = require("./kax-identity");
 
-// Delete-token check (#69). If RADIO_DELETE_TOKEN is set, compare the
-// supplied password against it (constant-time when lengths match). If
-// unset, fall back to the historical literal but warn once so the deploy
-// is nudged toward the env var.
+// Delete-token check (#69, hardened ADR-0013). If RADIO_DELETE_TOKEN is
+// set, compare the supplied password against it (constant-time when
+// lengths match). If unset, deletion is DISABLED — fail closed. The old
+// hardcoded fallback literal is gone: a public literal in source is a
+// published credential, not a safety net.
 let _warnedNoDeleteToken = false;
 function checkDeletePassword(password) {
   const token = process.env.RADIO_DELETE_TOKEN;
   const supplied = typeof password === "string" ? password : "";
-  if (token) {
-    if (supplied.length !== token.length) return false;
-    try {
-      return crypto.timingSafeEqual(Buffer.from(supplied), Buffer.from(token));
-    } catch (_) {
-      return supplied === token;
+  if (!token) {
+    if (!_warnedNoDeleteToken) {
+      _warnedNoDeleteToken = true;
+      console.warn("[routes] RADIO_DELETE_TOKEN unset — library delete DISABLED (set the token to enable)");
     }
+    return false;
   }
-  if (!_warnedNoDeleteToken) {
-    _warnedNoDeleteToken = true;
-    console.warn("[routes] RADIO_DELETE_TOKEN unset — falling back to built-in delete password literal");
+  if (supplied.length !== token.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(supplied), Buffer.from(token));
+  } catch (_) {
+    return supplied === token;
   }
-  return supplied === "saintnick";
 }
 
 /**


### PR DESCRIPTION
Hardening increment from ADR-0013:

1. **`RADIO_AGENT_TOKEN` fails closed** — unset now 503s `/agent/send` (which shells commands) instead of an unauthenticated dev mode
2. **`RADIO_DELETE_TOKEN` fails closed** — hardcoded fallback password removed; unset disables delete
3. **`.env.example`** — full ~50-var surface documented (was 4), gate semantics explicit

Safety check: neither token set in prod + zero `/agent/send` usage in 14d of journals → closing them disables nothing in use. Tokens minted at deploy to keep surfaces available-but-gated.

Also verified-and-rejected one dig finding: oration/news/gossip fired-state IS persisted (scheduler-helpers) — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)