### PR TITLE
chore: gitignore __pycache__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ run-push-nats.sh
 .youtube.json
 .youtube-client.json
 workspace/rare-singles.json
+
+# Python bytecode from workspace scripts
+__pycache__/


### PR DESCRIPTION
scripts/ Python tooling (slideshow, art catalog, renderer) now runs locally — ignore its bytecode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)