### PR TITLE
fix(render): reach per-voice LUFS targets on peaky turns via limiter makeup

### DIFF
--- a/scripts/render-dialogue.py
+++ b/scripts/render-dialogue.py
@@ -50,21 +50,33 @@ def measure_lufs(path):
     return float(d["input_i"]), float(d["input_tp"])
 
 def normalize(path, speaker):
+    # Plain gain only while the true-peak ceiling allows it; peaky turns (most
+    # ElevenLabs output) take the full gain through a limiter instead. The old
+    # TP-capped plain gain left them 2-3 dB short of target and could invert
+    # the K/F balance (GSP-022 shipped F 0.8 dB quieter than K before makeup).
     lufs, tp = measure_lufs(path)
-    gain = min(TARGET_LUFS[speaker] - lufs, MAX_TP - tp)
-    if abs(gain) < 0.3:
-        return lufs, 0.0
+    needed = TARGET_LUFS[speaker] - lufs
+    if abs(needed) < 0.3:
+        return lufs, 0.0, lufs
+    if needed > 0 and needed > MAX_TP - tp:
+        af = (f"volume={needed:.2f}dB,alimiter=limit={10 ** (MAX_TP / 20):.3f}"
+              ":level=false:attack=5:release=50")
+    else:
+        af = f"volume={needed:.2f}dB"
     tmp = path.replace(".mp3", "-norm.mp3")
-    subprocess.run(["ffmpeg", "-y", "-i", path, "-af", f"volume={gain:.2f}dB",
+    subprocess.run(["ffmpeg", "-y", "-i", path, "-af", af,
                     "-b:a", "128k", tmp], check=True, capture_output=True)
     os.replace(tmp, path)
-    return lufs, gain
+    final, _ = measure_lufs(path)
+    return lufs, needed, final
 
 files = []
+finals = {}
 for i, (spk, muf, line) in enumerate(turns):
     dest = os.path.join(outdir, f"turn{i:02d}-{spk[:4]}.mp3")
     sz = tts(spk, line, dest)
-    lufs, gain = normalize(dest, spk)
+    lufs, gain, final = normalize(dest, spk)
+    finals.setdefault(spk, []).append(final)
     if muf:
         # hand-over-the-mic: darken and duck, keep it legible as comedy
         muffled = dest.replace(".mp3", "-muf.mp3")
@@ -74,8 +86,13 @@ for i, (spk, muf, line) in enumerate(turns):
             check=True, capture_output=True,
         )
         os.replace(muffled, dest)
-    print(f"  turn{i:02d} {spk:<10}{' MUF' if muf else '    '} {len(line.split()):>4}w {sz//1024:>5}KB {lufs:>6.1f}LUFS {gain:+.1f}dB")
+    print(f"  turn{i:02d} {spk:<10}{' MUF' if muf else '    '} {len(line.split()):>4}w {sz//1024:>5}KB {lufs:>6.1f}->{final:>6.1f}LUFS {gain:+.1f}dB")
     files.append(dest)
+
+for spk, vals in sorted(finals.items()):
+    avg = sum(vals) / len(vals)
+    off = "" if abs(avg - TARGET_LUFS[spk]) <= 0.5 else "  ** OFF TARGET **"
+    print(f"POST-NORM {spk}: {avg:.2f} LUFS avg over {len(vals)} turns (target {TARGET_LUFS[spk]}){off}")
 
 sil = os.path.join(outdir, "sil04.mp3")
 subprocess.run(["ffmpeg", "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",


### PR DESCRIPTION
## Problem

`normalize()` capped plain gain at true-peak headroom (`gain = min(needed, MAX_TP - tp)`). Peaky ElevenLabs turns — which is most of them — got silently short-changed 2–3 dB, and nothing verified the result. GSP-022's first render shipped the K/F balance **inverted**: Flaukowski −18.6 / Kannaka −17.8 post-norm despite the −15/−16 targets, exactly the too-quiet-Flaukowski failure the per-voice targets were added to prevent.

## Fix

- When needed gain exceeds TP headroom, apply the **full** gain through `alimiter` at the −1 dBTP ceiling instead of truncating it. Plain gain path unchanged when headroom allows (no limiter coloration).
- Re-measure every turn after processing; per-turn line now prints `raw->final` LUFS.
- Per-voice post-norm averages printed at the end with an `** OFF TARGET **` flag (>0.5 dB) so a bad balance is visible at render time instead of after Nick hears it.

## Verification

Synthetic fixtures exercising both paths (speech-shaped crest with clicks at −0.8 dBTP; low-peak quiet tone):

| fixture | old behavior would land | new path | final vs target |
|---|---|---|---|
| peaky (limiter path) | −19.8 (4.8 dB short) | +4.6 dB via limiter | −0.85 dB |
| gentle (plain path) | −15.0 | +31.6 dB plain | −0.45 dB |

Matches the manual limiter-backed makeup pass that corrected the shipped GSP-022 episode (final K −16.5 / F −15.7, Flaukowski correctly ~1 dB hotter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)