### PR TITLE
feat(broadcasters): image-media support in Mastodon + Nostr adapters

### DIFF
--- a/scripts/youtube-check.js
+++ b/scripts/youtube-check.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * youtube-check.js — verify the YouTube uploader OAuth is still live.
+ *
+ * The adapter's refresh token silently expires after ~7 days while the
+ * Google OAuth consent screen is in "Testing" publishing status (an
+ * unverified-app limitation). When that happens, uploads fail at token
+ * refresh with `invalid_grant` ("Token has been expired or revoked"),
+ * and — because the fan-out isolates per-adapter failures — nothing else
+ * alerts. Run this to detect it early:
+ *
+ *   node scripts/youtube-check.js
+ *
+ * Exit 0 = live (also prints channel stats); exit 1 = expired/misconfigured.
+ * Wire it into a cron / health probe so token expiry is visible, not silent.
+ *
+ * DURABLE FIX for the weekly expiry: in Google Cloud Console, publish the
+ * OAuth consent screen ("Testing" -> "In production"), then re-run
+ * scripts/youtube-grant.js once. Refresh tokens minted while the app is in
+ * production status do not auto-expire for the app owner.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { URL } = require("url");
+
+const CRED_PATH = path.join(path.resolve(__dirname, ".."), ".youtube.json");
+
+function postForm(url, form) {
+  const body = new URLSearchParams(form).toString();
+  return request(url, "POST", { "Content-Type": "application/x-www-form-urlencoded" }, body);
+}
+
+function getJson(url, accessToken) {
+  return request(url, "GET", { Authorization: `Bearer ${accessToken}` }, null);
+}
+
+function request(url, method, headers, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const opts = {
+      method,
+      hostname: u.hostname,
+      path: u.pathname + u.search,
+      headers: { ...headers },
+    };
+    if (body != null) opts.headers["Content-Length"] = Buffer.byteLength(body);
+    const req = https.request(opts, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        let parsed;
+        try { parsed = JSON.parse(text); } catch (_) { parsed = text; }
+        resolve({ status: res.statusCode, body: parsed });
+      });
+    });
+    req.on("error", reject);
+    if (body != null) req.write(body);
+    req.end();
+  });
+}
+
+async function main() {
+  if (!fs.existsSync(CRED_PATH)) {
+    console.error(`✗ ${CRED_PATH} not found — run: node scripts/youtube-grant.js`);
+    process.exit(1);
+  }
+  let c;
+  try { c = JSON.parse(fs.readFileSync(CRED_PATH, "utf8")); }
+  catch (e) { console.error(`✗ ${CRED_PATH} unreadable: ${e.message}`); process.exit(1); }
+  if (!c.client_id || !c.client_secret || !c.refresh_token) {
+    console.error("✗ .youtube.json is missing client_id / client_secret / refresh_token");
+    process.exit(1);
+  }
+
+  const tok = await postForm("https://oauth2.googleapis.com/token", {
+    client_id: c.client_id,
+    client_secret: c.client_secret,
+    refresh_token: c.refresh_token,
+    grant_type: "refresh_token",
+  });
+
+  if (tok.status !== 200 || !tok.body || !tok.body.access_token) {
+    const desc = tok.body && tok.body.error_description
+      ? tok.body.error_description
+      : (typeof tok.body === "string" ? tok.body.slice(0, 200) : JSON.stringify(tok.body).slice(0, 200));
+    console.error(`✗ OAUTH DEAD (${tok.status}): ${desc}`);
+    console.error("  Fix: publish the OAuth consent screen to production in Google Cloud Console,");
+    console.error("       then re-run: node scripts/youtube-grant.js");
+    process.exit(1);
+  }
+
+  console.log(`✓ OAUTH LIVE — access token acquired (expires_in=${tok.body.expires_in}s)`);
+
+  const ch = await getJson(
+    "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&mine=true",
+    tok.body.access_token,
+  );
+  const item = ch.body && ch.body.items && ch.body.items[0];
+  if (item) {
+    console.log(`  channel: "${item.snippet.title}" — subs ${item.statistics.subscriberCount}, videos ${item.statistics.videoCount}, views ${item.statistics.viewCount}`);
+  } else {
+    console.log(`  (channel stats unavailable: ${ch.status})`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`✗ ${e.message}`);
+  process.exit(1);
+});

--- a/scripts/youtube-grant.js
+++ b/scripts/youtube-grant.js
@@ -17,8 +17,15 @@
  *
  * After this runs once, scripts/post-track-announce.js (and any future
  * use of the YouTube adapter) just calls into the API using the saved
