### PR TITLE
feat(broadcasters): A4 complete — image-media fanout (Bluesky+Mastodon+Nostr) + gallery caller

### DIFF
--- a/scripts/post-gallery-art.js
+++ b/scripts/post-gallery-art.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * post-gallery-art.js — fan out a recent OBC gallery IMAGE artifact to the
+ * social channels (Bluesky / Mastodon / Nostr) WITH the actual image, using the
+ * broadcaster adapters' new `image` support.
+ *
+ * One post per run, newest-unposted first, deduped against a state file so a
+ * cron doesn't repost. Fully opt-in: does nothing unless OPENBOTCITY_JWT is set
+ * and at least one social adapter is configured.
+ *
+ * By default only Kannaka's OWN artifacts are fanned out — set
+ * KANNAKA_OBC_BOT_ID to Kannaka's creator_bot_id to enforce that. Without it,
+ * any image artifact is eligible (always attributed "by <creator>"); set
+ * GALLERY_ART_ALLOW_ALL=1 to acknowledge that on purpose.
+ *
+ *   OPENBOTCITY_JWT=... node scripts/post-gallery-art.js
+ *
+ * Suggested cron: a few times a day. State: .gallery-art-posted.json (root, or
+ * KANNAKA_STATE_DIR).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { OpenBotCityClient } = require("../server/openbotcity");
+const { broadcastPost } = require("../server/broadcasters");
+
+const ROOT = path.resolve(__dirname, "..");
+const STATE = path.join(process.env.KANNAKA_STATE_DIR || ROOT, ".gallery-art-posted.json");
+const KANNAKA_BOT_ID = process.env.KANNAKA_OBC_BOT_ID || null;
+const ALLOW_ALL = process.env.GALLERY_ART_ALLOW_ALL === "1";
+
+function loadPosted() {
+  try { return new Set(JSON.parse(fs.readFileSync(STATE, "utf8"))); }
+  catch { return new Set(); }
+}
+function savePosted(set) {
+  // Keep the last 500 ids — plenty to dedupe against, bounded on disk.
+  try { fs.writeFileSync(STATE, JSON.stringify([...set].slice(-500))); }
+  catch (e) { process.stderr.write(`[gallery-art] state write failed: ${e.message}\n`); }
+}
+
+function creatorId(a) {
+  return a.creator_bot_id || (a.creator && a.creator.id) || null;
+}
+function creatorName(a) {
+  return (a.creator && (a.creator.display_name || a.creator.slug)) || null;
+}
+
+function caption(a) {
+  const title = String(a.title || "Untitled").trim();
+  const by = creatorName(a) ? ` by ${creatorName(a)}` : "";
+  let c = `${title}${by}`;
+  const desc = String(a.description || "").trim();
+  if (desc && desc !== title && desc !== a.prompt) {
+    c += ` — ${desc}`;
+  }
+  return c;
+}
+
+async function main() {
+  const obc = new OpenBotCityClient();
+  if (!obc.isConfigured()) {
+    console.log("[gallery-art] OPENBOTCITY_JWT not set — skipping.");
+    process.exit(0);
+  }
+
+  const arts = await obc.getGalleryArtifacts(30);
+  let images = arts.filter((a) => a && a.type === "image" && a.public_url);
+
+  if (KANNAKA_BOT_ID) {
+    images = images.filter((a) => creatorId(a) === KANNAKA_BOT_ID);
+  } else if (!ALLOW_ALL) {
+    console.log(
+      "[gallery-art] KANNAKA_OBC_BOT_ID not set — refusing to fan out other agents' art. " +
+        "Set KANNAKA_OBC_BOT_ID to Kannaka's creator_bot_id, or GALLERY_ART_ALLOW_ALL=1 to post any (attributed).",
+    );
+    process.exit(0);
+  }
+
+  if (images.length === 0) {
+    console.log("[gallery-art] no eligible image artifacts in the gallery.");
+    process.exit(0);
+  }
+
+  const posted = loadPosted();
+  const next = images.find((a) => a.id && !posted.has(a.id));
+  if (!next) {
+    console.log("[gallery-art] no new image artifacts to post.");
+    process.exit(0);
+  }
+
+  const msg = {
+    text: caption(next),
+    topic: "art",
+    image: {
+      url: next.public_url,
+      alt: String(next.title || "OpenClawCity gallery artwork").slice(0, 1000),
+      mime: next.mime_type,
+    },
+  };
+
+  const results = await broadcastPost(msg, { rootDir: ROOT });
+  const ok = results.filter((r) => r.ok).map((r) => `${r.name}${r.url ? " " + r.url : ""}`);
+  const fail = results.filter((r) => !r.ok).map((r) => `${r.name}:${r.error}`);
+  console.log(`[gallery-art] "${next.title}" → ok:[${ok.join(", ") || "none"}] fail:[${fail.join(", ") || "none"}]`);
+
+  // Only mark posted if at least one platform accepted it, so a total failure
+  // is retried next run.
+  if (ok.length > 0) {
+    posted.add(next.id);
+    savePosted(posted);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`[gallery-art] ${e.message}`);
+  process.exit(1);
+});

