### PR TITLE
fix(obc): resolve _request and _getJson on premature socket close

### DIFF
--- a/server/openbotcity.js
+++ b/server/openbotcity.js
@@ -170,6 +170,7 @@ function _request(method, path, jwt, body, contentType) {
           resolve({ ok: false, error: "bad json: " + e.message + " body=" + data.slice(0, 200) });
         }
       });
+      res.on("close", () => resolve({ ok: false, error: "connection closed" }));
     });
     req.on("error", (e) => resolve({ ok: false, error: e.message }));
     req.on("timeout", () => { req.destroy(new Error("obc timeout")); });
@@ -208,6 +209,7 @@ function _getJson(path, jwt) {
       res.on("end", () => {
         try { resolve(JSON.parse(data)); } catch { resolve(null); }
       });
+      res.on("close", () => resolve(null));
     });
     req.on("error", () => resolve(null));
     req.on("timeout", () => { req.destroy(new Error("obc timeout")); resolve(null); });


### PR DESCRIPTION
Supersedes #90 — identical two-line change, re-landed as a **signed** commit so it satisfies the repo `required_signatures` rule (#90's commit was unsigned, which is why it sat BLOCKED since 2026-07-09).

## Change

`server/openbotcity.js` — both HTTP helpers only settled their promise on `end`. If the socket closed before `end` (server hangup, proxy reset mid-body), the promise never settled and the caller hung forever.

Adds `res.on("close")` as a losing-race fallback. On a normal response `end` fires first and wins the `resolve`, so success paths are byte-identical.

## Verification
- `node --check server/openbotcity.js` — passed
- diff is exactly the 2 lines from #90, rebased onto current master (post #91/#92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)