### PR TITLE
fix(config): honour RADIO_PORT and let --port outrank ambient PORT

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,28 @@ const BASE_DIR = path.join(__dirname, "..");
 
 const args = process.argv.slice(2);
 const portIdx = args.indexOf("--port");
-const PORT = parseInt(process.env.PORT || (portIdx >= 0 ? args[portIdx + 1] : '')) || 8888;
+// Precedence: explicit --port flag, then RADIO_PORT, then PORT, then 8888.
+// An explicit flag has to win over ambient env — scripts/radio.sh computes the
+// port from RADIO_PORT and passes it as `--port`, so a stray PORT in the
+// environment used to bind the server somewhere radio.sh's own BASE_URL (and
+// scripts/drop.js, which reads RADIO_PORT) would then fail to reach.
+// RADIO_PORT outranks PORT because it is the documented, radio-specific name.
+const PORT = firstPort([
+  portIdx >= 0 ? args[portIdx + 1] : undefined,
+  process.env.RADIO_PORT,
+  process.env.PORT,
+]) || 8888;
+
+/** First value that parses as a usable TCP port, else undefined. */
+function firstPort(candidates) {
+  for (const raw of candidates) {
+    if (raw === undefined || raw === null || String(raw).trim() === "") continue;
+    const n = parseInt(String(raw).trim(), 10);
+    if (Number.isInteger(n) && n >= 0 && n <= 65535) return n;
+    console.warn(`[config] ignoring invalid port value ${JSON.stringify(String(raw))}`);
+  }
+  return undefined;
+}
 const musicIdx = args.indexOf("--music-dir");
 
 let MUSIC_DIR = musicIdx >= 0


### PR DESCRIPTION
Closes #151.

## The bug is bigger than the issue title

`server/index.js` resolved its listen port as:

```js
const PORT = parseInt(process.env.PORT || (portIdx >= 0 ? args[portIdx + 1] : "")) || 8888;
```

Two problems, and the second is the sharper one:

**1. `RADIO_PORT` was ignored outright** — even though it is the documented knob (`workspace/skills/kannaka-radio/SKILL.md:260`, `| RADIO_PORT | 8888 | HTTP port |`) and the variable `scripts/drop.js:130` reads to reach a running server.

**2. An explicit `--port` flag lost to an ambient `PORT` env var.** `scripts/radio.sh` computes the port from `RADIO_PORT`, launches with `node "$SERVER_JS" --port "$PORT"` (line 74), and builds `BASE_URL` from the same value (line 36). So with a stray `PORT` in the environment — common, since lots of tooling sets it — the server bound one port while `radio.sh`s health checks and `drop.js` both kept addressing `RADIO_PORT`. Split-brain, and it looks like the server is down rather than misconfigured.

## The fix

Precedence is now **`--port` flag → `RADIO_PORT` → `PORT` → 8888**. An explicit flag beats ambient env; the radio-specific name beats the generic one.

Values that do not parse as a 0–65535 integer are skipped with a warning rather than silently collapsing to 8888, so a typo no longer masquerades as the default.

## Verification

`node --check server/index.js` passes, and the precedence table was exercised directly:

```
PASS  flag wins over both env vars           -> 9000
PASS  RADIO_PORT wins over PORT              -> 7000
PASS  PORT used when it is the only one      -> 6000
PASS  all unset -> undefined -> 8888
PASS  blank/whitespace skipped               -> 6000
PASS  invalid flag falls through to RADIO_PORT -> 7000   (warned on "notaport")
PASS  out-of-range falls through             -> 7000   (warned on "99999")
ALL PASSED
```

No behaviour change for the common deployments: with only `PORT` set, or with neither set, the resolved port is identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)