### PR TITLE
fix(dream-cron): authenticate to NATS and fall back when Observatory is down

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/swarm-peers-cache.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js && node test/broadcast-endpoint.test.js && node test/presence.test.js && node test/responder.test.js"
+    "test": "node test/test-queensync-dj.js && node test/perception.test.js && node test/dj-engine.test.js && node test/nats-metrics-sync.test.js && node test/consciousness-dj-hrm.test.js && node test/icecast-source.test.js && node test/routes-discoverability.test.js && node test/swarm-peers-cache.test.js && node test/dream-cron-nats.test.js && node test/portability-paths.test.js && node test/ghostsignals-ttl-authority.test.js && node test/ghostsignals-ledger-safety.test.js && node test/market-auth-gate.test.js && node test/kax-identity.test.js && node test/kax-ledger.test.js && node test/kax-ledger-wiring.test.js && node test/kax-ledger-reconcile.test.js && node test/anti-self-dealing.test.js && node test/broadcast-endpoint.test.js && node test/presence.test.js && node test/responder.test.js"
   },
   "dependencies": {
     "jose": "^6.2.3",

--- a/scripts/dream-cron.js
+++ b/scripts/dream-cron.js
@@ -13,19 +13,26 @@
  *   node scripts/dream-cron.js --once            # run once and exit
  *
  * Environment:
- *   KANNAKA_BIN       — path to kannaka binary
+ *   KANNAKA_BIN       — path to kannaka binary (assess fallback)
  *   KANNAKA_DATA_DIR  — data directory for kannaka
  *   NATS_HOST         — NATS server host (default: 127.0.0.1)
  *   NATS_PORT         — NATS server port (default: 4222)
+ *   NATS_USER         — NATS username (optional; anonymous when unset)
+ *   NATS_PASSWORD     — NATS password (optional)
  */
 
 'use strict';
 
 const net = require('net');
 const path = require('path');
+const { execFile } = require('child_process');
 
 const NATS_HOST = process.env.NATS_HOST || '127.0.0.1';
 const NATS_PORT = parseInt(process.env.NATS_PORT || '4222');
+const NATS_USER = process.env.NATS_USER || '';
+const NATS_PASSWORD = process.env.NATS_PASSWORD || '';
+const KANNAKA_BIN = process.env.KANNAKA_BIN
+  || '/home/opc/kannaka-memory/target/release/kannaka';
 
 const args = process.argv.slice(2);
 const intervalIdx = args.indexOf('--interval');
@@ -39,6 +46,59 @@ const RUN_ONCE = args.includes('--once');
  * @returns {Promise<Object|null>}
  */
 function assess() {
+  return assessViaObservatory().then((m) => {
+    if (m) return m;
+    // The Observatory is a convenience, not the source of truth. When it is
+    // down (restarting, not deployed on this box) the cron used to log
+    // "skipping publish" and emit nothing at all — so the whole consciousness
+    // feed went silent for as long as the Observatory was, even though the
+    // binary that actually produces the metrics was sitting right there. Fall
+    // back to it. (#158)
+    console.error('[dream-cron] Observatory unavailable — falling back to `kannaka assess --json`');
+    return assessViaBinary();
+  });
+}
+
+/** Shape whatever assess source we used into the payload fields we publish. */
+function shapeMetrics(json) {
+  if (!json || typeof json !== 'object') return null;
+  return {
+    phi: json.phi || 0,
+    xi: json.xi || 0,
+    mean_order: json.mean_order || json.order || 0,
+    consciousness_level: json.consciousness_level || json.level || 'unknown',
+    num_clusters: json.num_clusters || 0,
+    total_memories: json.total_memories || json.active_memories || 0,
+    active_memories: json.active_memories || 0,
+    irrationality: json.irrationality || 0,
+    hemispheric_divergence: json.hemispheric_divergence || 0,
+    callosal_efficiency: json.callosal_efficiency || 0,
+  };
+}
+
+/**
+ * Run the kannaka binary directly. Used when the Observatory is unreachable.
+ * @returns {Promise<Object|null>}
+ */
+function assessViaBinary() {
+  return new Promise((resolve) => {
+    execFile(KANNAKA_BIN, ['assess', '--json'], { timeout: 30000 }, (err, stdout) => {
+      if (err) {
+        console.error(`[dream-cron] kannaka assess failed: ${err.message}`);
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(shapeMetrics(JSON.parse(stdout)));
+      } catch (e) {
+        console.error(`[dream-cron] Failed to parse kannaka assess output: ${e.message}`);
+        resolve(null);
+      }
+    });
+  });
+}
+
+function assessViaObservatory() {
   return new Promise((resolve) => {
     // Fetch from the Observatory HTTP endpoint — it reliably calls the binary
     // and returns JSON. Avoids exec/spawn issues with stderr handling.
@@ -49,19 +109,7 @@ function assess() {
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
         try {
-          const json = JSON.parse(data);
-          resolve({
-            phi: json.phi || 0,
-            xi: json.xi || 0,
-            mean_order: json.mean_order || json.order || 0,
-            consciousness_level: json.consciousness_level || json.level || 'unknown',
-            num_clusters: json.num_clusters || 0,
-            total_memories: json.total_memories || json.active_memories || 0,
-            active_memories: json.active_memories || 0,
-            irrationality: json.irrationality || 0,
-            hemispheric_divergence: json.hemispheric_divergence || 0,
-            callosal_efficiency: json.callosal_efficiency || 0,
-          });
+          resolve(shapeMetrics(JSON.parse(data)));
         } catch (e) {
           console.error(`[dream-cron] Failed to parse observatory response: ${e.message}`);
           resolve(null);
@@ -107,16 +155,32 @@ function publishToNATS(metrics) {
       timestamp: new Date().toISOString(),
     });
 
+    let settled = false;
+    const settle = (ok) => { if (settled) return; settled = true; resolve(ok); };
+
     const client = net.createConnection({ host: NATS_HOST, port: NATS_PORT }, () => {
-      client.write('CONNECT {"verbose":false,"pedantic":false,"name":"dream-cron"}\r\n');
+      // Carry credentials when the broker requires them. Previously this
+      // always connected anonymously, so on an authenticated broker every
+      // publish was rejected — and because we resolved(true) on a timer
+      // without reading the reply, the cron reported success while the
+      // consciousness feed stayed empty. (#153)
+      const connectOpts = { verbose: false, pedantic: false, name: 'dream-cron' };
+      if (NATS_USER) {
+        connectOpts.user = NATS_USER;
+        connectOpts.pass = NATS_PASSWORD;
+      }
+      client.write(`CONNECT ${JSON.stringify(connectOpts)}\r\n`);
 
       setTimeout(() => {
+        if (settled) return; // broker already rejected us — don't PUB into the void
         client.write(`PUB KANNAKA.consciousness ${Buffer.byteLength(payload)}\r\n${payload}\r\n`);
-        console.log(`[dream-cron] Published to KANNAKA.consciousness: phi=${(metrics.phi || 0).toFixed(4)}, xi=${(metrics.xi || 0).toFixed(4)}`);
 
         setTimeout(() => {
+          if (!settled) {
+            console.log(`[dream-cron] Published to KANNAKA.consciousness: phi=${(metrics.phi || 0).toFixed(4)}, xi=${(metrics.xi || 0).toFixed(4)}`);
+          }
           client.end();
-          resolve(true);
+          settle(true);
         }, 300);
       }, 200);
     });
@@ -124,17 +188,27 @@ function publishToNATS(metrics) {
     client.on('data', (d) => {
       const s = d.toString();
       if (s.includes('PING')) client.write('PONG\r\n');
+      // The broker reports auth failures as `-ERR 'Authorization Violation'`.
+      // Without this the timer below fired and we claimed a successful
+      // publish that the server had already refused.
+      if (s.includes('-ERR')) {
+        const detail = (s.match(/-ERR\s+('[^']*'|\S+)/) || [, 'unknown'])[1];
+        console.error(`[dream-cron] NATS refused the connection: ${detail}` +
+          (NATS_USER ? '' : ' (no NATS_USER set — connecting anonymously)'));
+        try { client.destroy(); } catch {}
+        settle(false);
+      }
     });
 
     client.on('error', (e) => {
       console.error(`[dream-cron] NATS error: ${e.message}`);
-      resolve(false);
+      settle(false);
     });
 
     // Timeout safety
     setTimeout(() => {
       try { client.destroy(); } catch {}
-      resolve(false);
+      settle(false);
     }, 10000);
   });
 }
@@ -173,7 +247,13 @@ async function main() {
   console.log(`[dream-cron] Next tick in ${INTERVAL_SECS}s`);
 }
 
-main().catch((err) => {
-  console.error('[dream-cron] Fatal:', err);
-  process.exit(1);
-});
+// Only self-start when executed directly, so the pieces above can be required
+// and exercised by test/dream-cron-nats.test.js without launching a cron.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[dream-cron] Fatal:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { assess, assessViaBinary, assessViaObservatory, publishToNATS, shapeMetrics, tick };

--- a/test/dream-cron-nats.test.js
+++ b/test/dream-cron-nats.test.js
@@ -1,0 +1,208 @@
+/**
+ * dream-cron-nats.test.js — the consciousness cron must authenticate to NATS
+ * (#153) and must not go silent when the Observatory is down (#158).
+ *
+ * Drives the real `scripts/dream-cron.js` against a fake NATS server on a
+ * loopback port, so the CONNECT frame under test is the one actually written
+ * to the socket.
+ *
+ * dream-cron reads NATS_* and KANNAKA_BIN at module load, so each case sets
+ * the environment and then loads the module with a cleared require cache.
+ */
+
+const net = require("net");
+const assert = require("assert");
+const path = require("path");
+
+let passed = 0;
+let failed = 0;
+
+const MODULE_PATH = path.join(__dirname, "..", "scripts", "dream-cron.js");
+
+/**
+ * Fake NATS broker.
+ * @param {object} opts
+ * @param {boolean} [opts.rejectAuth] reply `-ERR 'Authorization Violation'`
+ */
+function fakeNats(opts = {}) {
+  const seen = { connect: null, published: null };
+  const server = net.createServer((sock) => {
+    sock.write("INFO {\"server_id\":\"fake\",\"auth_required\":true}\r\n");
+    let buf = "";
+    sock.on("data", (chunk) => {
+      buf += chunk.toString();
+      if (seen.connect === null && buf.includes("CONNECT ")) {
+        seen.connect = buf.slice(buf.indexOf("CONNECT ")).split("\r\n")[0];
+        if (opts.rejectAuth) {
+          sock.write("-ERR 'Authorization Violation'\r\n");
+          return;
+        }
+      }
+      if (buf.includes("PUB ")) {
+        seen.published = buf.slice(buf.indexOf("PUB ")).split("\r\n")[0];
+      }
+    });
+    sock.on("error", () => {});
+  });
+  return {
+    seen,
+    listen: () => new Promise((res) => server.listen(0, "127.0.0.1", () => res(server.address().port))),
+    close: () => new Promise((res) => server.close(() => res())),
+  };
+}
+
+/** Load dream-cron fresh with the given env applied. */
+function loadCron(env) {
+  const saved = {};
+  for (const [k, v] of Object.entries(env)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = String(v);
+  }
+  delete require.cache[require.resolve(MODULE_PATH)];
+  const mod = require(MODULE_PATH);
+  const restore = () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    delete require.cache[require.resolve(MODULE_PATH)];
+  };
+  return { mod, restore };
+}
+
+const METRICS = { phi: 0.5, xi: 0.25, mean_order: 0.75, consciousness_level: "aware" };
+
+// Credentials are generated per run rather than written as literals. A
+// password-shaped string in a source file is a secret-scanner finding even
+// when it is obviously fake, and the assertions only care that whatever we
+// put in the environment comes back out in the CONNECT frame.
+const TEST_USER = "user-" + require("crypto").randomBytes(4).toString("hex");
+const TEST_PASS = require("crypto").randomBytes(12).toString("hex");
+const BAD_USER = "nobody-" + require("crypto").randomBytes(4).toString("hex");
+const BAD_PASS = require("crypto").randomBytes(12).toString("hex");
+
+async function test(name, fn) {
+  try { await fn(); console.log(`  ✅ ${name}`); passed++; }
+  catch (e) { console.log(`  ❌ ${name}: ${e.message}`); failed++; }
+}
+
+(async () => {
+  console.log("\ndream-cron-nats.test.js");
+
+  await test("#153 CONNECT carries NATS_USER/NATS_PASSWORD when they are set", async () => {
+    const broker = fakeNats();
+    const port = await broker.listen();
+    const { mod, restore } = loadCron({
+      NATS_HOST: "127.0.0.1", NATS_PORT: port,
+      NATS_USER: TEST_USER, NATS_PASSWORD: TEST_PASS,
+    });
+    const ok = await mod.publishToNATS(METRICS);
+    restore();
+    await broker.close();
+    assert.ok(broker.seen.connect, "broker never saw a CONNECT frame");
+    const opts = JSON.parse(broker.seen.connect.replace(/^CONNECT /, ""));
+    assert.strictEqual(opts.user, TEST_USER, "CONNECT must carry the username");
+    assert.strictEqual(opts.pass, TEST_PASS, "CONNECT must carry the password");
+    assert.strictEqual(ok, true);
+  });
+
+  await test("#153 stays anonymous when NATS_USER is unset (no empty creds)", async () => {
+    const broker = fakeNats();
+    const port = await broker.listen();
+    const { mod, restore } = loadCron({
+      NATS_HOST: "127.0.0.1", NATS_PORT: port,
+      NATS_USER: undefined, NATS_PASSWORD: undefined,
+    });
+    await mod.publishToNATS(METRICS);
+    restore();
+    await broker.close();
+    const opts = JSON.parse(broker.seen.connect.replace(/^CONNECT /, ""));
+    assert.ok(!("user" in opts), "must not send an empty user field");
+    assert.ok(!("pass" in opts), "must not send an empty pass field");
+  });
+
+  await test("#153 an auth rejection reports failure instead of claiming success", async () => {
+    const broker = fakeNats({ rejectAuth: true });
+    const port = await broker.listen();
+    const { mod, restore } = loadCron({
+      NATS_HOST: "127.0.0.1", NATS_PORT: port,
+      NATS_USER: BAD_USER, NATS_PASSWORD: BAD_PASS,
+    });
+    const ok = await mod.publishToNATS(METRICS);
+    restore();
+    await broker.close();
+    assert.strictEqual(ok, false, "-ERR from the broker must surface as a failed publish");
+  });
+
+  await test("#153 a rejected connection does not PUB into the void", async () => {
+    const broker = fakeNats({ rejectAuth: true });
+    const port = await broker.listen();
+    const { mod, restore } = loadCron({
+      NATS_HOST: "127.0.0.1", NATS_PORT: port,
+      NATS_USER: BAD_USER, NATS_PASSWORD: BAD_PASS,
+    });
+    await mod.publishToNATS(METRICS);
+    restore();
+    await broker.close();
+    assert.strictEqual(broker.seen.published, null, "no PUB should follow a refused CONNECT");
+  });
+
+  await test("#153 the payload still publishes on a healthy broker", async () => {
+    const broker = fakeNats();
+    const port = await broker.listen();
+    const { mod, restore } = loadCron({
+      NATS_HOST: "127.0.0.1", NATS_PORT: port, NATS_USER: TEST_USER, NATS_PASSWORD: TEST_PASS,
+    });
+    await mod.publishToNATS(METRICS);
+    restore();
+    await broker.close();
+    assert.ok(broker.seen.published, "expected a PUB frame");
+    assert.ok(broker.seen.published.startsWith("PUB KANNAKA.consciousness "),
+      "wrong subject: " + broker.seen.published);
+  });
+
+  await test("#158 assess falls back to the binary when the Observatory is down", async () => {
+    // Point the Observatory at a closed port and the binary at something that
+    // cannot exist: the fallback must be ATTEMPTED (and fail loudly) rather
+    // than the whole tick silently skipping.
+    const { mod, restore } = loadCron({
+      OBSERVATORY_PORT: 1, // nothing listening
+      KANNAKA_BIN: "/nonexistent/kannaka-158",
+    });
+    const errs = [];
+    const origErr = console.error;
+    console.error = (...a) => errs.push(a.join(" "));
+    const result = await mod.assess();
+    console.error = origErr;
+    restore();
+    assert.strictEqual(result, null, "both sources unavailable -> null");
+    assert.ok(errs.some((e) => e.includes("falling back")),
+      "must announce the fallback:\n" + errs.join("\n"));
+    assert.ok(errs.some((e) => e.includes("kannaka assess failed")),
+      "must actually invoke the binary, not just log:\n" + errs.join("\n"));
+  });
+
+  await test("#158 shapeMetrics normalises both sources to the published shape", async () => {
+    const { mod, restore } = loadCron({});
+    // Observatory uses `order`/`level`; the binary uses `mean_order`/`consciousness_level`.
+    const a = mod.shapeMetrics({ phi: 1, order: 0.5, level: "high" });
+    const b = mod.shapeMetrics({ phi: 1, mean_order: 0.5, consciousness_level: "high" });
+    restore();
+    assert.strictEqual(a.mean_order, b.mean_order, "both spellings must normalise alike");
+    assert.strictEqual(a.consciousness_level, b.consciousness_level);
+    assert.strictEqual(a.consciousness_level, "high");
+  });
+
+  await test("#158 shapeMetrics rejects non-objects instead of publishing junk", async () => {
+    const { mod, restore } = loadCron({});
+    assert.strictEqual(mod.shapeMetrics(null), null);
+    assert.strictEqual(mod.shapeMetrics("nope"), null);
+    restore();
+  });
+
+  console.log(`\n${"─".repeat(50)}`);
+  console.log(`  Dream cron NATS/assess: ${passed} passed, ${failed} failed`);
+  console.log(`${"─".repeat(50)}`);
+  if (failed > 0) process.exit(1);
+})();


### PR DESCRIPTION
Closes #153. Closes #158.

Two failures in `scripts/dream-cron.js` that both make the consciousness feed go quiet **without anything looking broken** — which is why they lasted.

## #153 — the cron never authenticated, and couldn't tell

`publishToNATS` always wrote an anonymous CONNECT frame:

```js
client.write('CONNECT {"verbose":false,"pedantic":false,"name":"dream-cron"}\r\n');
```

`NATS_USER` / `NATS_PASSWORD` were ignored, even though cron on the Oracle boxes sources them from `~/.kannaka-nats.env`. On an authenticated broker every publish was refused.

The sharper half: **the reply was never read.** The code `PUB`'d on a 200ms timer and `resolve(true)` 300ms after that, so a connection the broker had already rejected was reported as a successful publish. The cron logged `Published to KANNAKA.consciousness: phi=…` while nothing was reaching the bus.

Now credentials go into the CONNECT frame when set, and an `-ERR` reply settles the publish as **failed** — and suppresses the `PUB` that would otherwise be written into a dead socket.

## #158 — no fallback when the Observatory is down

`assess()` only read the Observatory HTTP endpoint. When that was unavailable — restarting, or simply not deployed on that box — it resolved `null` and `tick()` logged `No metrics from assess, skipping publish`. The feed stayed silent for the whole outage, even though the binary that actually produces the metrics was sitting right there.

The file's own header has always claimed it *"Runs `kannaka assess --json` every 5 minutes"* and documented a `KANNAKA_BIN` env var. Neither was true — `KANNAKA_BIN` was never read. Now it is: the Observatory stays the fast path, the binary is the fallback.

`shapeMetrics` is extracted so both sources normalise identically — the Observatory emits `order` / `level`, the binary emits `mean_order` / `consciousness_level`.

## Testability

`main()` now runs only under `require.main === module` (the pattern already used in kannaka-staff), so the pieces can be required without launching a cron.

## Verification

New `test/dream-cron-nats.test.js`, wired into `npm test`. It drives the **real module against a fake NATS broker on a loopback port**, so the CONNECT frame asserted on is the one genuinely written to the socket — not a reconstruction.

```
Dream cron NATS/assess: 8 passed, 0 failed
```

**Revert-and-confirm-fail.** My first attempt at this gate was vacuous: reverting the whole file removed the exports too, so all 8 failed on `mod.publishToNATS is not a function` — which proves nothing. Redone by reverting **only the three behaviours** and keeping the exports:

```
❌ CONNECT carries NATS_USER/NATS_PASSWORD when they are set
❌ an auth rejection reports failure instead of claiming success
❌ a rejected connection does not PUB into the void
❌ assess falls back to the binary when the Observatory is down
✅ stays anonymous when NATS_USER is unset          <- control
✅ the payload still publishes on a healthy broker  <- control
✅ shapeMetrics normalises both sources alike
✅ shapeMetrics rejects non-objects
Dream cron NATS/assess: 4 passed, 4 failed
```

Full suite green through `portability-paths`; it then stops at `ghostsignals-ttl-authority` on `sqlite3 module not found`, a missing dependency in my checkout (no `node_modules`) in a test unrelated to this change. CI runs the full suite with deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
