### PR TITLE
fix(api): redact operator identity from the public peer directory

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -44,6 +44,36 @@ function checkDeletePassword(password) {
  * load balancer) > incoming Host header > localhost fallback. The result is
  * always returned without a trailing slash so callers can concatenate paths.
  */
+/**
+ * Fields of a `kannaka swarm peers --json` record that are safe to publish.
+ *
+ * ALLOWLIST, deliberately — not a denylist. `/api/swarm/peers` is advertised
+ * as public in /.well-known/api-catalog and used to return the CLI's records
+ * verbatim, which meant the operator's `identity: { email, user_id }` was
+ * served to any anonymous caller. A denylist would have fixed today's leak and
+ * quietly re-opened it the next time the CLI grew a field; with an allowlist a
+ * new field is withheld until someone decides it is public. (#137)
+ */
+const PUBLIC_PEER_FIELDS = [
+  "agent_id",
+  "display_name",
+  "capabilities",
+  "joined_at",
+  "last_seen",
+  "kannaka_version",
+  "memory_count",
+];
+
+/** Project one peer record down to its publishable fields. */
+function publicPeerFields(peer) {
+  if (!peer || typeof peer !== "object") return {};
+  const out = {};
+  for (const k of PUBLIC_PEER_FIELDS) {
+    if (peer[k] !== undefined) out[k] = peer[k];
+  }
+  return out;
+}
+
 function publicOrigin(req) {
   const envUrl = (process.env.RADIO_PUBLIC_URL || "").trim();
   if (envUrl) return envUrl.replace(/\/+$/, "");
@@ -1113,7 +1143,12 @@ module.exports = function setupRoutes(deps) {
         const c = global._peersCache;
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
-          peers: (c && c.peers) || [],
+          // Projected again on the way out. The cache is already redacted at
+          // write time, but this is the boundary that actually faces the
+          // internet, so it does not rely on every writer having remembered.
+          // Idempotent: the allowlist projection of a projected record is
+          // itself. (#137)
+          peers: ((c && c.peers) || []).map(publicPeerFields),
           // Present only when the last refresh failed and we are serving the
           // previous directory, so a client can tell "swarm is empty" apart
           // from "we could not ask just now".
@@ -1157,7 +1192,9 @@ module.exports = function setupRoutes(deps) {
             // too. Anything else is a shape we do not understand — treat it as
             // a failed refresh rather than publishing an empty directory.
             const list = Array.isArray(out) ? out : (Array.isArray(out && out.peers) ? out.peers : null);
-            if (list) global._peersCache = { t: now, peers: list };
+            // Redact BEFORE caching, so the secret never sits in memory and the
+            // stale-serving path can't republish it either.
+            if (list) global._peersCache = { t: now, peers: list.map(publicPeerFields) };
             else keep(`unexpected swarm peers shape: ${typeof out}`);
           } catch (e) {
             keep(`unparseable swarm peers output: ${e.message}`);

--- a/test/swarm-peers-cache.test.js
+++ b/test/swarm-peers-cache.test.js
@@ -143,6 +143,57 @@ const GOOD_PEERS = [{ id: "oracle-1" }, { id: "oracle-2" }, { id: "witness-01" }
       "failed refresh should still stamp the cache to throttle respawns");
   });
 
+  // ── #137: the public endpoint must not leak operator identity ──
+  //
+  // /api/swarm/peers is advertised as public in /.well-known/api-catalog and
+  // used to return `kannaka swarm peers --json` records verbatim — including
+  // the operator's identity.email / identity.user_id. Verified against the
+  // real CLI: the local "Kannaka" peer record does carry an identity object.
+  await test("#137 identity is stripped from the public peer directory", async () => {
+    global._peersCache = { t: Date.now(), peers: [{
+      agent_id: "Kannaka",
+      display_name: "Kannaka",
+      identity: { email: "operator@example.invalid", user_id: "00000000-dead-beef-0000-000000000000" },
+      memory_count: 42,
+    }] };
+    const r = await get(handler, "/api/swarm/peers");
+    assert.ok(!r.body.includes("operator@example.invalid"), "email reached the wire: " + r.body);
+    assert.ok(!r.body.includes("dead-beef"), "user_id reached the wire: " + r.body);
+    assert.ok(!r.body.includes("identity"), "identity object was serialised: " + r.body);
+  });
+
+  await test("#137 the useful public fields survive redaction", async () => {
+    global._peersCache = { t: Date.now(), peers: [{
+      agent_id: "gossipghost-01",
+      display_name: "GossipGhost",
+      capabilities: { ask: true, dream: true },
+      joined_at: "2026-07-28T15:19:24Z",
+      last_seen: "2026-07-28T15:19:24Z",
+      kannaka_version: "0.11.1",
+      memory_count: 25,
+      identity: { email: "nope@example.invalid" },
+    }] };
+    const body = JSON.parse((await get(handler, "/api/swarm/peers")).body);
+    const p = body.peers[0];
+    assert.strictEqual(p.agent_id, "gossipghost-01");
+    assert.strictEqual(p.display_name, "GossipGhost");
+    assert.strictEqual(p.memory_count, 25);
+    assert.strictEqual(p.kannaka_version, "0.11.1");
+    assert.deepStrictEqual(p.capabilities, { ask: true, dream: true });
+    assert.strictEqual(p.identity, undefined, "redaction must apply to every record");
+  });
+
+  await test("#137 an unknown future field is withheld by default (allowlist, not denylist)", async () => {
+    global._peersCache = { t: Date.now(), peers: [{
+      agent_id: "future-01",
+      some_new_secret_field: "should-not-be-published",
+    }] };
+    const r = await get(handler, "/api/swarm/peers");
+    assert.ok(!r.body.includes("should-not-be-published"),
+      "a field the CLI adds later must stay withheld until allowlisted: " + r.body);
+    assert.ok(r.body.includes("future-01"), "known fields still pass through");
+  });
+
   delete global._peersCache;
 
   console.log(`\n${"─".repeat(50)}`);


### PR DESCRIPTION
Closes #137.

## The leak

`GET /api/swarm/peers` returned `kannaka swarm peers --json` records **verbatim**. Those records carry an `identity` object for the local agent, so the operator's **email address and user_id were served to any anonymous caller** — on an endpoint explicitly advertised as public in `/.well-known/api-catalog`.

I confirmed this against the live CLI rather than inferring it from the code. Of the 5 peers currently visible, exactly one — the local `Kannaka` record — carries `identity: { email, user_id }`. The other four don't, which is precisely why this survives a casual read of the response.

## The fix

Each record is projected through an **allowlist** of publishable fields:

```js
const PUBLIC_PEER_FIELDS = [
  "agent_id", "display_name", "capabilities",
  "joined_at", "last_seen", "kannaka_version", "memory_count",
];
```

**Allowlist, not denylist — deliberately.** Blocking `identity` alone would fix today's leak and silently re-open it the next time the CLI grows a field. With an allowlist, a new field is withheld until somebody decides it is public. There's a test asserting exactly that (`some_new_secret_field` stays out).

**Applied at both the cache write and the response send:**

- redacting on **write** keeps the secret out of process memory entirely, and out of the stale-serving path added in #165 — that path republishes the last good list, so an unredacted cache would have leaked through it too
- redacting on **send** means the guarantee doesn't depend on every future writer having remembered

The projection is idempotent, so doing both is free.

## Verification

3 new cases in `test/swarm-peers-cache.test.js`:

```
Swarm peers cache: 10 passed, 0 failed
```

**Revert-and-confirm-fail**, removing only the two projection calls and keeping the helper so the failures are behavioural:

```
❌ #137 identity is stripped from the public peer directory
   email reached the wire: {"peers":[{"agent_id":"Kannaka","display_name":"Kannaka",
   "identity":{"email":"...","user_id":"..."},"memory_count":42}]}
❌ #137 the useful public fields survive redaction
❌ #137 an unknown future field is withheld by default (allowlist, not denylist)
Swarm peers cache: 7 passed, 3 failed
```

The second test matters as much as the first: it pins that the *useful* fields — agent_id, display_name, capabilities, version, memory_count — still come through, so this hardens the endpoint without hollowing it out.

Full radio suite green end to end (exit 0).

## Operational note

This stops the leak at the source going forward, but anything already scraped or cached downstream (CDN, archive.org, a third party's crawler) is outside this repo's reach. Worth deciding separately whether the exposed `user_id` warrants rotation — I haven't assumed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
