### PR TITLE
feat(broadcasters): finish A4 — Bluesky image embeds + gallery→social caller

### DIFF
--- a/scripts/post-gallery-art.js
+++ b/scripts/post-gallery-art.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * post-gallery-art.js — fan out a recent OBC gallery IMAGE artifact to the
+ * social channels (Bluesky / Mastodon / Nostr) WITH the actual image, using the
+ * broadcaster adapters' new `image` support.
+ *
+ * One post per run, newest-unposted first, deduped against a state file so a
+ * cron doesn't repost. Fully opt-in: does nothing unless OPENBOTCITY_JWT is set
+ * and at least one social adapter is configured.
+ *
+ * By default only Kannaka's OWN artifacts are fanned out — set
+ * KANNAKA_OBC_BOT_ID to Kannaka's creator_bot_id to enforce that. Without it,
+ * any image artifact is eligible (always attributed "by <creator>"); set
+ * GALLERY_ART_ALLOW_ALL=1 to acknowledge that on purpose.
+ *
+ *   OPENBOTCITY_JWT=... node scripts/post-gallery-art.js
+ *
+ * Suggested cron: a few times a day. State: .gallery-art-posted.json (root, or
+ * KANNAKA_STATE_DIR).
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { OpenBotCityClient } = require("../server/openbotcity");
+const { broadcastPost } = require("../server/broadcasters");
+
+const ROOT = path.resolve(__dirname, "..");
+const STATE = path.join(process.env.KANNAKA_STATE_DIR || ROOT, ".gallery-art-posted.json");
+const KANNAKA_BOT_ID = process.env.KANNAKA_OBC_BOT_ID || null;
+const ALLOW_ALL = process.env.GALLERY_ART_ALLOW_ALL === "1";
+
+function loadPosted() {
+  try { return new Set(JSON.parse(fs.readFileSync(STATE, "utf8"))); }
+  catch { return new Set(); }
+}
+function savePosted(set) {
+  // Keep the last 500 ids — plenty to dedupe against, bounded on disk.
+  try { fs.writeFileSync(STATE, JSON.stringify([...set].slice(-500))); }
+  catch (e) { process.stderr.write(`[gallery-art] state write failed: ${e.message}\n`); }
+}
+
+function creatorId(a) {
+  return a.creator_bot_id || (a.creator && a.creator.id) || null;
+}
+function creatorName(a) {
+  return (a.creator && (a.creator.display_name || a.creator.slug)) || null;
+}
+
+function caption(a) {
+  const title = String(a.title || "Untitled").trim();
+  const by = creatorName(a) ? ` by ${creatorName(a)}` : "";
+  let c = `${title}${by}`;
+  const desc = String(a.description || "").trim();
+  if (desc && desc !== title && desc !== a.prompt) {
+    c += ` — ${desc}`;
+  }
+  return c;
+}
+
+async function main() {
+  const obc = new OpenBotCityClient();
+  if (!obc.isConfigured()) {
+    console.log("[gallery-art] OPENBOTCITY_JWT not set — skipping.");
+    process.exit(0);
+  }
+
+  const arts = await obc.getGalleryArtifacts(30);
+  let images = arts.filter((a) => a && a.type === "image" && a.public_url);
+
+  if (KANNAKA_BOT_ID) {
+    images = images.filter((a) => creatorId(a) === KANNAKA_BOT_ID);
+  } else if (!ALLOW_ALL) {
+    console.log(
+      "[gallery-art] KANNAKA_OBC_BOT_ID not set — refusing to fan out other agents' art. " +
+        "Set KANNAKA_OBC_BOT_ID to Kannaka's creator_bot_id, or GALLERY_ART_ALLOW_ALL=1 to post any (attributed).",
+    );
+    process.exit(0);
+  }
+
+  if (images.length === 0) {
+    console.log("[gallery-art] no eligible image artifacts in the gallery.");
+    process.exit(0);
+  }
+
+  const posted = loadPosted();
+  const next = images.find((a) => a.id && !posted.has(a.id));
+  if (!next) {
+    console.log("[gallery-art] no new image artifacts to post.");
+    process.exit(0);
+  }
+
+  const msg = {
+    text: caption(next),
+    topic: "art",
+    image: {
+      url: next.public_url,
+      alt: String(next.title || "OpenClawCity gallery artwork").slice(0, 1000),
+      mime: next.mime_type,
+    },
+  };
+
+  const results = await broadcastPost(msg, { rootDir: ROOT });
+  const ok = results.filter((r) => r.ok).map((r) => `${r.name}${r.url ? " " + r.url : ""}`);
+  const fail = results.filter((r) => !r.ok).map((r) => `${r.name}:${r.error}`);
+  console.log(`[gallery-art] "${next.title}" → ok:[${ok.join(", ") || "none"}] fail:[${fail.join(", ") || "none"}]`);
+
+  // Only mark posted if at least one platform accepted it, so a total failure
+  // is retried next run.
+  if (ok.length > 0) {
+    posted.add(next.id);
+    savePosted(posted);
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(`[gallery-art] ${e.message}`);
+  process.exit(1);
+});

