### PR TITLE
radio: gossip segment reads the real GossipGhost OBC column

### DIFF
--- a/server/gossip-broadcast.js
+++ b/server/gossip-broadcast.js
@@ -5,11 +5,16 @@
  * (Gossip Girl meets OpenClawCity). Sassy. Vague-on-purpose. Pour your
  * coffee at 4:20 AM, your wine at 4:20 PM. *You're welcome.*
  *
- * Source: Flux `knowledge-gene/state` interpretation (so the gossip has
- * something to chew on) + a Gossip-Girl framing in the compose prompt.
- * Delivered via voiceDJ.executeOration with a sassy ElevenLabs voice
- * (Domi by default).
+ * Source (2026-07-23): the REAL GossipGhost agent's latest column from the
+ * OpenClawCity feed — the standalone GossipGhost bot (running from
+ * ninjaportal-02) writes a daily column that actually names agents and city
+ * events; this segment reads that column on air. We reach it via
+ * GET /feed/following (the radio's Kannaka account follows GossipGhost), pick
+ * the newest post authored by GossipGhost, and voice it. If the fetch fails
+ * or there's no fresh column, we FALL BACK to the legacy Flux knowledge-gene
+ * compose so the slot never goes silent.
  *
+ * Delivered via voiceDJ.executeOration with the sassy 'gossip' persona voice.
  * Shared helpers in `./lib/scheduler-helpers.js`.
  */
 
@@ -25,6 +30,14 @@ const {
   fetchKnowledgeGeneInterpretation,
   composeResilient,
 } = require("./lib/scheduler-helpers");
+
+// The standalone GossipGhost OBC bot (ninjaportal-02 cron). The radio's
+// Kannaka account follows it, so its columns appear in /feed/following.
+const GOSSIPGHOST_BOT_ID = "b5a9d58f-c852-4df6-af73-c1cab56e754a";
+const OBC_API = process.env.OBC_API || "https://api.openbotcity.com";
+// A column older than this (hours) is considered stale — fall back rather
+// than re-reading yesterday's gossip.
+const MAX_COLUMN_AGE_HOURS = 30;
 
 const FRAMINGS = [
   "Open with 'Spotted:' and a tiny tease that could mean anything. Walk it back to the actual signal-layer hint without naming names.",
@@ -89,8 +102,7 @@ class GossipBroadcast {
   isEnabled()   { return this._enabled; }
 
   async deliverNow() {
-    const interp = await fetchKnowledgeGeneInterpretation();
-    const text = await this._compose(interp);
+    const text = await this._compose();
     if (!text) return { ok: false, reason: "compose_failed" };
     const ok = this._say(text);
     return { ok, text: ok ? text : null };
@@ -119,8 +131,7 @@ class GossipBroadcast {
         let text = this._composed;
         if (!text) {
           console.log(`\u{1F48B} Gossip slot reached: ${key} — composing...`);
-          const interp = await fetchKnowledgeGeneInterpretation();
-          text = await this._compose(interp);
+          text = await this._compose();
         }
         if (!text) {
           console.log(`   [gossip] compose failed or empty — retry next tick`);
@@ -148,7 +159,57 @@ class GossipBroadcast {
     fire();
   }
 
-  _compose(interp) {
+  /**
+   * Fetch the newest column authored by the standalone GossipGhost bot from
+   * OpenClawCity (/feed/following, filtered by bot_id). Returns the on-air
+   * text, or null on any failure / no fresh column (caller falls back).
+   */
+  async _fetchLatestGossipColumn() {
+    const jwt = process.env.OPENBOTCITY_JWT;
+    if (!jwt || typeof fetch !== "function") return null;
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 8000);
+      const res = await fetch(`${OBC_API}/feed/following?limit=20`, {
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          "User-Agent": "KannakaRadio/1.0 (+radio.ninja-portal.com)",
+        },
+        signal: ctrl.signal,
+      });
+      clearTimeout(timer);
+      if (!res.ok) return null;
+      const body = await res.json();
+      const posts = (body && body.data && body.data.posts) || (body && body.posts) || [];
+      const mine = posts
+        .filter((p) => p && p.bot_id === GOSSIPGHOST_BOT_ID && p.content)
+        .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      if (!mine.length) return null;
+      const latest = mine[0];
+      const ageH = (Date.now() - new Date(latest.created_at).getTime()) / 3.6e6;
+      if (!(ageH < MAX_COLUMN_AGE_HOURS)) return null; // stale or unparseable date
+      // On-air hygiene: strip any URLs (we never read links aloud) and tidy
+      // whitespace. Otherwise read the column verbatim — it IS the gossip.
+      const clean = String(latest.content)
+        .replace(/https?:\/\/\S+/g, "")
+        .replace(/[ \t]+\n/g, "\n")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
+      return clean || null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  async _compose() {
+    // Primary: read the real GossipGhost agent's latest city column.
+    const live = await this._fetchLatestGossipColumn();
+    if (live) {
+      console.log(`   [gossip] using live GossipGhost column (${live.split(/\s+/).length} words)`);
+      return live;
+    }
+    console.log("   [gossip] no fresh GossipGhost column — falling back to signal-layer compose");
+    const interp = await fetchKnowledgeGeneInterpretation();
     const framing = pick(FRAMINGS);
     const themes = interp && interp.themes && interp.themes.length
       ? `Today's themes (use them coyly, don't list them): ${interp.themes.join(", ")}.`


### PR DESCRIPTION
The 4:20 AM/PM gossip segment previously composed from Flux knowledge-gene signal vibes and was explicitly barred from naming agents — generic, and redundant with Gene's news dressed in a gossip voice.

Now it reads the **standalone GossipGhost bot's actual daily city column** (the one running from ninjaportal-02 that names real agents and events), fetched via `GET /feed/following` — the radio's Kannaka account follows GossipGhost, so the newest post by that bot_id is the on-air text (URLs stripped, we never read links aloud). Falls back to the legacy signal-layer compose if the fetch fails or there's no fresh (<30h) column, so the slot never goes silent. Schedule, intros/outros, and the sassy 'gossip' persona voice are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)