### PR TITLE
fix(dream-cron): publish nightly exemplars to the configured broker

### DIFF
--- a/dream-cron.sh
+++ b/dream-cron.sh
@@ -60,7 +60,15 @@ cd /home/opc/kannaka-radio && node push-nats.js >> "$LOG" 2>&1
 # selectively pull these into their own HRM. Best-effort — failures
 # don't break the cron.
 echo "--- PUBLISHING EXEMPLARS ---" >> "$LOG"
-$KANNAKA swarm exemplars publish --agent-id kannaka-prime --top-k 25 --nats-url nats://127.0.0.1:4222 >> "$LOG" 2>&1
+# Use the install's configured broker. This was hardcoded to
+# nats://127.0.0.1:4222 immediately after sourcing /home/opc/.kannaka-nats.env
+# -- the very file that carries KANNAKA_NATS_URL -- so on a box pointed at the
+# shared swarm the nightly exemplar broadcast went to a local broker and no
+# other agent could ever absorb it. Nothing failed; the exemplars just went
+# nowhere. (#122)
+NATS_URL_FOR_EXEMPLARS="${KANNAKA_NATS_URL:-nats://127.0.0.1:4222}"
+echo "    broker: $NATS_URL_FOR_EXEMPLARS" >> "$LOG"
+$KANNAKA swarm exemplars publish --agent-id kannaka-prime --top-k 25 --nats-url "$NATS_URL_FOR_EXEMPLARS" >> "$LOG" 2>&1
 
 # Draft and post a dream dispatch to Bluesky. The script reads the dream
 # log excerpt from stdin; failure is non-fatal for the cron (exit 0 if


### PR DESCRIPTION
Closes #122.

## The bug

`dream-cron.sh` sources `/home/opc/.kannaka-nats.env` at the top — the file that carries the swarm broker settings and credentials — and then, 50 lines later, hardcodes the broker anyway:

```bash
$KANNAKA swarm exemplars publish --agent-id kannaka-prime --top-k 25 --nats-url nats://127.0.0.1:4222
```

So on a box pointed at the shared swarm, the nightly exemplar broadcast went to a **local** broker and no other agent could ever `swarm absorb --from kannaka-prime` it. Nothing failed. Nothing logged an error. The exemplars just went nowhere, every night.

## The fix

```bash
NATS_URL_FOR_EXEMPLARS="${KANNAKA_NATS_URL:-nats://127.0.0.1:4222}"
```

A configured install publishes to its real broker; an unconfigured one behaves exactly as before. The resolved broker is echoed into the dream log, so the next person debugging *"nobody absorbed my exemplars"* can see where they actually went.

## Verification

- `bash -n dream-cron.sh` — clean
- the parameter expansion exercised directly:

```
unset        -> nats://127.0.0.1:4222
configured   -> nats://swarm.ninja-portal.com:4222
empty string -> nats://127.0.0.1:4222
```

`:-` (not `-`) is deliberate, so an exported-but-empty `KANNAKA_NATS_URL` falls back rather than passing an empty `--nats-url`.

## This is the third instance of one bug class today

| Where | Read | Ignored |
|---|---|---|
| kannaka-eye#53 | `NATS_URL` only | `KANNAKA_NATS_URL` |
| kannaka-radio#99 | `NATS_HOST`/`NATS_PORT` only | `KANNAKA_NATS_URL` |
| here (#122) | hardcoded literal | `KANNAKA_NATS_URL` |

All three silently fell back to localhost on a correctly-configured box, and none of them errored. Worth knowing that `KANNAKA_NATS_URL` is the constellation-wide setting (kannaka-memory resolves it in `ask.rs`/`identity.rs`) and that three separate components were each independently ignoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)