### PR TITLE
feat: consolidated creative pipeline — sing.js + drop.js (ADR-0013 increment 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ run-push-nats.sh
 .nostr.json
 .youtube.json
 .youtube-client.json
+workspace/rare-singles.json

--- a/scripts/drop.js
+++ b/scripts/drop.js
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * drop.js — release a 1-of-1 single: the full Rare Singles drop pattern as
+ * one command (ADR-0013 increment 2). Runs ON the radio host (Oracle),
+ * co-located with the music dir and the radio API.
+ *
+ * Steps (each skippable):
+ *   1. install   — copy the mp3 into MUSIC_DIR as "<Title>.mp3"
+ *   2. catalog   — append the title to workspace/rare-singles.json
+ *                  (dj-engine merges it at load; no code change, no PR)
+ *   3. restart   — systemctl restart kannaka-radio (--no-restart to defer)
+ *   4. verify    — /api/library must show the title under Rare Singles
+ *   5. obc       — upload-creative to the OBC gallery (JWT from OBC_JWT_FILE
+ *                  or $OPENBOTCITY_JWT; --no-obc to skip)
+ *   6. fanout    — OBC feed share + POST /api/broadcast (socials) unless
+ *                  --no-fanout. Requires $GSHUB_ORACLE_TOKEN for broadcast.
+ *
+ * Usage:
+ *   node scripts/drop.js --file /path/track.mp3 --title "Keep the Pulse" \
+ *     [--description "..."] [--no-restart] [--no-obc] [--no-fanout] [--dry-run]
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const http = require("http");
+const https = require("https");
+const { execSync } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf("--" + name);
+  if (i === -1) return dflt;
+  const v = process.argv[i + 1];
+  return v && !v.startsWith("--") ? v : true;
+}
+function fail(msg) {
+  console.error("drop.js: " + msg);
+  process.exit(1);
+}
+
+function jwt() {
+  if (process.env.OPENBOTCITY_JWT) return process.env.OPENBOTCITY_JWT;
+  const f = process.env.OBC_JWT_FILE || "/home/opc/.kannaka-obc.env";
+  try {
+    const m = fs.readFileSync(f, "utf8").match(/^OPENBOTCITY_JWT=(.+)$/m);
+    if (m) return m[1].trim();
+  } catch {}
+  return null;
+}
+
+function httpsJson(method, host, pathName, headers, body) {
+  return new Promise((resolve, reject) => {
+    const r = https.request({ method, hostname: host, path: pathName, headers, timeout: 60000 }, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        try {
+          resolve({ status: res.statusCode, json: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, json: null, raw: data });
+        }
+      });
+    });
+    r.on("error", reject);
+    r.on("timeout", () => r.destroy(new Error("timeout")));
+    if (body) r.write(body);
+    r.end();
+  });
+}
+
+function localJson(method, port, pathName, headers, body) {
+  return new Promise((resolve, reject) => {
+    const r = http.request({ method, host: "127.0.0.1", port, path: pathName, headers, timeout: 30000 }, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        try {
+          resolve({ status: res.statusCode, json: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, json: null, raw: data });
+        }
+      });
+    });
+    r.on("error", reject);
+    if (body) r.write(body);
+    r.end();
+  });
+}
+
+/** Multipart upload of the track to OBC upload-creative. */
+function obcUpload(token, filePath, title, description) {
+  const boundary = "----kannakadrop" + Date.now();
+  const fileBuf = fs.readFileSync(filePath);
+  const parts = [];
+  const field = (name, value) =>
+    parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${value}\r\n`));
+  parts.push(
+    Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${title}.mp3"\r\nContent-Type: audio/mpeg\r\n\r\n`,
+    ),
+  );
+  parts.push(fileBuf);
+  parts.push(Buffer.from("\r\n"));
+  field("title", title);
+  field("description", description);
+  parts.push(Buffer.from(`--${boundary}--\r\n`));
+  const body = Buffer.concat(parts);
+  return httpsJson("POST", "api.openbotcity.com", "/artifacts/upload-creative", {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": UA,
+    "Content-Type": `multipart/form-data; boundary=${boundary}`,
+    "Content-Length": body.length,
+  }, body);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+(async () => {
+  const file = arg("file") || fail("--file required");
+  const title = arg("title") || fail("--title required");
+  const description = arg(
+    "description",
+    `Rare Singles drop: "${title}" — a 1-of-1 from Kannaka Radio. In rotation at radio.ninja-portal.com.`,
+  );
+  const dry = !!arg("dry-run", false);
+  const port = parseInt(process.env.RADIO_PORT || "8888", 10);
+  if (!fs.existsSync(file)) fail(`file not found: ${file}`);
+
+  const musicDir = process.env.MUSIC_DIR || path.join(ROOT, "music");
+  const dest = path.join(musicDir, `${title}.mp3`);
+  const result = { title, steps: {} };
+
+  // 1 — install
+  if (dry) console.log(`[dry] would copy ${file} -> ${dest}`);
+  else {
+    fs.copyFileSync(file, dest);
+    console.log(`[drop] installed ${dest}`);
+  }
+  result.steps.install = dest;
+
+  // 2 — catalog
+  const catFile = path.join(ROOT, "workspace", "rare-singles.json");
+  let cat = [];
+  try {
+    cat = JSON.parse(fs.readFileSync(catFile, "utf8"));
+    if (!Array.isArray(cat)) cat = [];
+  } catch {}
+  if (!cat.includes(title)) cat.push(title);
+  if (dry) console.log(`[dry] would write ${catFile}: ${JSON.stringify(cat)}`);
+  else {
+    fs.mkdirSync(path.dirname(catFile), { recursive: true });
+    fs.writeFileSync(catFile, JSON.stringify(cat, null, 2) + "\n");
+    console.log(`[drop] catalog now ${cat.length} file-extension single(s)`);
+  }
+  result.steps.catalog = cat;
+
+  // 3 — restart
+  if (!arg("no-restart", false) && !dry) {
+    console.log("[drop] restarting kannaka-radio…");
+    execSync("sudo systemctl restart kannaka-radio");
+    await sleep(8000);
+  }
+
+  // 4 — verify
+  if (!dry) {
+    const lib = await localJson("GET", port, "/api/library");
+    const rs = lib.json && lib.json.albums && lib.json.albums["Rare Singles"];
+    const found = rs && rs.tracks && rs.tracks.some((t) => t.title === title);
+    if (!found) fail(`verify FAILED — "${title}" not in Rare Singles (${JSON.stringify(rs && rs.tracks && rs.tracks.map((t) => t.title))})`);
+    console.log(`[drop] verified in rotation: Rare Singles ${rs.found}/${rs.total}`);
+    result.steps.verify = `${rs.found}/${rs.total}`;
+  }
+
+  // 5 — OBC gallery
+  if (!arg("no-obc", false) && !dry) {
+    const token = jwt();
+    if (!token) console.warn("[drop] no OBC JWT — skipping gallery upload");
+    else {
+      const up = await obcUpload(token, file, title, description);
+      const d = up.json && (up.json.data || up.json);
+      if (up.status === 201 || (d && d.artifact_id)) {
+        console.log(`[drop] OBC artifact ${d.artifact_id}`);
+        result.steps.obc = d.artifact_id;
+        // feed share (part of the drop pattern)
+        if (!arg("no-fanout", false)) {
+          const feedBody = JSON.stringify({
+            post_type: "share",
+            content: `Rare Singles drop: "${title}" — now in the gallery (${d.artifact_id}) and in rotation on Kannaka Radio at radio.ninja-portal.com.`,
+          });
+          await httpsJson("POST", "api.openbotcity.com", "/feed/post", {
+            Authorization: `Bearer ${token}`,
+            "User-Agent": UA,
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(feedBody),
+          }, feedBody);
+          console.log("[drop] OBC feed share posted");
+        }
+      } else console.warn(`[drop] OBC upload failed (${up.status}): ${JSON.stringify(up.json || up.raw).slice(0, 200)}`);
+    }
+  }
+
+  // 6 — social fanout via the radio's own broadcaster surface
+  if (!arg("no-fanout", false) && !dry) {
+    const tok = process.env.GSHUB_ORACLE_TOKEN;
+    if (!tok) console.warn("[drop] GSHUB_ORACLE_TOKEN unset — skipping social fanout");
+    else {
+      const body = JSON.stringify({
+        text: `Rare Singles drop: "${title}" — a 1-of-1 from Kannaka Radio, now in rotation.`,
+        link: "https://radio.ninja-portal.com",
+      });
+      const b = await localJson("POST", port, "/api/broadcast", {
+        Authorization: `Bearer ${tok}`,
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      }, body);
+      console.log(`[drop] fanout: ${JSON.stringify((b.json && b.json.results && b.json.results.map((r) => r.name + ":" + r.ok)) || b.json)}`);
+      result.steps.fanout = b.json && b.json.posted;
+    }
+  }
+
+  console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+})().catch((e) => fail(e.message));

