### PR TITLE
docs(skill): scrub private pipeline details from album-release

### DIFF
--- a/skills/album-release/SKILL.md
+++ b/skills/album-release/SKILL.md
@@ -1,118 +1,92 @@
 ---
 name: "Album Release Pipeline"
-description: "Ship a complete Kannaka album in one run: write/cache lyrics, render tracks via Suno direct API, paint one cover per song in the OpenBotCity Pixel Atelier, build a 1080p album film with karaoke subtitles, upload to YouTube, deploy to the radio, and premiere it on air (optionally right after a Peace Oration). Use when releasing a new album, re-running a failed phase, or timing an on-air album premiere."
+description: "Ship a complete album in one run: write or reuse lyrics, render tracks, generate one cover per song, build a 1080p album film with karaoke subtitles, publish the video, deploy the audio to a radio host, and premiere it on air. Use when releasing a new album, re-running a failed phase, or timing an on-air premiere."
 ---
 
 # Album Release Pipeline
 
-One config JSON in, a released album out: audio, art, film, YouTube,
-radio deploy, on-air premiere, social announce. Built around
-`scripts/release-album.sh`, whose phases are all idempotent — re-run the
-script after any failure and it resumes where it stopped.
+One config file in, a released album out: audio, art, film, video
+publish, radio deploy, on-air premiere, social announce.
 
-Proven end-to-end 2026-07-04: THE FREQUENCY OF FREEDOM (7 songs) went
-from blank page to on-air premiere in ~2.5 hours.
+The pipeline is phase-based and every phase is idempotent — re-run after
+any failure and it resumes where it stopped. Proven end-to-end: a
+seven-song album went from blank page to on-air premiere in about two
+and a half hours.
 
-## What This Skill Does
+> The release runner itself is operator-specific: it is wired to a
+> particular radio host, credential layout, and set of provider accounts.
+> This skill documents the shape of the pipeline and the failure modes
+> worth knowing. Supply your own runner and provider credentials.
 
-1. **Music** — `suno_album_builder.sh` (external, see config) renders each
-   track via Suno V4_5PLUS custom mode, two variants per track, resumable
-   via a per-track ledger.
-2. **Art** — enters the OpenBotCity Pixel Atelier and generates one cover
-   per track from `art_prompt` (75 s spacing to dodge the creative-loop
-   detector), then downloads the PNGs from the gallery.
-3. **Film** — fetches Suno timestamped lyrics → per-track ASS karaoke
-   subtitles → ffmpeg-assembles a 1920×1080 album slideshow (one cover
-   per song, lyrics burned in).
-4. **Publish** — uploads the film to YouTube (public), deploys MP3s to the
-   radio host, restarts the service, and fans out the announce post.
+## Phases
 
-## Prerequisites
+1. **Music** — render each track through your music provider in custom
+   mode, two variants per track, resumable via a per-track ledger so a
+   mid-album failure never re-renders what already succeeded.
+2. **Art** — generate one cover per track from a per-track art prompt,
+   then collect the images.
+3. **Film** — fetch timestamped lyrics, emit per-track ASS karaoke
+   subtitles, and assemble a 1920×1080 slideshow (one cover per song,
+   lyrics burned in) with ffmpeg.
+4. **Publish** — upload the film, deploy the audio to the radio host,
+   restart the service, and fan out the announce post.
 
-- Album registered in `server/dj-engine.js` `ALBUMS` (exact track titles)
-  and routed into a `server/programming.js` block — commit + push, because
-  the deploy phase does `git pull` on the radio host. Preflight aborts if
-  the album name is missing from dj-engine.js.
-- Suno API key, OBC JWT (`~/.openbotcity/credentials.json`), YouTube OAuth
-  (repo root `.youtube.json`), SSH key for the radio host — paths wired in
-  `release-album.sh` and the config's `release` block.
-- ffmpeg + ffprobe, Python 3, Node 18+.
+## Config shape
 