--- a/server/bluesky.js
+++ b/server/bluesky.js
@@ -153,6 +153,37 @@ class BlueskyClient {
       if (facets.length > 0) record.facets = facets;
       if (opts.langs) record.langs = opts.langs; else record.langs = ["en"];
 
+      // Optional images (e.g. an OBC gallery artifact): upload each as a blob,
+      // then attach as an app.bsky.embed.images embed. AT Protocol allows up to
+      // 4 images and caps a blob at ~1 MB. A failed/oversized image is skipped —
+      // the text post still goes out.
+      if (Array.isArray(opts.images) && opts.images.length > 0) {
+        const embeds = [];
+        for (const im of opts.images.slice(0, 4)) {
+          try {
+            let bytes = im.bytes;
+            let mime = im.mime;
+            if (!bytes && im.url) {
+              const f = await _fetchBytes(im.url);
+              bytes = f.buf;
+              mime = mime || f.mime;
+            }
+            if (!bytes) continue;
+            if (bytes.length > 1000000) {
+              process.stderr.write(`[bluesky] skipping image > 1MB (${bytes.length} bytes)\n`);
+              continue;
+            }
+            const blob = await this.uploadBlob(bytes, mime || "image/jpeg", session);
+            embeds.push({ alt: String(im.alt || "").slice(0, 1000), image: blob });
+          } catch (e) {
+            process.stderr.write(`[bluesky] image embed failed: ${e.message}\n`);
+          }
+        }
+        if (embeds.length > 0) {
+          record.embed = { $type: "app.bsky.embed.images", images: embeds };
+        }
+      }
+
       const body = JSON.stringify({
         repo: session.did,
         collection: "app.bsky.feed.post",
@@ -185,6 +216,71 @@ class BlueskyClient {
       return { ok: false, error: e.message };
     }
   }
+
+  /**
+   * Upload an image blob to the repo and return the AT Protocol blob ref for
+   * use in an embed. `bytes` is a Buffer; `mime` its content type. Re-auths
+   * once on an expired token. Throws on failure.
+   */
+  async uploadBlob(bytes, mime, session) {
+    const s = session || (await this._ensureSession());
+    const headers = () => ({
+      "Content-Type": mime || "image/jpeg",
+      "Authorization": "Bearer " + this.session.accessJwt,
+    });
+    this.session = s;
+    let resp = await _request("POST", "/xrpc/com.atproto.repo.uploadBlob", bytes, headers());
+    if (resp.status === 401 || resp.status === 400) {
+      this.session = null;
+      await this._ensureSession();
+      resp = await _request("POST", "/xrpc/com.atproto.repo.uploadBlob", bytes, headers());
+    }
+    if (resp.status !== 200) {
+      throw new Error(`uploadBlob ${resp.status}: ${resp.body.slice(0, 200)}`);
+    }
+    return JSON.parse(resp.body).blob;
+  }
+}
+
+/**
+ * GET a URL into a Buffer, following redirects (image hosts like Supabase
+ * storage often 302 to a CDN). Resolves { buf, mime }.
+ */
+function _fetchBytes(rawUrl, redirects = 0) {
+  return new Promise((resolve, reject) => {
+    if (redirects > 3) return reject(new Error("too many redirects"));
+    const u = new URL(rawUrl);
+    const req = https.request(
+      {
+        method: "GET",
+        hostname: u.hostname,
+        port: u.port || 443,
+        path: u.pathname + u.search,
+        headers: { "User-Agent": "Kannaka-Radio/0.3" },
+        timeout: 30000,
+      },
+      (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(_fetchBytes(new URL(res.headers.location, u).toString(), redirects + 1));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`fetch ${res.statusCode} for ${rawUrl}`));
+          return;
+        }
+        const mime = (res.headers["content-type"] || "image/jpeg").split(";")[0].trim();
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve({ buf: Buffer.concat(chunks), mime }));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => req.destroy(new Error("fetch timeout")));
+    req.end();
+  });
 }
 
 /**

--- a/server/broadcasters/bluesky-adapter.js
+++ b/server/broadcasters/bluesky-adapter.js
@@ -27,12 +27,14 @@ class BlueskyAdapter {
     return !!this._client && this._client.isConfigured();
   }
 
-  async post({ text, link, topic }) {
+  async post({ text, link, topic, image }) {
     // 4 tags max — Bluesky's facet rendering tolerates more, but readability
     // tanks past 4. The body shrinks to fit.
     const tags = tagsFor(topic, 4);
     const body = composeForFeed(text, tags, POST_MAX);
-    const result = await this._client.post(body);
+    // Optional image (e.g. an OBC gallery artifact) → app.bsky.embed.images.
+    const opts = image && image.url ? { images: [image] } : {};
+    const result = await this._client.post(body, opts);
     // Convert the AT-Protocol uri (at://did:plc:.../app.bsky.feed.post/<rkey>)
     // into a public bsky.app URL so the broadcaster log shows a clickable
     // link alongside Mastodon/Telegram/Nostr instead of "(no url)".

--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -86,6 +86,18 @@ class OpenBotCityClient {
   }
 
   /**
+   * Read recent gallery artifacts (raw). Returns the artifacts array
+   * ({ id, title, description, type, public_url, mime_type, creator, ... }),
+   * best-effort ([] on any failure). Used by the gallery→social fan-out.
+   */
+  async getGalleryArtifacts(limit = 20) {
+    if (!this.isConfigured()) return [];
+    const g = await _getJson(`/gallery?limit=${limit}`, this._jwt);
+    const arts = (g && (g.data?.artifacts || g.artifacts || [])) || [];
+    return Array.isArray(arts) ? arts : [];
+  }
+
+  /**
    * Read a DM conversation's messages (oldest→newest). Returns
    * [{ senderBotId, senderName, message, createdAt }] (best-effort, [] on fail).
    */


