### PR TITLE
fix(dj): actually play queued requests and vote winners

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -507,6 +507,10 @@ class DJEngine {
   constructor(opts) {
     this._getMusicDir = opts.getMusicDir;
     this._onTrackChange = opts.onTrackChange || (() => {});
+    // Fired when userQueue is drained by playback, so the WS clients that
+    // render the queue see the request leave it. Optional: the engine works
+    // fine without it, the UI just refreshes a beat later off /api/state.
+    this._onQueueChange = opts.onQueueChange || (() => {});
     // Phase 3 of ADR-0006 — feedback loop. The Floor (workspace/index.html)
     // accumulates reactions per track; we read those stats here to bump
     // high-resonance tracks toward the front of new playlists. Settable
@@ -1302,8 +1306,62 @@ class DJEngine {
    * so Kannaka has time to "think about what she's going to say."
    * Returns null if there's no next track and the playlist doesn't loop.
    */
+  /**
+   * Move the head of `userQueue` into the playlist slot that airs next.
+   *
+   * `addToQueue` (POST /api/queue) and the vote-window winner both push into
+   * `userQueue`, but nothing ever read it back out — so requests and vote
+   * winners accumulated forever and never played (#142). Playback is driven
+   * entirely by `playlistMeta[currentTrackIdx]`, so the fix is to splice the
+   * request into that array rather than teach every consumer about a second
+   * source of tracks: history, the 12h no-repeat ledger, peek/announce and
+   * the UI all keep working unchanged.
+   *
+   * Idempotent within a boundary — if the next slot already holds a promoted
+   * request we return it instead of promoting another. That matters because
+   * `peekNextTrack` (which pre-generates the DJ intro) and `advanceTrack`
+   * both call this: without the guard the DJ would announce one request and
+   * then play a different one.
+   *
+   * @returns {object|null} the promoted entry, or null if nothing was queued.
+   */
+  _promoteQueuedRequest() {
+    const meta = this.state.playlistMeta;
+    if (!meta || !Array.isArray(this.userQueue)) return null;
+
+    const nextIdx = this.state.currentTrackIdx + 1;
+    if (meta[nextIdx] && meta[nextIdx].requested) return meta[nextIdx];
+    if (this.userQueue.length === 0) return null;
+
+    const req = this.userQueue.shift();
+    const file = req.filename || req.path;
+    if (!file) return null; // malformed entry — drop it rather than wedge the queue
+
+    const entry = {
+      title: req.title || path.basename(String(file), path.extname(String(file))),
+      album: this.state.currentAlbum || "Requests",
+      file,
+      requested: true,
+      votedIn: !!req.votedIn,
+    };
+    // Clamp: currentTrackIdx can be -1 (jumpToTrack/prevTrack rewind it), and
+    // it can sit at the last index when the playlist is about to wrap.
+    const at = Math.min(Math.max(nextIdx, 0), meta.length);
+    meta.splice(at, 0, entry);
+    this.state.playlist.splice(at, 0, entry.file);
+
+    console.log(`[dj] request promoted to next slot: "${entry.title}"${entry.votedIn ? " (vote winner)" : ""}`);
+    try { this._onQueueChange(this.userQueue); } catch (_) {}
+    return entry;
+  }
+
   peekNextTrack() {
     if (!this.state.playlistMeta || this.state.playlistMeta.length === 0) return null;
+    // A pending request outranks whatever the playlist had queued up next,
+    // and promoting it here (not just in advanceTrack) keeps the DJ's
+    // "coming up next" announcement matched to what actually airs.
+    const promoted = this._promoteQueuedRequest();
+    if (promoted) return promoted;
     const nextIdx = this.state.currentTrackIdx + 1;
     // Wrap-and-reshuffle race: if we'd loop, advanceTrack reshuffles before
     // picking [0]. Doing that here too means peek and advance see the same
@@ -1360,6 +1418,11 @@ class DJEngine {
       if (cur) { this._markPlayed(cur); this._onTrackChange(cur); }
       return cur;
     }
+
+    // Splice any pending request into the next slot BEFORE incrementing, so
+    // the increment lands on it. No-op when peekNextTrack already promoted
+    // this boundary's request.
+    this._promoteQueuedRequest();
 
     this.state.currentTrackIdx++;
     if (this.state.currentTrackIdx >= this.state.playlist.length) {

--- a/server/index.js
+++ b/server/index.js
@@ -239,6 +239,10 @@ let _inTrackChange = false; // re-entrancy guard: loadAlbum inside programming c
 
 const djEngine = new DJEngine({
   getMusicDir: () => MUSIC_DIR,
+  // Fired when playback drains a request out of userQueue (#142), so the
+  // queue panel drops it at the moment it starts airing rather than showing
+  // a track that is already playing as still "up next".
+  onQueueChange: () => broadcastQueue(),
   onTrackChange: (track) => {
     // ── Re-entrancy guard ────────────────────────────────
     // programming.onTrackChange may call loadAlbum which resets the playlist.

--- a/test/dj-engine.test.js
+++ b/test/dj-engine.test.js
@@ -140,6 +140,108 @@ test('generateTrackClusters returns cluster per album', () => {
   assert.ok(names.includes('Emergence'));
 });
 
+// ── User queue is actually consumed by playback (#142) ──────
+//
+// addToQueue and the vote-window winner both push into userQueue, but
+// nothing used to read it back out, so requests never aired. These lock in
+// that advanceTrack drains the queue, that peek and advance agree on what
+// plays next, and that an empty queue changes nothing.
+
+/** Fresh engine with a hand-built 3-track playlist and no real files. */
+function queueRig() {
+  const changes = [];
+  const e = new DJEngine({
+    getMusicDir: () => '/nonexistent-music-dir',
+    onTrackChange: () => {},
+    onQueueChange: (q) => changes.push(q.length),
+  });
+  e.state.playlistMeta = [
+    { title: 'A', file: '/m/a.mp3' },
+    { title: 'B', file: '/m/b.mp3' },
+    { title: 'C', file: '/m/c.mp3' },
+  ];
+  e.state.playlist = e.state.playlistMeta.map(t => t.file);
+  e.state.currentTrackIdx = 0;
+  e.state.channel = 'dj';
+  return { e, changes };
+}
+
+test('#142 advanceTrack plays a queued request before the next playlist track', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ filename: '/m/req.mp3', title: 'Requested', path: '/m/req.mp3' });
+  const next = e.advanceTrack();
+  assert.strictEqual(next.title, 'Requested', 'request should air next, not playlist track B');
+  assert.strictEqual(e.userQueue.length, 0, 'request should be drained from userQueue');
+  assert.strictEqual(next.requested, true, 'promoted entry should be marked requested');
+});
+
+test('#142 playlist and playlistMeta stay parallel after promotion', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ filename: '/m/req.mp3', title: 'Requested', path: '/m/req.mp3' });
+  e.advanceTrack();
+  assert.strictEqual(e.state.playlist.length, e.state.playlistMeta.length,
+    'splicing must touch both arrays or getCurrentTrack desyncs from the file list');
+  assert.deepStrictEqual(e.state.playlist, e.state.playlistMeta.map(t => t.file));
+});
+
+test('#142 the playlist resumes where it left off after the request', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ filename: '/m/req.mp3', title: 'Requested', path: '/m/req.mp3' });
+  e.advanceTrack();
+  const after = e.advanceTrack();
+  assert.strictEqual(after.title, 'B', 'track B should still follow, not be skipped');
+});
+
+test('#142 peekNextTrack and advanceTrack agree — request is not injected twice', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ filename: '/m/req.mp3', title: 'Requested', path: '/m/req.mp3' });
+  const peeked = e.peekNextTrack();
+  const played = e.advanceTrack();
+  assert.strictEqual(peeked.title, 'Requested', 'peek should see the request');
+  assert.strictEqual(played.title, 'Requested', 'advance should play what peek announced');
+  assert.strictEqual(e.state.playlistMeta.filter(t => t.requested).length, 1,
+    'promoting in both peek and advance must not duplicate the entry');
+});
+
+test('#142 vote winners carry votedIn through to the aired track', () => {
+  const { e } = queueRig();
+  e.userQueue.unshift({ filename: '/m/win.mp3', title: 'Winner', path: '/m/win.mp3', votedIn: true });
+  const next = e.advanceTrack();
+  assert.strictEqual(next.title, 'Winner');
+  assert.strictEqual(next.votedIn, true);
+});
+
+test('#142 multiple requests air in FIFO order, one per boundary', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ filename: '/m/1.mp3', title: 'First', path: '/m/1.mp3' });
+  e.userQueue.push({ filename: '/m/2.mp3', title: 'Second', path: '/m/2.mp3' });
+  assert.strictEqual(e.advanceTrack().title, 'First');
+  assert.strictEqual(e.advanceTrack().title, 'Second');
+  assert.strictEqual(e.advanceTrack().title, 'B', 'then back to the playlist');
+});
+
+test('#142 onQueueChange fires so the UI drops the request as it starts', () => {
+  const { e, changes } = queueRig();
+  e.userQueue.push({ filename: '/m/req.mp3', title: 'Requested', path: '/m/req.mp3' });
+  e.advanceTrack();
+  assert.deepStrictEqual(changes, [0], 'one notification, reporting the drained queue');
+});
+
+test('#142 an empty queue leaves advanceTrack behaviour unchanged', () => {
+  const { e, changes } = queueRig();
+  assert.strictEqual(e.advanceTrack().title, 'B');
+  assert.strictEqual(e.state.playlistMeta.length, 3, 'nothing spliced in');
+  assert.deepStrictEqual(changes, [], 'no spurious queue notifications');
+});
+
+test('#142 a malformed queue entry is dropped instead of wedging the queue', () => {
+  const { e } = queueRig();
+  e.userQueue.push({ title: 'No file anywhere' });
+  const next = e.advanceTrack();
+  assert.strictEqual(next.title, 'B', 'playlist continues');
+  assert.strictEqual(e.userQueue.length, 0, 'bad entry removed, not retried forever');
+});
+
 // ── Summary ─────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);