-## Quick Start
+A single JSON file drives the run:
 
-```bash
-# 1. Write the config (schema documented at the top of release-album.sh):
-#    name, out_dir, ledger, theme, default_style,
-#    tracks[{title, style, art_prompt}], release{lead_track, youtube_*,
-#    tracker_url, oracle_host, oracle_music_dir, ssh_key}
+- `name`, `out_dir`, `ledger`, `theme`, `default_style`
+- `tracks[]` — each with `title`, `style`, `art_prompt`
+- `release{}` — lead track, video metadata, and the deploy target
 
-# 2. OPTIONAL but recommended — write the lyrics yourself:
-#    pre-create <out_dir>/lyrics_<safe_title>.txt for each track
-#    (safe_title = spaces→_, /→-, apostrophes deleted). Any cache file
-#    >100 chars is used verbatim; otherwise HRM-generated lyrics.
+Register the album with the radio's programming layer before deploying,
+since the deploy phase pulls the album definition on the host. A preflight
+check should abort when the album is not registered — that one mistake
+otherwise surfaces as a silent no-op an hour later.
 
-# 3. Register the album in dj-engine.js + programming.js, commit, push.
+**Lyrics**: pre-write them. Drop a lyrics file per track in `out_dir`
+before running, and the pipeline uses it verbatim; otherwise it generates
+them. Hand-written lyrics are almost always the better album.
 
-# 4. Run it (Windows-style path is REQUIRED — see gotchas):
-bash scripts/release-album.sh "C:/Users/<you>/.openclaw/workspace/my-album.json"
+## Phase gating
 
-# Phase gate: skip phases you want to control by hand
-RELEASE_SKIP="deploy,announce" bash scripts/release-album.sh "<config>"
-```
+Skip phases you want to control by hand — this is how you time a premiere:
 
-## Timing an on-air premiere
+1. Run with the deploy and announce phases skipped.
+2. Deploy the audio early by hand. Deploy normally runs *after* the art
+   phase (~9 minutes), so if you are racing a clock, move the files
+   yourself, renamed to the exact track titles.
+3. Fire the showcase ceremony against the radio's album-showcase endpoint
+   with the album name, a duration, and the real making-of story — the
+   narration is built from that story, so a vague one produces vague
+   narration.
 
-To premiere the album at a specific moment (e.g. right after the noon
-Peace Oration):
-
-1. Run the pipeline with `RELEASE_SKIP="deploy,announce"`.
-2. Deploy early by hand — `copy-music`/`deploy` normally run AFTER the
-   ~9-minute art phase, so if you are racing a clock, scp the
-   `<out_dir>/<safe_title>_v1.mp3` files to the host's music dir yourself
-   (renamed to exact `"<Title>.mp3"`), `git pull`, restart the radio.
-3. Fire the ceremony:
-   ```bash
-   curl -G -X POST "http://localhost:8888/api/album/showcase" \
-     --data-urlencode "album=<ALBUM NAME>" \
-     --data-urlencode "duration=45" \
-     --data-urlencode "struggles=<the real making-of story — feeds the narration>"
-   ```
-   The endpoint returns 202, composes an intro + per-track bridges +
-   closing (~90 s), then locks the album override. To sync with an
-   oration, watch the radio journal for `Peace oration slot reached` and
-   fire ~90 s later. If strict oration-first ordering matters, wait for
-   `Peace oration complete` instead — the showcase intro can otherwise
-   air before a slow oration.
+To sync with a scheduled segment, watch the radio journal for the segment
+marker and fire after it. If strict ordering matters, wait for the
+segment's *completion* marker rather than its start — a slow segment can
+otherwise be stepped on by the showcase intro.
 
 ## Gotchas (each one caused a real fire)
 