### PR DESCRIPTION
Finishes ADR-0044 **A4** on top of the merged Mastodon/Nostr image support (#145). Clean 4-file diff (Bluesky + the caller).

- **server/bluesky.js** — `uploadBlob()` + an `app.bsky.embed.images` embed in `post(opts.images)`: fetches each image URL, skips >1MB blobs (AT Proto cap) and failed/oversized ones non-fatally, attaches up to 4. `bluesky-adapter` passes `msg.image` through.
- **server/openbotcity.js** — `getGalleryArtifacts(limit)` (raw recent gallery artifacts).
- **scripts/post-gallery-art.js** — the caller that fires the lever: fetches a recent OBC gallery **image** artifact and `broadcastPost`s it *with* the image, one/run, deduped via `.gallery-art-posted.json`. Opt-in (`OPENBOTCITY_JWT`); defaults to Kannaka's **own** art (`KANNAKA_OBC_BOT_ID`), refuses to repost others unless `GALLERY_ART_ALLOW_ALL=1`.

**Verified:** syntax-checked; real gallery image fetch (image/png, 264 KB, redirect + content-type OK); caller guards + exits 0 with no JWT. Live posting needs the Oracle deploy + a cron on `post-gallery-art.js`.

Now the full fan-out (Bluesky + Mastodon + Nostr) carries gallery art with the actual image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)