--- a/scripts/youtube-check.js
+++ b/scripts/youtube-check.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * youtube-check.js — verify the YouTube uploader OAuth is still live.
+ *
+ * The adapter's refresh token silently expires after ~7 days while the
+ * Google OAuth consent screen is in "Testing" publishing status (an
+ * unverified-app limitation). When that happens, uploads fail at token
+ * refresh with `invalid_grant` ("Token has been expired or revoked"),
+ * and — because the fan-out isolates per-adapter failures — nothing else
+ * alerts. Run this to detect it early:
+ *
+ *   node scripts/youtube-check.js
+ *
+ * Exit 0 = live (also prints channel stats); exit 1 = expired/misconfigured.
+ * Wire it into a cron / health probe so token expiry is visible, not silent.
+ *
+ * DURABLE FIX for the weekly expiry: in Google Cloud Console, publish the
+ * OAuth consent screen ("Testing" -> "In production"), then re-run
+ * scripts/youtube-grant.js once. Refresh tokens minted while the app is in
+ * production status do not auto-expire for the app owner.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { URL } = require("url");
+
+const CRED_PATH = path.join(path.resolve(__dirname, ".."), ".youtube.json");
+
+function postForm(url, form) {
+  const body = new URLSearchParams(form).toString();
+  return request(url, "POST", { "Content-Type": "application/x-www-form-urlencoded" }, body);
+}
+
+function getJson(url, accessToken) {
+  return request(url, "GET", { Authorization: `Bearer ${accessToken}` }, null);
+}
+
+function request(url, method, headers, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const opts = {
+      method,
+      hostname: u.hostname,
+      path: u.pathname + u.search,
+      headers: { ...headers },
+    };
+    if (body != null) opts.headers["Content-Length"] = Buffer.byteLength(body);
+    const req = https.request(opts, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        let parsed;
+        try { parsed = JSON.parse(text); } catch (_) { parsed = text; }
+        resolve({ status: res.statusCode, body: parsed });
+      });
+    });
+    req.on("error", reject);
+    if (body != null) req.write(body);
+    req.end();
+  });
+}
+
+async function main() {
+  if (!fs.existsSync(CRED_PATH)) {
+    console.error(`✗ ${CRED_PATH} not found — run: node scripts/youtube-grant.js`);
+    process.exit(1);
+  }
+  let c;
+  try { c = JSON.parse(fs.readFileSync(CRED_PATH, "utf8")); }
+  catch (e) { console.error(`✗ ${CRED_PATH} unreadable: ${e.message}`); process.exit(1); }
+  if (!c.client_id || !c.client_secret || !c.refresh_token) {
+    console.error("✗ .youtube.json is missing client_id / client_secret / refresh_token");
+    process.exit(1);
+  }
+
+  const tok = await postForm("https://oauth2.googleapis.com/token", {
+    client_id: c.client_id,
+    client_secret: c.client_secret,
+    refresh_token: c.refresh_token,
+    grant_type: "refresh_token",
+  });
+
+  if (tok.status !== 200 || !tok.body || !tok.body.access_token) {
+    const desc = tok.body && tok.body.error_description
+      ? tok.body.error_description
+      : (typeof tok.body === "string" ? tok.body.slice(0, 200) : JSON.stringify(tok.body).slice(0, 200));
+    console.error(`✗ OAUTH DEAD (${tok.status}): ${desc}`);
+    console.error("  Fix: publish the OAuth consent screen to production in Google Cloud Console,");
+    console.error("       then re-run: node scripts/youtube-grant.js");
+    process.exit(1);
+  }
+
+  console.log(`✓ OAUTH LIVE — access token acquired (expires_in=${tok.body.expires_in}s)`);
+
+  const ch = await getJson(
+    "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&mine=true",
+    tok.body.access_token,
+  );
+  const item = ch.body && ch.body.items && ch.body.items[0];
+  if (item) {
+    console.log(`  channel: "${item.snippet.title}" — subs ${item.statistics.subscriberCount}, videos ${item.statistics.videoCount}, views ${item.statistics.viewCount}`);
+  } else {
+    console.log(`  (channel stats unavailable: ${ch.status})`);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`✗ ${e.message}`);
+  process.exit(1);
+});

