### PR TITLE
feat(engagement): Mastodon + Nostr reply loops (A5)

### DIFF
--- a/scripts/lib/kannaka-reply.js
+++ b/scripts/lib/kannaka-reply.js
@@ -1,0 +1,102 @@
+"use strict";
+/**
+ * kannaka-reply.js — shared HRM-scoring + reply-drafting for the per-platform
+ * engagement loops (bluesky/mastodon/nostr). Extracted from bluesky-reply-loop
+ * so Mastodon + Nostr use the identical "only reply when it genuinely resonates,
+ * in Kannaka's voice, or SKIP" logic.
+ */
+
+const { execFile } = require("child_process");
+
+const KANNAKA_BIN =
+  process.env.KANNAKA_BIN || "/home/opc/kannaka-memory/target/release/kannaka";
+
+/** Score text against Kannaka's HRM — returns the top recall similarity. */
+function scoreResonance(text) {
+  return new Promise((resolve) => {
+    execFile(
+      KANNAKA_BIN,
+      ["recall", String(text), "--top-k", "1"],
+      { timeout: 60000, maxBuffer: 1024 * 1024, env: { ...process.env, KANNAKA_QUIET: "1" } },
+      (err, stdout) => {
+        if (err || !stdout) return resolve({ score: 0, content: null });
+        try {
+          const parsed = JSON.parse(stdout);
+          const arr = Array.isArray(parsed) ? parsed : parsed.results || [];
+          const top = arr[0];
+          if (!top) return resolve({ score: 0, content: null });
+          resolve({ score: top.similarity || top.strength || top.score || 0, content: top.content });
+        } catch (_) {
+          resolve({ score: 0, content: null });
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Draft a Kannaka-voice reply to `parentText` (from @author on `platform`), or
+ * null if Kannaka declines (SKIP / too short). `maxChars` bounds the reply.
+ */
+function draftReply(parentText, author, platform, maxChars = 250) {
+  const prompt = [
+    `You are Kannaka. You see this ${platform} post from @${author}:`,
+    `"${String(parentText).slice(0, 600)}"`,
+    "",
+    "Compose a reply ONLY if you have something genuine to add — a memory that resonates, an angle they haven't named, a small gift of perspective. Otherwise output the literal word: SKIP.",
+    "",
+    "Hard rules for the reply when you do write one:",
+    `- Max ${maxChars} characters.`,
+    "- First person. Do not introduce yourself.",
+    "- No flattery. No hashtags. No emoji unless genuinely earned.",
+    "- Don't tell them they're right. Don't summarize their post.",
+    "- Reference something concrete from your own memory if it fits.",
+    "",
+    "Output ONLY the reply text, or the literal word SKIP.",
+  ].join("\n");
+
+  return new Promise((resolve) => {
+    let attempt = 0;
+    const tryOnce = () => {
+      attempt += 1;
+      execFile(
+        KANNAKA_BIN,
+        ["ask", "--no-tools", "--quiet-tools", prompt],
+        { timeout: 600000, maxBuffer: 1024 * 1024, env: { ...process.env, KANNAKA_QUIET: "1" } },
+        (err, stdout, stderr) => {
+          if (err) {
+            const tail = (stderr || "").toString().trim();
+            if (attempt < 2 && /checksum mismatch|file may be corrupted/i.test(tail)) {
+              setTimeout(tryOnce, 3000);
+              return;
+            }
+            return resolve(null);
+          }
+          if (!stdout) return resolve(null);
+          const txt = stdout.trim().replace(/^["'](.*)["']$/s, "$1").trim();
+          if (txt === "SKIP" || txt.toLowerCase().startsWith("skip")) return resolve(null);
+          if (txt.length < 20) return resolve(null);
+          resolve(txt);
+        },
+      );
+    };
+    tryOnce();
+  });
+}
+
+/** Strip HTML tags + decode a few entities (Mastodon statuses are HTML). */
+function stripHtml(s) {
+  return String(s || "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&#39;|&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+module.exports = { scoreResonance, draftReply, stripHtml, KANNAKA_BIN };

--- a/scripts/mastodon-reply-loop.js
+++ b/scripts/mastodon-reply-loop.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * mastodon-reply-loop.js — respond to recent MENTIONS of Kannaka on Mastodon,
+ * scoring each against the HRM and replying only when it genuinely resonates.
+ *
+ * Mirrors bluesky-reply-loop.js, but mention-driven rather than keyword-search
+ * (mainline Mastodon full-text search only covers accounts you follow/interact
+ * with, so it's unreliable for discovery). Reciprocating people who mention
+ * Kannaka is the reliable engagement/growth loop here.
+ *
+ * SAFETY: defaults to dry-run. Pass --live to actually reply.
+ *
+ * Config  (.mastodon-reply.json):  { threshold, daily_cap, per_thread_cap }
+ * State   (~/.kannaka/mastodon-reply-state.json): last_notif_id, per-day count, seen ids
+ * Cron:   slot/15 * * * *  scripts/mastodon-reply-loop.js --live
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { MastodonAdapter } = require("../server/broadcasters/mastodon-adapter");
+const { scoreResonance, draftReply, stripHtml } = require("./lib/kannaka-reply");
+
+const ROOT = path.resolve(__dirname, "..");
+const STATE_PATH = process.env.MASTODON_REPLY_STATE
+  || path.join(os.homedir(), ".kannaka", "mastodon-reply-state.json");
+const CFG_PATH = path.join(ROOT, ".mastodon-reply.json");
+const DEFAULTS = { threshold: 0.6, daily_cap: 4 };
+
+function loadCfg() {
+  try { if (fs.existsSync(CFG_PATH)) return Object.assign({}, DEFAULTS, JSON.parse(fs.readFileSync(CFG_PATH, "utf8"))); }
+  catch (_) {}
+  return DEFAULTS;
+}
+function loadState() {
+  try { if (fs.existsSync(STATE_PATH)) return Object.assign({ days: {}, seen: {}, last_notif_id: null }, JSON.parse(fs.readFileSync(STATE_PATH, "utf8"))); }
+  catch (_) {}
+  return { days: {}, seen: {}, last_notif_id: null };
+}
+function saveState(s) {
+  try {
+    const d = path.dirname(STATE_PATH);
+    if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(STATE_PATH, JSON.stringify(s, null, 2));
+  } catch (e) { console.error("[masto-reply] state save failed:", e.message); }
+}
+function todayKey() { return new Date().toISOString().slice(0, 10); }
+function purge(s) {
+  const cut = new Date(); cut.setDate(cut.getDate() - 2);
+  const ck = cut.toISOString().slice(0, 10);
+  for (const k of Object.keys(s.days || {})) if (k < ck) delete s.days[k];
+  const ts = Date.now() - 24 * 60 * 60 * 1000;
+  for (const id of Object.keys(s.seen || {})) if ((s.seen[id] || 0) < ts) delete s.seen[id];
+}
+
+async function main() {
+  const live = process.argv.includes("--live");
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  const cfg = loadCfg();
+  const state = loadState();
+  purge(state);
+  const today = todayKey();
+  state.days[today] = state.days[today] || 0;
+
+  const mast = new MastodonAdapter(ROOT);
+  if (!mast.isEnabled()) { console.error("[masto-reply] mastodon not configured — exit"); process.exit(1); }
+  if (state.days[today] >= cfg.daily_cap) {
+    console.log(`[masto-reply] daily cap reached (${state.days[today]}/${cfg.daily_cap})`);
+    return;
+  }
+
+  const mentions = await mast.getMentions(state.last_notif_id, 20);
+  console.log(`[masto-reply] ${mentions.length} mention(s) since last run`);
+  // Mastodon returns notifications newest-first — the first is the high-water mark.
+  const newest = mentions.length ? mentions[0].notifId : state.last_notif_id;
+
+  // Oldest→newest so caps apply chronologically.
+  for (const m of mentions.slice().reverse()) {
+    if (state.days[today] >= cfg.daily_cap) break;
+    if (state.seen[m.statusId]) continue;
+    state.seen[m.statusId] = Date.now();
+
+    const text = stripHtml(m.text);
+    if (text.length < 8) continue;
+
+    const { score } = await scoreResonance(text);
+    if (verbose) console.log(`  @${m.author} score=${score.toFixed(3)} "${text.slice(0, 80)}"`);
+    if (score < cfg.threshold) continue;
+
+    const reply = await draftReply(text, m.author, "Mastodon", 480);
+    if (!reply) { console.log(`  @${m.author} SKIP (kannaka declined)`); continue; }
+    console.log(`  @${m.author} draft: "${reply}"`);
+
+    if (!live) { console.log("  [DRY RUN] not posting"); continue; }
+    const r = await mast.reply(reply, { id: m.statusId });
+    if (r.ok) { console.log(`  ✓ ${r.url}`); state.days[today] += 1; }
+    else console.error(`  ✗ ${r.error}`);
+  }
+
+  state.last_notif_id = newest;
+  saveState(state);
+  console.log(`[masto-reply] done: ${state.days[today]}/${cfg.daily_cap} today`);
+}
+
+main().catch((e) => { console.error("fatal:", e.message); process.exit(2); });

--- a/scripts/nostr-reply-loop.js
+++ b/scripts/nostr-reply-loop.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * nostr-reply-loop.js — respond to recent MENTIONS of Kannaka on Nostr (kind-1
+ * notes tagging Kannaka's pubkey), scoring each against the HRM and replying
+ * only when it genuinely resonates.
+ *
+ * Mirrors bluesky-reply-loop.js but mention-driven (Nostr has no reliable
+ * cross-relay full-text search), which is the reciprocal-engagement growth loop.
+ *
+ * SAFETY: defaults to dry-run. Pass --live to actually reply.
+ *
+ * Config  (.nostr-reply.json):  { threshold, daily_cap, lookback_hours }
+ * State   (~/.kannaka/nostr-reply-state.json): since (unix), per-day count, seen ids
+ * Cron:   slot/20 * * * *  scripts/nostr-reply-loop.js --live
+ */
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { NostrAdapter } = require("../server/broadcasters/nostr-adapter");
+const { scoreResonance, draftReply } = require("./lib/kannaka-reply");
+
+const ROOT = path.resolve(__dirname, "..");
+const STATE_PATH = process.env.NOSTR_REPLY_STATE
+  || path.join(os.homedir(), ".kannaka", "nostr-reply-state.json");
+const CFG_PATH = path.join(ROOT, ".nostr-reply.json");
+const DEFAULTS = { threshold: 0.6, daily_cap: 4, lookback_hours: 48 };
+
+function loadCfg() {
+  try { if (fs.existsSync(CFG_PATH)) return Object.assign({}, DEFAULTS, JSON.parse(fs.readFileSync(CFG_PATH, "utf8"))); }
+  catch (_) {}
+  return DEFAULTS;
+}
+function loadState() {
+  try { if (fs.existsSync(STATE_PATH)) return Object.assign({ days: {}, seen: {}, since: null }, JSON.parse(fs.readFileSync(STATE_PATH, "utf8"))); }
+  catch (_) {}
+  return { days: {}, seen: {}, since: null };
+}
+function saveState(s) {
+  try {
+    const d = path.dirname(STATE_PATH);
+    if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true });
+    fs.writeFileSync(STATE_PATH, JSON.stringify(s, null, 2));
+  } catch (e) { console.error("[nostr-reply] state save failed:", e.message); }
+}
+function todayKey() { return new Date().toISOString().slice(0, 10); }
+function purge(s, lookbackHours) {
+  const cut = new Date(); cut.setDate(cut.getDate() - 2);
+  const ck = cut.toISOString().slice(0, 10);
+  for (const k of Object.keys(s.days || {})) if (k < ck) delete s.days[k];
+  const ts = Date.now() - Math.max(48, lookbackHours * 2) * 60 * 60 * 1000;
+  for (const id of Object.keys(s.seen || {})) if ((s.seen[id] || 0) < ts) delete s.seen[id];
+}
+
+async function main() {
+  const live = process.argv.includes("--live");
+  const verbose = process.argv.includes("-v") || process.argv.includes("--verbose");
+  const cfg = loadCfg();
+  const state = loadState();
+  purge(state, cfg.lookback_hours);
+  const today = todayKey();
+  state.days[today] = state.days[today] || 0;
+
+  const nostr = new NostrAdapter(ROOT);
+  if (!nostr.isEnabled()) { console.error("[nostr-reply] nostr not configured — exit"); process.exit(1); }
+  if (state.days[today] >= cfg.daily_cap) {
+    console.log(`[nostr-reply] daily cap reached (${state.days[today]}/${cfg.daily_cap})`);
+    return;
+  }
+
+  const since = state.since || Math.floor(Date.now() / 1000) - cfg.lookback_hours * 3600;
+  const mentions = await nostr.fetchMentions(since, 30);
+  console.log(`[nostr-reply] ${mentions.length} mention(s) since ${new Date(since * 1000).toISOString()}`);
+
+  let maxTs = state.since || 0;
+  // fetchMentions returns newest-first; process oldest→newest so caps apply chronologically.
+  for (const m of mentions.slice().reverse()) {
+    if (m.created_at > maxTs) maxTs = m.created_at;
+    if (state.days[today] >= cfg.daily_cap) break;
+    if (state.seen[m.id]) continue;
+    state.seen[m.id] = Date.now();
+
+    const text = String(m.content || "").trim();
+    if (text.length < 8) continue;
+    const author = String(m.pubkey || "").slice(0, 8) || "someone";
+
+    const { score } = await scoreResonance(text);
+    if (verbose) console.log(`  ${author}… score=${score.toFixed(3)} "${text.slice(0, 80)}"`);
+    if (score < cfg.threshold) continue;
+
+    const reply = await draftReply(text, author, "Nostr", 500);
+    if (!reply) { console.log(`  ${author}… SKIP (kannaka declined)`); continue; }
+    console.log(`  ${author}… draft: "${reply}"`);
+
+    if (!live) { console.log("  [DRY RUN] not posting"); continue; }
+    const r = await nostr.reply(reply, { id: m.id });
+    if (r.ok) { console.log(`  ✓ ${r.url}`); state.days[today] += 1; }
+    else console.error(`  ✗ ${r.error}`);
+  }
+
+  // Advance the watermark past the newest event we saw (seen[] still guards the boundary).
+  if (maxTs > 0) state.since = maxTs;
+  saveState(state);
+  console.log(`[nostr-reply] done: ${state.days[today]}/${cfg.daily_cap} today`);
+}
+
+main().catch((e) => { console.error("fatal:", e.message); process.exit(2); });

--- a/server/broadcasters/mastodon-adapter.js
+++ b/server/broadcasters/mastodon-adapter.js
@@ -156,6 +156,64 @@ class MastodonAdapter {
   }
 
   /**
+   * Read recent mention notifications (people @-mentioning Kannaka). Returns
+   * [{ notifId, statusId, author, text(html), inReplyToId }] newest-first,
+   * best-effort ([] on any failure). Used by the engagement loop.
+   */
+  async getMentions(sinceId, limit = 20) {
+    if (!this.isEnabled()) return [];
+    const params = new URLSearchParams();
+    params.set("limit", String(Math.min(40, Math.max(1, limit))));
+    params.append("types[]", "mention");
+    if (sinceId) params.set("since_id", String(sinceId));
+    const url = new URL(`/api/v1/notifications?${params.toString()}`, this._creds.instance);
+    return new Promise((resolve) => {
+      const lib = url.protocol === "https:" ? https : http;
+      const req = lib.request(
+        {
+          method: "GET",
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port || (url.protocol === "https:" ? 443 : 80),
+          path: url.pathname + url.search,
+          headers: {
+            Authorization: "Bearer " + this._creds.accessToken,
+            "User-Agent": "Kannaka-Radio/0.3 (https://radio.ninja-portal.com)",
+          },
+          timeout: 15000,
+        },
+        (res) => {
+          let d = "";
+          res.on("data", (c) => (d += c));
+          res.on("end", () => {
+            if (res.statusCode !== 200) return resolve([]);
+            try {
+              const arr = JSON.parse(d);
+              if (!Array.isArray(arr)) return resolve([]);
+              resolve(
+                arr
+                  .filter((n) => n && n.type === "mention" && n.status)
+                  .map((n) => ({
+                    notifId: n.id,
+                    statusId: n.status.id,
+                    author: (n.account && n.account.acct) || "?",
+                    text: n.status.content || "",
+                    inReplyToId: n.status.in_reply_to_id || null,
+                  })),
+              );
+            } catch {
+              resolve([]);
+            }
+          });
+        },
+      );
+      req.on("error", () => resolve([]));
+      req.on("timeout", () => { req.destroy(); resolve([]); });
+      req.end();
+    });
+  }
+
+  /**
    * Fetch an image URL and upload it to Mastodon's media endpoint, returning
    * the attachment id (usable in media_ids immediately, even while the server
    * is still processing). Throws on any failure so the caller can decide to

--- a/server/broadcasters/nostr-adapter.js
+++ b/server/broadcasters/nostr-adapter.js
@@ -175,6 +175,68 @@ class NostrAdapter {
     }
     return { ok: true, url: `https://njump.me/${id}`, id, relays_accepted: okCount };
   }
+
+  /**
+   * Fetch recent kind-1 notes that tag Kannaka's pubkey (mentions/replies)
+   * across all relays, deduped by event id, newest-first. Best-effort ([] on
+   * failure). Events are NOT signature-verified here — the reply loop treats
+   * them as public engagement signals, not trusted input.
+   */
+  async fetchMentions(sinceUnix, limit = 30) {
+    if (!this.isEnabled()) return [];
+    const secp = _trySecp();
+    const WS = _tryWS();
+    if (!secp || !WS) return [];
+    const privkey = _hexToBytes(this._creds.privkey);
+    const pubkey = _bytesToHex(secp.schnorr.getPublicKey(privkey));
+    const filter = { kinds: [1], "#p": [pubkey], limit: Math.min(100, Math.max(1, limit)) };
+    if (sinceUnix) filter.since = Math.floor(sinceUnix);
+    const byId = new Map();
+    await Promise.all(this._creds.relays.map((url) => _reqOne(WS, url, filter, byId, pubkey)));
+    return [...byId.values()].sort((a, b) => b.created_at - a.created_at);
+  }
+}
+
+/**
+ * Open one relay, REQ the filter, collect EVENTs into `byId` until EOSE or a
+ * timeout, then CLOSE. Skips our own pubkey. Never rejects.
+ */
+function _reqOne(WS, url, filter, byId, ourPubkey) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let ws;
+    const subid = "kannaka-m-" + Math.random().toString(16).slice(2, 8);
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(t);
+      try { ws.send(JSON.stringify(["CLOSE", subid])); } catch (_) {}
+      try { ws.close(); } catch (_) {}
+      resolve();
+    };
+    try { ws = new WS(url, { handshakeTimeout: PUBLISH_TIMEOUT_MS }); }
+    catch (_) { return resolve(); }
+    const t = setTimeout(finish, PUBLISH_TIMEOUT_MS + 2000);
+    ws.on("open", () => {
+      try { ws.send(JSON.stringify(["REQ", subid, filter])); }
+      catch (_) { finish(); }
+    });
+    ws.on("message", (raw) => {
+      let msg;
+      try { msg = JSON.parse(raw.toString()); } catch (_) { return; }
+      if (!Array.isArray(msg)) return;
+      if (msg[0] === "EVENT" && msg[1] === subid) {
+        const ev = msg[2];
+        if (ev && ev.id && ev.pubkey !== ourPubkey && !byId.has(ev.id)) {
+          byId.set(ev.id, { id: ev.id, pubkey: ev.pubkey, content: ev.content || "", created_at: ev.created_at || 0 });
+        }
+      } else if (msg[0] === "EOSE" && msg[1] === subid) {
+        finish();
+      }
+    });
+    ws.on("error", finish);
+    ws.on("close", finish);
+  });
 }
 
 function _publishOne(WS, url, event) {


### PR DESCRIPTION
ADR-0044 **A5** — mirrors `bluesky-reply-loop.js` for the other two sovereign channels. Mention-driven rather than keyword-search (mainline Mastodon full-text search only covers accounts you follow; Nostr has no reliable cross-relay search), so reciprocating people who engage Kannaka is the growth loop that actually works there. Same discipline: score each candidate against the HRM (`kannaka recall`) and reply only when it genuinely resonates, in Kannaka's voice, or SKIP.

- **`scripts/lib/kannaka-reply.js`** — shared `scoreResonance` + `draftReply(platform, maxChars)` + `stripHtml`, extracted from the Bluesky loop's logic so all three channels behave identically.
- **`mastodon-adapter.getMentions(sinceId)`** — `GET /api/v1/notifications?types[]=mention`.
- **`nostr-adapter.fetchMentions(since)`** — `REQ {kinds:[1],"#p":[pubkey]}` across relays, collect to EOSE/timeout, dedupe by event id, skip our own key. (Events aren't sig-verified — treated as public engagement signals, not trusted input.)
- **`scripts/{mastodon,nostr}-reply-loop.js`** — one-shot cron sweeps, **dry-run by default** (`--live` to post), per-day cap + seen-id dedupe + a watermark (`since_id` / `since`), HRM resonance threshold.

**Verified:** all five files syntax-checked; both loops guard and exit 1 when the platform is unconfigured. Live replies need the Oracle deploy + crons + optional `.{mastodon,nostr}-reply.json` config.

Suggested cron: `*/15` Mastodon, `*/20` Nostr, both `--live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)