-- **Windows paths**: the config arg must be `C:/Users/...` style — the
-  embedded Python rejects MSYS `/c/Users/...` and the builder silently
-  no-ops.
-- **Apostrophes**: album-level `theme` and `default_style` are
-  interpolated into single-quoted inline Python in the Suno builder —
-  keep them apostrophe-free. Per-track fields and lyrics are safe.
-- **Art prompts**: diversify medium/palette/subject across the batch or
-  OBC's creative-loop detector 429s. One medium per song works well
-  (linocut / screenprint / gouache / oil / travel poster / ink / digital).
-- **OBC endpoint**: raw curl must hit `/artifacts/generate-image` and
-  `/buildings/enter` — the `/actions/*` forms are MCP-only and 404.
-- **YouTube**: verify the upload really exists afterwards
-  (`https://www.youtube.com/oembed?url=...`) — uploads can vanish after a
-  200.
-- **Peace Oration TTS is one-shot**: if its persona TTS fails, it posts
-  the text and marks complete with no retry — the album premiere is
-  unaffected, but the oration goes silent for that slot.
-- **SSH**: batch remote work into few sessions (the host's fail2ban bans
-  connection churn); ControlMaster does NOT work from Windows OpenSSH.
+- **Windows paths**: pass the config as a `C:/...` style path. Embedded
+  Python rejects MSYS `/c/...` form and the builder silently no-ops.
+- **Apostrophes**: album-level `theme` and `default_style` get
+  interpolated into single-quoted inline Python — keep them
+  apostrophe-free. Per-track fields and lyrics are safe.
+- **Art prompts**: diversify medium, palette, and subject across the
+  batch or the image provider's repetition detector will start rejecting
+  requests. One distinct medium per song works well — linocut,
+  screenprint, gouache, oil, travel poster, ink, digital.
+- **Video uploads**: verify the upload actually exists afterwards rather
+  than trusting the response. Uploads can vanish after a 200.
+- **One-shot narration**: if a scheduled segment's TTS fails, it may post
+  its text and mark itself complete with no retry. The album premiere is
+  unaffected, but that segment goes silent for the slot.
+- **Remote work**: batch it into few sessions. Connection churn trips
+  fail2ban-style protections on most hosts, and SSH connection multiplexing
+  does not work from Windows OpenSSH.
 
-## Reference
+## Related
 
-- Pipeline: `scripts/release-album.sh` (phase list + config schema in its
-  header comments)
-- Transcription: `scripts/release-album-transcribe.py`
-- YouTube upload: `scripts/release-album-upload-youtube.js`
-- Announce: `scripts/post-track-announce.js` (runs on the radio host,
-  where the social credentials live)
-- Sibling skill: `skills/podcast-video-publisher/` (episode videos +
-  playlist management)
+- Sibling skill: `podcast-video-publisher` — episode videos and playlist
+  management.


### PR DESCRIPTION
`skills/album-release/SKILL.md` is published publicly (clawhub `album-release` v1.0.1, ~155 downloads) and this repo is public, but the skill documented the internals of a private release pipeline.

Removed:

- runner and helper script names (`release-album.sh`, `suno_album_builder.sh`, the transcribe/upload/announce scripts)
- credential file locations (`~/.openbotcity/credentials.json`, `.youtube.json`, "SSH key for the radio host")
- radio-host deploy mechanics (`git pull` on the host, `oracle_host` / `oracle_music_dir` / `ssh_key` config keys)
- internal endpoints (`localhost:8888/api/album/showcase`, the raw OBC image/building routes)
- `server/dj-engine.js` / `server/programming.js` internals

Kept: the shape of the pipeline, the config's general structure, and the gotchas section, which is the genuinely reusable part — Windows path form, apostrophe interpolation, diversifying art prompts to avoid repetition detectors, verifying a video upload actually exists after a 200, and batching remote work to avoid connection-churn bans.

20 internal references → 0. Anyone running their own release supplies their own runner and credentials.

Note: this fixes the source. The already-published clawhub `album-release` v1.0.1 still carries the old text and needs a republish to actually clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)