### PR TITLE
[auto-maintainer] refactor(inline-requires): hoist http/https/getFiles to module top in dj-engine + routes

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -5,7 +5,8 @@
 
 const path = require("path");
 const fs = require("fs");
-const { findAudioFile } = require("./utils");
+const https = require("https");
+const { findAudioFile, getFiles } = require("./utils");
 const { interleaveCommercials } = require("./commercials");
 
 // ── The Consciousness Series — DJ Setlist ──────────────────
@@ -925,7 +926,6 @@ class DJEngine {
    * Fetch audio artifacts from kax. Returns array of { title, url }.
    */
   async _fetchKaxArtifacts() {
-    const https = require('https');
     return new Promise((resolve, reject) => {
       const req = https.get('https://kax.ninja-portal.com/api/artifacts', (res) => {
         let data = '';
@@ -1610,7 +1610,6 @@ class DJEngine {
    * @param {string} [opts.tag] — optional tag filter; only return tracks matching this tag
    */
   getLibraryStatus(musicDir, opts) {
-    const { getFiles } = require("./utils");
     const files = getFiles(musicDir);
     const tagFilter = opts && opts.tag ? opts.tag : null;
     const result = {};

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,6 +4,7 @@
  */
 
 const fs = require("fs");
+const http = require("http");
 const path = require("path");
 const crypto = require("crypto");
 const { execFile } = require("child_process");
@@ -846,7 +847,6 @@ module.exports = function setupRoutes(deps) {
       let body = "";
       req.on("data", c => body += c);
       req.on("end", () => {
-        const http = require("http");
         const data = body || "{}";
         const opts = {
           hostname: "127.0.0.1",
@@ -945,7 +945,6 @@ module.exports = function setupRoutes(deps) {
         // back to the HTTP endpoint. Still first-page-only and still without
         // file_path, so the response says so rather than implying a full
         // search happened.
-        const http = require("http");
         http.get("http://127.0.0.1:3001/stems", (pres) => {
           let buf = "";
           pres.on("data", c => buf += c);
@@ -1226,7 +1225,6 @@ module.exports = function setupRoutes(deps) {
         sendPeers();
         return;
       }
-      const { execFile } = require("child_process");
       const bin = config.kannakabin || "/home/opc/.local/bin/kannaka";
       execFile(bin, ["swarm", "peers", "--json"], {
         timeout: 30000,
@@ -1992,7 +1990,6 @@ load();
         res.end(JSON.stringify({ error: "programming or peaceOration not initialized" }));
         return;
       }
-      const { ALBUMS } = require("./dj-engine");
       const album = ALBUMS[albumName];
       if (!album) {
         res.writeHead(404, { "Content-Type": "application/json" });


### PR DESCRIPTION
## What changed

Two files, 5 inline `require()` calls removed, 3 new top-level bindings added. Net: +3 / -7 lines.

### `server/dj-engine.js`

| Site | Before | After |
|------|--------|-------|
| `_fetchKaxArtifacts()` | `const https = require('https')` inside the method on every call | Hoisted to module top alongside `path`, `fs`, etc. |
| `getLibraryStatus()` | `const { getFiles } = require("./utils")` — second `require('./utils')` call | Added `getFiles` to the existing top-level destructure on line 8 |

### `server/routes.js`

| Site | Before | After |
|------|--------|-------|
| `/api/orc/resonance` POST handler (l.849) | `const http = require("http")` inside `res.on("end", ...)` callback | Single top-level `const http = require("http")` binding |
| Stem-HTTP fallback path (l.948) | Same inline `const http = require("http")` | Removed; uses the new top-level binding |
| `/api/swarm/peers` handler (l.1229) | `const { execFile } = require("child_process")` — `execFile` already imported at line 9 | Removed inline; outer binding used |
| Album-oration handler (l.1993) | `const { ALBUMS } = require("./dj-engine")` — `ALBUMS` already imported at line 10 | Removed inline; outer binding used |

## Why it's safe

Node.js caches every `require()` call — repeated calls for the same module path always return the same cached object. The inline re-requires returned the same value as the top-level bindings; this is a pure deduplication with no semantic difference.

This is the same pattern as:
- kannaka-staff PR #35 (inline `require` hoisting in `src/index.js`)
- The previous auto-maintainer commit on `scheduler-helpers.js` (July 14)

## Verification

```
npm test
# Results: 17 passed, 0 failed  (test-queensync-dj)
# Perception: 10 passed, 0 failed
# DJ Engine: 23 passed, 0 failed
# NATS Metrics Sync: 11 passed, 0 failed
# NATS endpoint resolution: 9 passed, 0 failed
# VoiceDJ endpoints: 9 passed, 0 failed
# GhostSignals init failure: 0 passed, 1 failed  ← pre-existing (missing `ws` native module in dev container; fails identically on clean main)
```

79 tests pass — identical baseline. The one pre-existing failure (`gshub-init-failure.test.js`) is caused by the missing `ws` package in the dev container, not by this change.

## Runtime

~18 minutes wall-clock (including startup jitter, in-flight check, repo survey across all 6 repos, and work).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvV8yVdHhCxY3HYgTebmgy)_