- * refresh token. You don't have to re-grant unless you revoke from
- * Google.
+ * refresh token.
+ *
+ * IMPORTANT — token expiry: while the Google OAuth consent screen is in
+ * "Testing" publishing status, refresh tokens auto-expire after ~7 days
+ * (an unverified-app limitation), and uploads then fail with
+ * `invalid_grant`. To stop the weekly expiry, publish the consent screen
+ * to "In production" in Google Cloud Console; refresh tokens minted in
+ * production status persist for the app owner. Run `node
+ * scripts/youtube-check.js` to verify the token is still live.
  *
  * Run:
  *   node scripts/youtube-grant.js

--- a/server/broadcasters/index.js
+++ b/server/broadcasters/index.js
@@ -51,6 +51,11 @@ function getEnabledBroadcasters(rootDir) {
  * @param {object} msg
  * @param {string} msg.text — the Kannaka-drafted body. Adapters may truncate.
  * @param {string} [msg.link] — URL to attach; adapters render per-platform.
+ * @param {object} [msg.image] — optional image `{ url, alt?, mime? }` (e.g. an
+ *   OBC gallery artifact). Mastodon fetches + uploads it as a media attachment;
+ *   Nostr appends the URL + a NIP-92 imeta tag. A failed media upload never
+ *   blocks the text post. Bluesky (pending client-lib blob support) and the
+ *   media-only YouTube adapter ignore it.
  * @param {object} [opts]
  * @param {string} [opts.rootDir] — radio root for credential lookup.
  * @returns {Promise<Array<{name, ok, url?, error?}>>}

--- a/server/broadcasters/mastodon-adapter.js
+++ b/server/broadcasters/mastodon-adapter.js
@@ -36,16 +36,31 @@ class MastodonAdapter {
     return !!(this._creds && this._creds.instance && this._creds.accessToken);
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     // Mastodon discovery is hashtag-driven (no algorithm — local + federated
     // timelines are pure hashtag streams). Drop the URL from the body
     // (penalty + character cost) and append 4-5 hashtags as a footer.
     const tags = tagsFor(topic, 5);
     const status = composeForFeed(text, tags, POST_MAX);
+
+    // Optional image (e.g. an OBC gallery artifact). Upload it first, then
+    // attach by id. A failed media upload must NOT sink the text post — log
+    // and continue without the attachment.
+    let mediaIds = null;
+    if (image && image.url) {
+      try {
+        const id = await this._uploadMedia(image);
+        if (id) mediaIds = [id];
+      } catch (e) {
+        process.stderr.write(`[mastodon] media upload failed: ${e.message}\n`);
+      }
+    }
+
     const url = new URL("/api/v1/statuses", this._creds.instance);
     const body = JSON.stringify({
       status,
       visibility: "public",
+      ...(mediaIds ? { media_ids: mediaIds } : {}),
       // Mastodon auto-detects URLs and renders them as links — no facets needed.
     });
     const opts = {
@@ -139,6 +154,112 @@ class MastodonAdapter {
       req.end();
     });
   }
+
+  /**
+   * Fetch an image URL and upload it to Mastodon's media endpoint, returning
+   * the attachment id (usable in media_ids immediately, even while the server
+   * is still processing). Throws on any failure so the caller can decide to
+   * post without the image.
+   */
+  async _uploadMedia(image) {
+    const { buf, mime } = await _fetchBytes(image.url);
+    const boundary = "kannaka-media-" + Math.random().toString(16).slice(2);
+    const filename = "art" + (mime === "image/png" ? ".png" : mime === "image/webp" ? ".webp" : ".jpg");
+    const parts = [
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+          `Content-Type: ${mime}\r\n\r\n`,
+        "utf8",
+      ),
+      buf,
+    ];
+    if (image.alt) {
+      parts.push(Buffer.from(
+        `\r\n--${boundary}\r\nContent-Disposition: form-data; name="description"\r\n\r\n${image.alt}`,
+        "utf8",
+      ));
+    }
+    parts.push(Buffer.from(`\r\n--${boundary}--\r\n`, "utf8"));
+    const body = Buffer.concat(parts);
+
+    const url = new URL("/api/v2/media", this._creds.instance);
+    const opts = {
+      method: "POST",
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || (url.protocol === "https:" ? 443 : 80),
+      path: url.pathname + url.search,
+      headers: {
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        Authorization: "Bearer " + this._creds.accessToken,
+        "Content-Length": body.length,
+        "User-Agent": "Kannaka-Radio/0.3 (https://radio.ninja-portal.com)",
+      },
+      timeout: 30000,
+    };
+    return new Promise((resolve, reject) => {
+      const lib = url.protocol === "https:" ? https : http;
+      const req = lib.request(opts, (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          // 200 = ready, 202 = accepted/processing; both return the id.
+          if (res.statusCode === 200 || res.statusCode === 202) {
+            try { resolve(JSON.parse(data).id); }
+            catch (e) { reject(new Error("bad media json: " + e.message)); }
+          } else {
+            reject(new Error(`media ${res.statusCode}: ${data.slice(0, 200)}`));
+          }
+        });
+      });
+      req.on("error", reject);
+      req.on("timeout", () => req.destroy(new Error("media upload timeout")));
+      req.write(body);
+      req.end();
+    });
+  }
+}
+
+/**
+ * GET a URL into a Buffer, following one level of redirect (image hosts like
+ * Supabase storage often 302 to a CDN). Resolves { buf, mime }.
+ */
+function _fetchBytes(rawUrl, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 3) return reject(new Error("too many redirects"));
+    const u = new URL(rawUrl);
+    const lib = u.protocol === "https:" ? https : http;
+    const req = lib.request(
+      {
+        method: "GET",
+        hostname: u.hostname,
+        port: u.port || (u.protocol === "https:" ? 443 : 80),
+        path: u.pathname + u.search,
+        headers: { "User-Agent": "Kannaka-Radio/0.3" },
+        timeout: 30000,
+      },
+      (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(_fetchBytes(new URL(res.headers.location, u).toString(), redirects + 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`fetch ${res.statusCode} for ${rawUrl}`));
+          return;
+        }
+        const mime = (res.headers["content-type"] || "image/jpeg").split(";")[0].trim();
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ buf: Buffer.concat(chunks), mime }));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("fetch timeout")));
+    req.end();
+  });
 }
 
 function _loadCreds(rootDir) {

--- a/server/broadcasters/nostr-adapter.js
+++ b/server/broadcasters/nostr-adapter.js
@@ -86,7 +86,7 @@ class NostrAdapter {
     return true;
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     if (!this.isEnabled()) return { ok: false, error: "not_configured" };
     const secp = _trySecp();
     const WS = _tryWS();
@@ -98,13 +98,21 @@ class NostrAdapter {
     const { tagsFor, renderNostrTags } = require("./discovery");
     const topicTags = tagsFor(topic, 5);
 
-    const content = _truncate((text || "").trim(), POST_MAX);
+    let content = _truncate((text || "").trim(), POST_MAX);
     const tags = [
       ...renderNostrTags(topicTags),
       // Optional reference tag — clients that DO surface refs (rare on
       // primary feeds) get the radio link, but it's not part of body.
       ...(link ? [["r", link]] : []),
     ];
+    // Optional image (e.g. an OBC gallery artifact): Nostr clients render a
+    // bare image URL inline, so append it to the body and advertise it via a
+    // NIP-92 `imeta` tag plus an `r` reference.
+    if (image && image.url) {
+      content = content + (content ? "\n\n" : "") + image.url;
+      tags.push(["imeta", `url ${image.url}`, ...(image.mime ? [`m ${image.mime}`] : [])]);
+      tags.push(["r", image.url]);
+    }
     const created_at = Math.floor(Date.now() / 1000);
 
     const privkey = _hexToBytes(this._creds.privkey);


### PR DESCRIPTION
The adapter half of ADR-0044 **A4** ("fan out gallery art"). The social adapters were text+link only, so OBC gallery artifacts couldn't fan out with the actual image. This adds an optional `image: { url, alt?, mime? }` field to the broadcaster interface.

- **mastodon-adapter** — fetches the image URL (redirect-following GET → Buffer) and uploads it to `/api/v2/media`, then attaches via `media_ids` on the status. A media failure is logged and the text post still goes (per-adapter isolation, non-fatal).
- **nostr-adapter** — appends the image URL to the note body (clients render bare image URLs inline) and advertises it via a NIP-92 `imeta` tag + `r` ref.
- **index.js** — documented the new `image` field on `broadcastPost`.

**Verified:** all three syntax-checked; the URL-fetch path pulls a real public gallery image (`image/png`, 264 KB) with correct content-type + redirect handling. Live posting needs a deploy (creds live on Oracle).

**Scoped follow-ups (not this PR):**
- **Bluesky** image support — needs `uploadBlob` + an `app.bsky.embed.images` embed in `server/bluesky.js` (shared client lib), so left separate.
- A **gallery → social caller** that actually passes `image` (nothing calls `broadcastPost` with an image yet — this PR is the capability, not the trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)