### PR DESCRIPTION
Closes #142.

## The bug

`DJEngine.userQueue` is written by two paths and read by none:

- `addToQueue()` — `POST /api/queue` (`server/routes.js:1161`)
- the vote-window result handler — `djEngine.userQueue.unshift({... votedIn: true})` (`server/routes.js:1534`)

`removeFromQueue` / `shuffleQueue` / `broadcastQueue` all maintain and display it. But playback is driven entirely by `playlistMeta[currentTrackIdx]`, and **`advanceTrack` never touched `userQueue`**. So every listener request and every vote winner piled up in an array that the UI rendered and the station ignored. The vote feature in particular ran the whole window, announced a winner, logged `Vote winner queued: "X"` — and then never played it.

## The fix

Splice the head of `userQueue` into the playlist slot that airs next, instead of teaching every consumer about a second source of tracks. Because the request becomes a normal `playlistMeta` entry, history, the 12h no-repeat ledger, `peekNextTrack`, the DJ announce and the queue UI all keep working with no changes, and `playlist` / `playlistMeta` stay parallel.

Three details worth calling out:

- **`_promoteQueuedRequest` is idempotent within a boundary.** `peekNextTrack` (which pre-generates the DJ intro so Kannaka has time to think) and `advanceTrack` both call it. Without the guard the DJ would announce one request and then play a different one — the same class of peek/advance disagreement the existing `_reshufflePending` flag was added to prevent.
- **Malformed entries are dropped, not retried.** An entry with no `filename` or `path` is removed rather than left at the head, so a single bad POST cannot wedge the queue permanently.
- **`onQueueChange`** is new and optional; wired in `index.js` to `broadcastQueue()` so the queue panel drops the request the moment it starts airing, rather than showing an already-playing track as still up next.

## Verification

9 regression tests added to `test/dj-engine.test.js`, in the files existing style:

```
DJ Engine: 23 passed, 0 failed
```

**Revert-and-confirm-fail:** with `server/dj-engine.js` reverted to master and the new tests kept, **7 of 9 turn red**:

```
❌ advanceTrack plays a queued request before the next playlist track
❌ the playlist resumes where it left off after the request
❌ peekNextTrack and advanceTrack agree — request is not injected twice
❌ vote winners carry votedIn through to the aired track
❌ multiple requests air in FIFO order, one per boundary
❌ onQueueChange fires so the UI drops the request as it starts
❌ a malformed queue entry is dropped instead of wedging the queue
✅ an empty queue leaves advanceTrack behaviour unchanged   <- negative control
✅ playlist and playlistMeta stay parallel after promotion  <- negative control
DJ Engine: 16 passed, 7 failed
```

The two that stay green are the negative controls and should hold either way — an empty queue must not change `advanceTrack`, and the arrays are trivially parallel when nothing is spliced.

Full suite passes locally through `portability-paths`; it then stops at `ghostsignals-ttl-authority` on `sqlite3 module not found`, which is a missing dependency in my checkout (no `node_modules`) in a test that does not import dj-engine. CI runs the full suite with deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)