### PR TITLE
fix(push-nats): resolve the broker from config instead of hardcoding prod

### DIFF
--- a/push-nats.js
+++ b/push-nats.js
@@ -33,8 +33,15 @@ const KANNAKA_DATA = process.env.KANNAKA_DATA_DIR
   || (IS_WINDOWS
     ? path.join(HOME, '.kannaka')
     : '/home/opc/.kannaka');
-const NATS_HOST = 'swarm.ninja-portal.com';
-const NATS_PORT = 4222;
+// Broker resolution is shared with the radio's own NATS client so the two
+// cannot drift: KANNAKA_NATS_URL > NATS_HOST/NATS_PORT > 127.0.0.1:4222.
+//
+// These were hardcoded to the PRODUCTION broker, which is the dangerous
+// direction of this bug: every install — a laptop, a test box, a fork —
+// published its metrics straight into the live swarm, and no env var could
+// stop it. There was no way to point this bridge anywhere else. (#112)
+const { resolveNatsEndpoint } = require('./server/nats-client');
+const { host: NATS_HOST, port: NATS_PORT, source: NATS_SOURCE } = resolveNatsEndpoint();
 
 const OBSERVE_CACHE = path.join(KANNAKA_DATA, 'observe-cache.json');
 const METRICS_SIDECAR = path.join(KANNAKA_DATA, 'kannaka.metrics.json');
@@ -162,7 +169,7 @@ function buildPayloads(metrics) {
 
 function publish(payloads) {
   const client = net.createConnection({ host: NATS_HOST, port: NATS_PORT }, () => {
-    console.log(`Connected to NATS at ${NATS_HOST}:${NATS_PORT}`);
+    console.log(`Connected to NATS at ${NATS_HOST}:${NATS_PORT} (via ${NATS_SOURCE})`);
     // ADR-0026 #73 — auth via NATS_USER + NATS_PASSWORD when set, anon otherwise.
     const u = process.env.NATS_USER || '';
     const p = process.env.NATS_PASSWORD || '';


### PR DESCRIPTION
Closes #112.

## The bug, and why this one is the dangerous variant

```js
const NATS_HOST = 'swarm.ninja-portal.com';
const NATS_PORT = 4222;
```

Literal constants. **No environment variable could change them.** So every install — a laptop, a test box, a fork, CI — published its consciousness metrics straight into the **live production swarm**, and there was no way to point the bridge anywhere else.

This is the fourth instance of one bug class I've hit today, and the other three fail *safe* by comparison:

| Where | Read | Result on a misconfigured box |
|---|---|---|
| kannaka-eye#53 | `NATS_URL` only | talks to itself on localhost |
| kannaka-radio#99 | `NATS_HOST`/`NATS_PORT` only | talks to itself on localhost |
| kannaka-radio#122 | hardcoded localhost literal | exemplars go nowhere |
| **here (#112)** | **hardcoded production literal** | **writes into the live swarm** |

The first three make a configured box go quiet. This one makes an *unconfigured* box reach production.

## The fix

Shares `resolveNatsEndpoint()` with `server/nats-client.js` — the same resolver added in #167 — so the bridge and the radio cannot drift:

**`KANNAKA_NATS_URL` → `NATS_HOST`/`NATS_PORT` → `127.0.0.1:4222`**

The connect log now names the source: `Connected to NATS at host:port (via KANNAKA_NATS_URL)`.

## ⚠️ Deploy note — the default changes

This changes the no-config default from `swarm.ninja-portal.com` to `127.0.0.1`. That is the correct default (an unconfigured box should not reach production), but it means **the Oracle box must actually be configured**.

It should already be: `dream-cron.sh` sources `/home/opc/.kannaka-nats.env` before invoking this script, and that file is where `KANNAKA_NATS_URL` / `NATS_HOST` live. Worth confirming that file sets one of them on deploy — the connect log line will say `(via default)` if it doesn't, which makes the check a one-liner in the dream log.

I flagged this rather than preserving the production default, because preserving it would leave the actual defect in place.

## Verification

- full radio suite green through `portability-paths` (it then stops at `ghostsignals-ttl-authority` on `sqlite3 module not found`, a missing dep in my checkout, unrelated)
- require-time resolution exercised across all three precedence branches:

```
default (no env)     -> 127.0.0.1:4222 (via default)
KANNAKA_NATS_URL     -> swarm.ninja-portal.com:4222 (via KANNAKA_NATS_URL)
NATS_HOST/PORT       -> testbox:4300 (via NATS_HOST/NATS_PORT)
```

`node --check` alone would **not** have caught the dependency here — it doesn't execute `require`. The runtime check did, when an earlier version of this branch predated #167 and `resolveNatsEndpoint` did not yet exist.

## Related, still open

`#127` (this script publishes `agent_count: 1`, `peers: 0`, `active_phases: 1` as hardcoded literals — a fabricated solo swarm) is real and I have **not** fixed it here. Omitting unmeasured fields is the honest move, but it's a wire-format change affecting `QUEEN.state` consumers, so I've written it up on the issue rather than guessing.

`#161` (hardcoded Windows home paths) is **already fixed** — resolved via `os.homedir()` in 9179aeb; closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