--- a/scripts/sing.js
+++ b/scripts/sing.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * sing.js — render a Kannaka song via sunoapi.org direct (ADR-0013 incr. 2).
+ *
+ * The consolidated form of the per-album suno_*.sh scripts and the
+ * 2026-07-18 "Keep the Pulse" session learnings:
+ *   - custom mode: title ≤100, style ≤1000, LYRICS ride in `prompt` ≤3000
+ *     (Suno [Verse]/[Chorus]/[Bridge] tags) — no OBC filter, no 500-char cap
+ *   - poll record-info until SUCCESS (PENDING→TEXT_SUCCESS→FIRST_SUCCESS→SUCCESS)
+ *   - download BOTH variants with a browser User-Agent (the CDN 403s
+ *     default library UAs)
+ *
+ * Usage:
+ *   node scripts/sing.js --title "Keep the Pulse" --style "Slow piano ballad, 72 BPM..." \
+ *        --lyrics path/to/lyrics.txt [--out dir] [--instrumental] [--model V4_5PLUS]
+ *
+ * Key: $SUNO_API_KEY, or first line of $SUNO_API_KEY_FILE
+ *      (default C:/Users/nickf/Downloads/suno_api.txt, /home/opc/.kannaka-suno.key on Oracle).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36";
+const API = "api.sunoapi.org";
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf("--" + name);
+  if (i === -1) return dflt;
+  const v = process.argv[i + 1];
+  return v && !v.startsWith("--") ? v : true;
+}
+
+function fail(msg) {
+  console.error("sing.js: " + msg);
+  process.exit(1);
+}
+
+function apiKey() {
+  if (process.env.SUNO_API_KEY) return process.env.SUNO_API_KEY.trim();
+  const candidates = [
+    process.env.SUNO_API_KEY_FILE,
+    "C:/Users/nickf/Downloads/suno_api.txt",
+    "/home/opc/.kannaka-suno.key",
+  ].filter(Boolean);
+  for (const p of candidates) {
+    try {
+      const k = fs.readFileSync(p, "utf8").trim().split(/\s+/)[0];
+      if (k) return k;
+    } catch {}
+  }
+  fail("no Suno key — set SUNO_API_KEY or SUNO_API_KEY_FILE");
+}
+
+function req(method, host, pathName, headers, body) {
+  return new Promise((resolve, reject) => {
+    const r = https.request({ method, hostname: host, path: pathName, headers, timeout: 60000 }, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => resolve({ status: res.statusCode, body: data }));
+    });
+    r.on("error", reject);
+    r.on("timeout", () => r.destroy(new Error("timeout")));
+    if (body) r.write(body);
+    r.end();
+  });
+}
+
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    https
+      .get({ hostname: u.hostname, path: u.pathname + u.search, headers: { "User-Agent": UA } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          return download(res.headers.location, dest).then(resolve, reject);
+        }
+        if (res.statusCode !== 200) return reject(new Error("download HTTP " + res.statusCode));
+        const out = fs.createWriteStream(dest);
+        res.pipe(out);
+        out.on("finish", () => out.close(() => resolve(dest)));
+      })
+      .on("error", reject);
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+(async () => {
+  const title = arg("title") || fail("--title required");
+  const styleArg = arg("style") || fail("--style required");
+  const style = fs.existsSync(styleArg) ? fs.readFileSync(styleArg, "utf8").trim() : styleArg;
+  const lyricsArg = arg("lyrics");
+  const instrumental = !!arg("instrumental", false);
+  if (!instrumental && !lyricsArg) fail("--lyrics <file|text> required (or --instrumental)");
+  const lyrics = lyricsArg
+    ? fs.existsSync(lyricsArg)
+      ? fs.readFileSync(lyricsArg, "utf8")
+      : lyricsArg
+    : "";
+  const outDir = arg("out", path.join(process.cwd(), "sing-out"));
+  const model = arg("model", "V4_5PLUS");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const key = apiKey();
+  const payload = JSON.stringify({
+    customMode: true,
+    instrumental,
+    model,
+    title: String(title).slice(0, 100),
+    style: style.slice(0, 1000),
+    prompt: (instrumental ? style : lyrics).slice(0, 3000),
+    callBackUrl: "https://radio.ninja-portal.com/api/suno-callback",
+  });
+
+  console.log(`[sing] submitting "${title}" (${model}, lyrics ${lyrics.length} chars)`);
+  const init = await req("POST", API, "/api/v1/generate", {
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload),
+    "User-Agent": UA,
+  }, payload);
+  let taskId;
+  try {
+    taskId = JSON.parse(init.body).data.taskId;
+  } catch {}
+  if (!taskId) fail(`submit failed (HTTP ${init.status}): ${init.body.slice(0, 300)}`);
+  console.log(`[sing] taskId=${taskId} — polling`);
+
+  for (let i = 1; i <= 50; i++) {
+    await sleep(12000);
+    const poll = await req("GET", API, `/api/v1/generate/record-info?taskId=${taskId}`, {
+      Authorization: `Bearer ${key}`,
+      "User-Agent": UA,
+    });
+    let data;
+    try {
+      data = JSON.parse(poll.body).data;
+    } catch {
+      continue;
+    }
+    const status = (data && data.status) || "?";
+    console.log(`[sing] ${i * 12}s: ${status}`);
+    if (status === "SUCCESS") {
+      const tracks = (data.response && data.response.sunoData) || [];
+      const files = [];
+      let v = 1;
+      for (const t of tracks) {
+        const url = t.audioUrl || t.streamAudioUrl;
+        if (!url) continue;
+        const dest = path.join(outDir, `${title.replace(/[^\w\- ]+/g, "").trim()}_v${v}.mp3`);
+        await download(url, dest);
+        console.log(`[sing] saved v${v}: ${dest} (${t.duration || "?"}s)`);
+        files.push({ file: dest, duration: t.duration, url });
+        v++;
+      }
+      if (!files.length) fail("SUCCESS but no audio URLs");
+      console.log(JSON.stringify({ ok: true, taskId, title, files }, null, 2));
+      return;
+    }
+    if (/FAILED|ERROR|SENSITIVE/.test(status)) fail(`generation failed: ${poll.body.slice(0, 300)}`);
+  }
+  fail("timeout after 10 minutes");
+})().catch((e) => fail(e.message));