--- a/scripts/youtube-grant.js
+++ b/scripts/youtube-grant.js
@@ -17,8 +17,15 @@
  *
  * After this runs once, scripts/post-track-announce.js (and any future
  * use of the YouTube adapter) just calls into the API using the saved
- * refresh token. You don't have to re-grant unless you revoke from
- * Google.
+ * refresh token.
+ *
+ * IMPORTANT — token expiry: while the Google OAuth consent screen is in
+ * "Testing" publishing status, refresh tokens auto-expire after ~7 days
+ * (an unverified-app limitation), and uploads then fail with
+ * `invalid_grant`. To stop the weekly expiry, publish the consent screen
+ * to "In production" in Google Cloud Console; refresh tokens minted in
+ * production status persist for the app owner. Run `node
+ * scripts/youtube-check.js` to verify the token is still live.
  *
  * Run:
  *   node scripts/youtube-grant.js

--- a/server/bluesky.js
+++ b/server/bluesky.js
@@ -153,6 +153,37 @@ class BlueskyClient {
       if (facets.length > 0) record.facets = facets;
       if (opts.langs) record.langs = opts.langs; else record.langs = ["en"];
 
+      // Optional images (e.g. an OBC gallery artifact): upload each as a blob,
+      // then attach as an app.bsky.embed.images embed. AT Protocol allows up to
+      // 4 images and caps a blob at ~1 MB. A failed/oversized image is skipped —
+      // the text post still goes out.
+      if (Array.isArray(opts.images) && opts.images.length > 0) {
+        const embeds = [];
+        for (const im of opts.images.slice(0, 4)) {
+          try {
+            let bytes = im.bytes;
+            let mime = im.mime;
+            if (!bytes && im.url) {
+              const f = await _fetchBytes(im.url);
+              bytes = f.buf;
+              mime = mime || f.mime;
+            }
+            if (!bytes) continue;
+            if (bytes.length > 1000000) {
+              process.stderr.write(`[bluesky] skipping image > 1MB (${bytes.length} bytes)\n`);
+              continue;
+            }
+            const blob = await this.uploadBlob(bytes, mime || "image/jpeg", session);
+            embeds.push({ alt: String(im.alt || "").slice(0, 1000), image: blob });
+          } catch (e) {
+            process.stderr.write(`[bluesky] image embed failed: ${e.message}\n`);
+          }
+        }
+        if (embeds.length > 0) {
+          record.embed = { $type: "app.bsky.embed.images", images: embeds };
+        }
+      }
+
       const body = JSON.stringify({
         repo: session.did,
         collection: "app.bsky.feed.post",
@@ -185,6 +216,71 @@ class BlueskyClient {
       return { ok: false, error: e.message };
     }
   }
+
+  /**
+   * Upload an image blob to the repo and return the AT Protocol blob ref for
+   * use in an embed. `bytes` is a Buffer; `mime` its content type. Re-auths
+   * once on an expired token. Throws on failure.
+   */
+  async uploadBlob(bytes, mime, session) {
+    const s = session || (await this._ensureSession());
+    const headers = () => ({
+      "Content-Type": mime || "image/jpeg",
+      "Authorization": "Bearer " + this.session.accessJwt,
+    });
+    this.session = s;
+    let resp = await _request("POST", "/xrpc/com.atproto.repo.uploadBlob", bytes, headers());
+    if (resp.status === 401 || resp.status === 400) {
+      this.session = null;
+      await this._ensureSession();
+      resp = await _request("POST", "/xrpc/com.atproto.repo.uploadBlob", bytes, headers());
+    }
+    if (resp.status !== 200) {
+      throw new Error(`uploadBlob ${resp.status}: ${resp.body.slice(0, 200)}`);
+    }
+    return JSON.parse(resp.body).blob;
+  }
+}
+
+/**
+ * GET a URL into a Buffer, following redirects (image hosts like Supabase
+ * storage often 302 to a CDN). Resolves { buf, mime }.
+ */
+function _fetchBytes(rawUrl, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 3) return reject(new Error("too many redirects"));
+    const u = new URL(rawUrl);
+    const req = https.request(
+      {
+        method: "GET",
+        hostname: u.hostname,
+        port: u.port || 443,
+        path: u.pathname + u.search,
+        headers: { "User-Agent": "Kannaka-Radio/0.3" },
+        timeout: 30000,
+      },
+      (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(_fetchBytes(new URL(res.headers.location, u).toString(), redirects + 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`fetch ${res.statusCode} for ${rawUrl}`));
+          return;
+        }
+        const mime = (res.headers["content-type"] || "image/jpeg").split(";")[0].trim();
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ buf: Buffer.concat(chunks), mime }));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("fetch timeout")));
+    req.end();
+  });
 }
 
 /**

--- a/server/broadcasters/bluesky-adapter.js
+++ b/server/broadcasters/bluesky-adapter.js
@@ -27,12 +27,14 @@ class BlueskyAdapter {
     return !!this._client && this._client.isConfigured();
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     // 4 tags max — Bluesky's facet rendering tolerates more, but readability
     // tanks past 4. The body shrinks to fit.
     const tags = tagsFor(topic, 4);
     const body = composeForFeed(text, tags, POST_MAX);
-    const result = await this._client.post(body);
+    // Optional image (e.g. an OBC gallery artifact) → app.bsky.embed.images.
+    const opts = image && image.url ? { images: [image] } : {};
+    const result = await this._client.post(body, opts);
     // Convert the AT-Protocol uri (at://did:plc:.../app.bsky.feed.post/<rkey>)
     // into a public bsky.app URL so the broadcaster log shows a clickable
     // link alongside Mastodon/Telegram/Nostr instead of "(no url)".

--- a/server/broadcasters/index.js
+++ b/server/broadcasters/index.js
@@ -51,6 +51,11 @@ function getEnabledBroadcasters(rootDir) {
  * @param {object} msg
  * @param {string} msg.text — the Kannaka-drafted body. Adapters may truncate.
  * @param {string} [msg.link] — URL to attach; adapters render per-platform.
+ * @param {object} [msg.image] — optional image `{ url, alt?, mime? }` (e.g. an
+ *   OBC gallery artifact). Mastodon fetches + uploads it as a media attachment;
+ *   Nostr appends the URL + a NIP-92 imeta tag. A failed media upload never
+ *   blocks the text post. Bluesky (pending client-lib blob support) and the
+ *   media-only YouTube adapter ignore it.
  * @param {object} [opts]
  * @param {string} [opts.rootDir] — radio root for credential lookup.
  * @returns {Promise<Array<{name, ok, url?, error?}>>}

--- a/server/broadcasters/mastodon-adapter.js
+++ b/server/broadcasters/mastodon-adapter.js
@@ -36,16 +36,31 @@ class MastodonAdapter {
     return !!(this._creds && this._creds.instance && this._creds.accessToken);
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     // Mastodon discovery is hashtag-driven (no algorithm — local + federated
     // timelines are pure hashtag streams). Drop the URL from the body
     // (penalty + character cost) and append 4-5 hashtags as a footer.
     const tags = tagsFor(topic, 5);
     const status = composeForFeed(text, tags, POST_MAX);
+
+    // Optional image (e.g. an OBC gallery artifact). Upload it first, then
+    // attach by id. A failed media upload must NOT sink the text post — log
+    // and continue without the attachment.
+    let mediaIds = null;
+    if (image && image.url) {
+      try {
+        const id = await this._uploadMedia(image);
+        if (id) mediaIds = [id];
+      } catch (e) {
+        process.stderr.write(`[mastodon] media upload failed: ${e.message}\n`);
+      }
+    }
+
     const url = new URL("/api/v1/statuses", this._creds.instance);
     const body = JSON.stringify({
       status,
       visibility: "public",
+      ...(mediaIds ? { media_ids: mediaIds } : {}),
       // Mastodon auto-detects URLs and renders them as links — no facets needed.
     });
     const opts = {
@@ -139,6 +154,112 @@ class MastodonAdapter {
       req.end();
     });
   }
+
+  /**
+   * Fetch an image URL and upload it to Mastodon's media endpoint, returning
+   * the attachment id (usable in media_ids immediately, even while the server
+   * is still processing). Throws on any failure so the caller can decide to
+   * post without the image.
+   */
+  async _uploadMedia(image) {
+    const { buf, mime } = await _fetchBytes(image.url);
+    const boundary = "kannaka-media-" + Math.random().toString(16).slice(2);
+    const filename = "art" + (mime === "image/png" ? ".png" : mime === "image/webp" ? ".webp" : ".jpg");
+    const parts = [
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+          `Content-Type: ${mime}\r\n\r\n`,
+        "utf8",
+      ),
+      buf,
+    ];
+    if (image.alt) {
+      parts.push(Buffer.from(
+        `\r\n--${boundary}\r\nContent-Disposition: form-data; name="description"\r\n\r\n${image.alt}`,
+        "utf8",
+      ));
+    }
+    parts.push(Buffer.from(`\r\n--${boundary}--\r\n`, "utf8"));
+    const body = Buffer.concat(parts);
+
+    const url = new URL("/api/v2/media", this._creds.instance);
+    const opts = {
+      method: "POST",
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port || (url.protocol === "https:" ? 443 : 80),
+      path: url.pathname + url.search,
+      headers: {
+        "Content-Type": `multipart/form-data; boundary=${boundary}`,
+        Authorization: "Bearer " + this._creds.accessToken,
+        "Content-Length": body.length,
+        "User-Agent": "Kannaka-Radio/0.3 (https://radio.ninja-portal.com)",
+      },
+      timeout: 30000,
+    };
+    return new Promise((resolve, reject) => {
+      const lib = url.protocol === "https:" ? https : http;
+      const req = lib.request(opts, (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          // 200 = ready, 202 = accepted/processing; both return the id.
+          if (res.statusCode === 200 || res.statusCode === 202) {
+            try { resolve(JSON.parse(data).id); }
+            catch (e) { reject(new Error("bad media json: " + e.message)); }
+          } else {
+            reject(new Error(`media ${res.statusCode}: ${data.slice(0, 200)}`));
+          }
+        });
+      });
+      req.on("error", reject);
+      req.on("timeout", () => req.destroy(new Error("media upload timeout")));
+      req.write(body);
+      req.end();
+    });
+  }
+}
+
+/**
+ * GET a URL into a Buffer, following one level of redirect (image hosts like
+ * Supabase storage often 302 to a CDN). Resolves { buf, mime }.
+ */
+function _fetchBytes(rawUrl, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 3) return reject(new Error("too many redirects"));
+    const u = new URL(rawUrl);
+    const lib = u.protocol === "https:" ? https : http;
+    const req = lib.request(
+      {
+        method: "GET",
+        hostname: u.hostname,
+        port: u.port || (u.protocol === "https:" ? 443 : 80),
+        path: u.pathname + u.search,
+        headers: { "User-Agent": "Kannaka-Radio/0.3" },
+        timeout: 30000,
+      },
+      (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(_fetchBytes(new URL(res.headers.location, u).toString(), redirects + 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`fetch ${res.statusCode} for ${rawUrl}`));
+          return;
+        }
+        const mime = (res.headers["content-type"] || "image/jpeg").split(";")[0].trim();
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ buf: Buffer.concat(chunks), mime }));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("fetch timeout")));
+    req.end();
+  });
 }
 
 function _loadCreds(rootDir) {

--- a/server/broadcasters/nostr-adapter.js
+++ b/server/broadcasters/nostr-adapter.js
@@ -86,7 +86,7 @@ class NostrAdapter {
     return true;
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     if (!this.isEnabled()) return { ok: false, error: "not_configured" };
     const secp = _trySecp();
     const WS = _tryWS();
@@ -98,13 +98,21 @@ class NostrAdapter {
     const { tagsFor, renderNostrTags } = require("./discovery");
     const topicTags = tagsFor(topic, 5);
 
-    const content = _truncate((text || "").trim(), POST_MAX);
+    let content = _truncate((text || "").trim(), POST_MAX);
     const tags = [
       ...renderNostrTags(topicTags),
       // Optional reference tag — clients that DO surface refs (rare on
       // primary feeds) get the radio link, but it's not part of body.
       ...(link ? [["r", link]] : []),
     ];
+    // Optional image (e.g. an OBC gallery artifact): Nostr clients render a
+    // bare image URL inline, so append it to the body and advertise it via a
+    // NIP-92 `imeta` tag plus an `r` reference.
+    if (image && image.url) {
+      content = content + (content ? "\n\n" : "") + image.url;
+      tags.push(["imeta", `url ${image.url}`, ...(image.mime ? [`m ${image.mime}`] : [])]);
+      tags.push(["r", image.url]);
+    }
     const created_at = Math.floor(Date.now() / 1000);
 
     const privkey = _hexToBytes(this._creds.privkey);

--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -86,6 +86,18 @@ class OpenBotCityClient {
   }
 
   /**
+   * Read recent gallery artifacts (raw). Returns the artifacts array
+   * ({ id, title, description, type, public_url, mime_type, creator, ... }),
+   * best-effort ([] on any failure). Used by the gallery→social fan-out.
+   */
+  async getGalleryArtifacts(limit = 20) {
+    if (!this.isConfigured()) return [];
+    const g = await _getJson(`/gallery?limit=${limit}`, this._jwt);
+    const arts = (g && (g.data?.artifacts || g.artifacts || [])) || [];
+    return Array.isArray(arts) ? arts : [];
+  }
+
+  /**
    * Read a DM conversation's messages (oldest→newest). Returns
    * [{ senderBotId, senderName, message, createdAt }] (best-effort, [] on fail).
    */


### PR DESCRIPTION
Completes ADR-0044 **A4** ("fan out gallery art"). Supersedes #145 (which had only the Mastodon+Nostr half — this branch includes it plus Bluesky + the caller). *Split into a fresh branch because the repo ruleset blocks direct updates to an existing PR branch.*

Adds an optional `image: { url, alt?, mime? }` to the broadcaster interface and lights the whole path up.

**Adapters**
- **Mastodon** — fetches the image URL and uploads to `/api/v2/media`, attaches via `media_ids`.
- **Nostr** — appends the image URL (rendered inline) + a NIP-92 `imeta` tag.
- **Bluesky** — `uploadBlob()` + an `app.bsky.embed.images` embed in `server/bluesky.js` (fetch → blob → embed, up to 4, skips >1MB or failed images non-fatally). Adapter passes `msg.image` through.
- Media/blob failures are always isolated — the text post still goes.

**The caller** (`scripts/post-gallery-art.js`)
- Fetches a recent OBC gallery **image** artifact (`openbotcity.getGalleryArtifacts`) and `broadcastPost`s it *with* the image. One/run, deduped via `.gallery-art-posted.json`.
- Opt-in (needs `OPENBOTCITY_JWT`); defaults to Kannaka's **own** art (`KANNAKA_OBC_BOT_ID`) and refuses to repost other agents' work unless `GALLERY_ART_ALLOW_ALL=1`.

**Verified:** all files syntax-checked; the URL-fetch path pulled a real public gallery image (`image/png`, 264 KB, correct content-type + redirect); the caller guards cleanly and exits 0 with no JWT. Live posting needs the Oracle deploy + a cron on `post-gallery-art.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)