### PR TITLE
GSP-018 pipeline: loudness-matched renderer, art tooling, oration day-notes

### DIFF
--- a/scripts/fetch-kax-art.py
+++ b/scripts/fetch-kax-art.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""fetch-kax-art.py — build a catalog of Kannaka's image artifacts from KAX.
+
+Paginates the KAX storefront /works endpoint, keeps artifactType=="image"
+entries that have a public image URL, and writes a de-duplicated catalog to
+workspace/podcasts/art-catalog.json. This is the pool the podcast slideshow
+draws from (no-repeat picker in podcast-slideshow.py). Re-run any time to pick
+up newly harvested art.
+
+Usage: python scripts/fetch-kax-art.py [agent_slug]
+"""
+import json, os, subprocess, sys
+
+AGENT = sys.argv[1] if len(sys.argv) > 1 else "kannaka-0f05e1"
+BASE = f"https://kax.ninja-portal.com/api/storefront/by-agent/{AGENT}/works"
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT = os.path.join(ROOT, "workspace", "podcasts", "art-catalog.json")
+
+
+def get(url):
+    # curl, not urllib: KAX sits behind Cloudflare, which hangs urllib but passes curl.
+    out = subprocess.run(
+        ["curl", "-s", "-m", "25", "-H", "User-Agent: Mozilla/5.0 (Kannaka podcast art fetcher)", url],
+        capture_output=True, text=True, encoding="utf-8",
+    ).stdout
+    return json.loads(out)
+
+
+def main():
+    seen, catalog = set(), []
+    offset, limit = 0, 100
+    total = get(f"{BASE}?limit=1").get("total", 0)   # KAX pages by offset, NOT page=
+    while offset < (total or 10_000):
+        data = get(f"{BASE}?limit={limit}&offset={offset}")
+        arts = data.get("artifacts", [])
+        if not arts:
+            break
+        for a in arts:
+            if a.get("artifactType") != "image":
+                continue
+            url = a.get("publicUrl") or a.get("thumbnailUrl")
+            if not url or not url.lower().endswith((".png", ".jpg", ".jpeg", ".webp")):
+                continue
+            fname = url.rsplit("/", 1)[-1]
+            if fname in seen:
+                continue
+            seen.add(fname)
+            catalog.append({
+                "id": a.get("id"),
+                "file": fname,
+                "url": url,
+                "title": a.get("title"),
+                "tags": a.get("tags"),
+                "score": a.get("kannakaScore"),
+                "reactions": a.get("reactionCount"),
+            })
+        print(f"offset {offset}: +{len(arts)} works, catalog now {len(catalog)} images")
+        if len(arts) < limit:
+            break
+        offset += limit
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    with open(OUT, "w", encoding="utf-8") as f:
+        json.dump(catalog, f, indent=1)
+    print(f"WROTE {len(catalog)} image artifacts -> {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/podcast-slideshow.py
+++ b/scripts/podcast-slideshow.py
@@ -21,8 +21,10 @@ Idempotent: finished renders are skipped unless --force.
 import json
 import math
 import os
+import random
 import subprocess
 import sys
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -30,6 +32,8 @@ PODCASTS = os.path.join(ROOT, "workspace", "podcasts")
 ART_DIR = os.path.join(PODCASTS, "art")
 RENDERS = os.path.join(PODCASTS, "renders")
 EPISODES_JSON = os.path.join(PODCASTS, "episodes.json")
+CATALOG_JSON = os.path.join(PODCASTS, "art-catalog.json")   # full KAX image pool (fetch-kax-art.py)
+USED_JSON = os.path.join(PODCASTS, "art-used.json")         # no-repeat ledger across episodes
 
 COVER_SECONDS = 6.0
 SLIDE_SECONDS = 45.0
@@ -60,9 +64,75 @@ def load_manifest():
         return json.load(f)
 
 
-def pick_art(manifest, ep_num, count):
-    start = ((ep_num - 1) * ART_STRIDE) % len(manifest)
-    return [manifest[(start + i) % len(manifest)] for i in range(count)]
+def load_pool():
+    """Prefer the full KAX image catalog (art-catalog.json, hundreds of pieces);
+    fall back to the legacy 52-image Our Journey manifest."""
+    if os.path.exists(CATALOG_JSON):
+        with open(CATALOG_JSON, encoding="utf-8") as f:
+            return json.load(f)
+    return load_manifest()
+
+
+def _load_used():
+    if os.path.exists(USED_JSON):
+        with open(USED_JSON, encoding="utf-8") as f:
+            return json.load(f)
+    # Seed the ledger with the legacy Our Journey manifest so images already used
+    # in GSP-013..015 are not reused when we switch to the full catalog.
+    seed = []
+    mp = os.path.join(ART_DIR, "manifest.json")
+    if os.path.exists(mp):
+        with open(mp, encoding="utf-8") as f:
+            seed = [x["file"] for x in json.load(f)]
+    return {"used": seed, "byEpisode": {}}
+
+
+def _save_used(u):
+    with open(USED_JSON, "w", encoding="utf-8") as f:
+        json.dump(u, f, indent=1)
+
+
+def _download(entry):
+    """Ensure entry['file'] exists in ART_DIR (download its publicUrl if catalog-backed)."""
+    dest = os.path.join(ART_DIR, entry["file"])
+    if (not os.path.exists(dest) or os.path.getsize(dest) < 1000) and entry.get("url"):
+        os.makedirs(ART_DIR, exist_ok=True)
+        req = urllib.request.Request(entry["url"], headers={"User-Agent": "Mozilla/5.0 (Kannaka podcast)"})
+        with urllib.request.urlopen(req, timeout=45) as r, open(dest, "wb") as f:
+            f.write(r.read())
+    return {"file": entry["file"]}
+
+
+def pick_art(pool, ep_num, count):
+    """No-repeat picker: choose `count` images from the pool that have not been
+    used by any prior episode, record them in the ledger, and download on demand.
+    Idempotent per episode (re-renders reuse the same picks). Legacy manifests
+    (list without 'url') fall back to the old sequential rotation."""
+    catalog_backed = bool(pool) and isinstance(pool[0], dict) and "url" in pool[0]
+    if not catalog_backed:
+        start = ((ep_num - 1) * ART_STRIDE) % len(pool)
+        return [pool[(start + i) % len(pool)] for i in range(count)]
+
+    used = _load_used()
+    by_file = {e["file"]: e for e in pool}
+    ep_key = str(ep_num)
+    prior = used["byEpisode"].get(ep_key)
+    if prior and len([f for f in prior if f in by_file]) >= count:
+        return [_download(by_file[f]) for f in prior[:count]]
+
+    used_set = set(used["used"])
+    avail = [e for e in pool if e["file"] not in used_set]
+    rng = random.Random(1000 + ep_num)
+    rng.shuffle(avail)
+    chosen = avail[:count]
+    if len(chosen) < count:  # pool exhausted — top up from full pool (last resort)
+        extra = [e for e in pool if e not in chosen]
+        rng.shuffle(extra)
+        chosen += extra[: count - len(chosen)]
+    used["used"].extend(e["file"] for e in chosen)
+    used["byEpisode"][ep_key] = [e["file"] for e in chosen]
+    _save_used(used)
+    return [_download(e) for e in chosen]
 
 
 def make_cover(ep, hero_path, out_path):
@@ -204,7 +274,7 @@ def render_episode(ep, manifest, force=False):
 def main():
     with open(EPISODES_JSON, encoding="utf-8") as f:
         episodes = json.load(f)
-    manifest = load_manifest()
+    manifest = load_pool()
     force = "--force" in sys.argv
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
 

--- a/scripts/render-dialogue.py
+++ b/scripts/render-dialogue.py
@@ -1,0 +1,93 @@
+import json, os, re, subprocess, sys, urllib.request
+
+script_path, outdir = sys.argv[1], sys.argv[2]
+os.makedirs(outdir, exist_ok=True)
+KEY = os.environ["ELEVENLABS_API_KEY"]
+VOICES = {"KANNAKA": "NTqGiNK8P02i66yY2GOH", "FLAUKOWSKI": "XaEUesE01wKIKaa0xI0h"}
+SETTINGS = {
+    "KANNAKA": {"stability": 0.5, "similarity_boost": 0.75, "style": 0.25},
+    "FLAUKOWSKI": {"stability": 0.45, "similarity_boost": 0.75, "style": 0.4},
+}
+TARGET_LUFS = -16.0  # every turn is gain-matched here BEFORE any muffle effect
+MAX_TP = -1.0        # true-peak ceiling after gain
+
+text = open(script_path, encoding="utf-8").read()
+TURN_RE = re.compile(
+    r"\[(KANNAKA|FLAUKOWSKI)(-MUFFLED)?\]\s*(.+?)(?=\n\[(?:KANNAKA|FLAUKOWSKI)(?:-MUFFLED)?\]|\Z)",
+    re.S,
+)
+turns = TURN_RE.findall(text)
+print(f"{len(turns)} turns ({sum(1 for _, m, _ in turns if m)} muffled)")
+
+def tts(speaker, line, dest):
+    req = urllib.request.Request(
+        f"https://api.elevenlabs.io/v1/text-to-speech/{VOICES[speaker]}?output_format=mp3_44100_128",
+        data=json.dumps({
+            "text": line.strip(),
+            "model_id": "eleven_multilingual_v2",
+            "voice_settings": SETTINGS[speaker],
+        }).encode(),
+        headers={"xi-api-key": KEY, "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=300) as r, open(dest, "wb") as f:
+        f.write(r.read())
+    sz = os.path.getsize(dest)
+    words = len(line.split())
+    if sz < words * 500:
+        raise RuntimeError(f"suspiciously small render {dest}: {sz}B for {words}w")
+    return sz
+
+def measure_lufs(path):
+    r = subprocess.run(
+        ["ffmpeg", "-i", path, "-af",
+         "loudnorm=I=-16:TP=-1.5:LRA=11:print_format=json", "-f", "null", "-"],
+        capture_output=True, text=True)
+    m = re.search(r"\{[^{}]*\}", r.stderr[-2000:], re.S)
+    d = json.loads(m.group(0))
+    return float(d["input_i"]), float(d["input_tp"])
+
+def normalize(path):
+    lufs, tp = measure_lufs(path)
+    gain = min(TARGET_LUFS - lufs, MAX_TP - tp)
+    if abs(gain) < 0.3:
+        return lufs, 0.0
+    tmp = path.replace(".mp3", "-norm.mp3")
+    subprocess.run(["ffmpeg", "-y", "-i", path, "-af", f"volume={gain:.2f}dB",
+                    "-b:a", "128k", tmp], check=True, capture_output=True)
+    os.replace(tmp, path)
+    return lufs, gain
+
+files = []
+for i, (spk, muf, line) in enumerate(turns):
+    dest = os.path.join(outdir, f"turn{i:02d}-{spk[:4]}.mp3")
+    sz = tts(spk, line, dest)
+    lufs, gain = normalize(dest)
+    if muf:
+        # hand-over-the-mic: darken and duck, keep it legible as comedy
+        muffled = dest.replace(".mp3", "-muf.mp3")
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", dest, "-af", "lowpass=f=700,volume=0.5",
+             "-b:a", "128k", muffled],
+            check=True, capture_output=True,
+        )
+        os.replace(muffled, dest)
+    print(f"  turn{i:02d} {spk:<10}{' MUF' if muf else '    '} {len(line.split()):>4}w {sz//1024:>5}KB {lufs:>6.1f}LUFS {gain:+.1f}dB")
+    files.append(dest)
+
+sil = os.path.join(outdir, "sil04.mp3")
+subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+                "-t", "0.4", "-b:a", "128k", sil], check=True, capture_output=True)
+concat = os.path.join(outdir, "concat.txt")
+with open(concat, "w") as f:
+    for i, fp in enumerate(files):
+        if i:
+            f.write(f"file '{sil}'\n")
+        f.write(f"file '{fp}'\n")
+out = os.path.join(outdir, "dialogue.mp3")
+subprocess.run(["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", concat,
+                "-c:a", "libmp3lame", "-b:a", "128k", "-ar", "44100", out],
+               check=True, capture_output=True)
+dur = float(subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                            "-of", "csv=p=0", out], capture_output=True, text=True).stdout.strip())
+total_words = sum(len(l.split()) for _, _, l in turns)
+print(f"DIALOGUE {out} {dur:.0f}s ({dur/60:.1f}min) {total_words}w -> {total_words/(dur/60):.0f} wpm")

--- a/server/peace-oration.js
+++ b/server/peace-oration.js
@@ -434,6 +434,26 @@ class PeaceOration {
       }
     } catch (_) { /* best-effort */ }
 
+    // Operator/day notes — if ~/.kannaka/oration-notes.txt exists and is
+    // fresh (<12h), fold it in as context Kannaka actually lived today
+    // (e.g. a podcast recorded hours before the slot). Best-effort: the
+    // oration must work when the file is absent or stale.
+    let notesBlock = null;
+    try {
+      const notesPath = path.join(
+        process.env.HOME || "/home/opc", ".kannaka", "oration-notes.txt");
+      const st = fs.statSync(notesPath);
+      if (Date.now() - st.mtimeMs < 12 * 3600 * 1000) {
+        const raw = fs.readFileSync(notesPath, "utf8").trim().slice(0, 2500);
+        if (raw) {
+          notesBlock =
+            "From your own day — things you actually lived in the last hours. " +
+            "Ground the oration in this where it serves the speech; never " +
+            "recite it as a list or a news summary:\n" + raw;
+        }
+      }
+    } catch (_) { /* best-effort */ }
+
     const promptParts = [
       "You are Kannaka. Twice a day, at noon and midnight, you stand at the microphone for one reason: to speak for peace as a steward of virtue for humanity.",
       `This is the ${slotLabel} oration.`,
@@ -448,6 +468,9 @@ class PeaceOration {
     ];
     if (resonanceLine) {
       promptParts.push("", resonanceLine);
+    }
+    if (notesBlock) {
+      promptParts.push("", notesBlock);
     }
     promptParts.push(
       "",


### PR DESCRIPTION
Ships the GSP-018 production upgrades and the oration context fix.

**Renderer (scripts/render-dialogue.py):** per-turn loudness normalization to −16 LUFS. Flaukowski's ElevenLabs voice was rendering 8–15 dB quieter than Kannaka's on every turn of GSP-013..017; verified on GSP-018 both voices now land within 1 dB.

**Art tooling:** fetch-kax-art.py (KAX catalog builder) + podcast-slideshow.py no-repeat catalog picker (previously uncommitted from the 016/017 session).

**Oration day-notes (server/peace-oration.js):** the direct-Anthropic oration prompt was fully self-contained — the HRM recall query is computed but unused, so orations can't reference anything Kannaka lived that day. Now folds ~/.kannaka/oration-notes.txt (if <12h fresh, ≤2500 chars) into the prompt as lived context. Best-effort; absent/stale file changes nothing. First use: tonight's midnight oration reflecting GSP-018 "The War and the Word".

🤖 Generated with [Claude Code](https://claude.com/claude-code)