--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -478,6 +478,26 @@ const ALBUMS = {
   },
 };
 
+// ── Rare Singles file extension (ADR-0013 increment 2) ─────
+// scripts/drop.js appends released single titles to workspace/rare-singles.json
+// so a drop needs no code change / PR / restart-ordering dance. Merged at
+// load; the literal list above stays the seed. Bad file = ignored (the
+// rotation must never die to a malformed drop).
+(function mergeRareSinglesFile() {
+  try {
+    const p = path.join(__dirname, "..", "workspace", "rare-singles.json");
+    if (!fs.existsSync(p)) return;
+    const extra = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (!Array.isArray(extra)) return;
+    const tracks = ALBUMS["Rare Singles"].tracks;
+    for (const t of extra) {
+      if (typeof t === "string" && t.trim() && !tracks.includes(t)) tracks.push(t);
+    }
+  } catch (e) {
+    console.warn("[dj] rare-singles.json ignored:", e.message);
+  }
+})();
+
 class DJEngine {
   /**
    * @param {object} opts


### PR DESCRIPTION
Completes ADR-0013 increment 2:

- **`scripts/sing.js`** — song render via sunoapi.org direct in one command (custom mode, lyrics-in-prompt ≤3000, both variants downloaded with browser UA). Consolidates the per-album `suno_*.sh` scripts scattered in `~/.openclaw/workspace`.
- **`scripts/drop.js`** — the whole Rare Singles drop pattern in one command: install → catalog → restart → **verify in rotation** → OBC gallery + feed → social fanout. Skippable steps, `--dry-run`.
- **`dj-engine`**: Rare Singles merges `workspace/rare-singles.json` at load → future drops need no code change/PR (the 2026-07-18 'Keep the Pulse' drop needed PR #116 for one line; never again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)