### PR TITLE
[auto-maintainer] fix(flux-publisher): guard against null perception in publishFullState

### DIFF
--- a/server/flux-publisher.js
+++ b/server/flux-publisher.js
@@ -124,7 +124,9 @@ class FluxPublisher {
 
   publishFullState() {
     const track = this._getCurrentTrack();
-    const perception = this._getPerception();
+    // _getPerception() returns null before any track has been heard; guard
+    // against that so the field accesses below never throw.
+    const perception = this._getPerception() || {};
     const djState = this._getDJState();
     const event = {
       stream: "radio",
@@ -143,12 +145,12 @@ class FluxPublisher {
           listeners: this._getListenerCount(),
           uptime: Math.floor(process.uptime()),
           current_perception: {
-            tempo_bpm: perception.tempo_bpm,
-            spectral_centroid_khz: perception.spectral_centroid,
-            rms_energy: perception.rms_energy,
-            pitch_hz: perception.pitch,
-            emotional_valence: perception.valence,
-            status: perception.status,
+            tempo_bpm: perception.tempo_bpm ?? null,
+            spectral_centroid_khz: perception.spectral_centroid ?? null,
+            rms_energy: perception.rms_energy ?? null,
+            pitch_hz: perception.pitch ?? null,
+            emotional_valence: perception.valence ?? null,
+            status: perception.status ?? null,
           },
           playlist: {
             album: djState.currentAlbum,


### PR DESCRIPTION
## What changed

`publishFullState()` in `server/flux-publisher.js` accessed six fields on the result of `this._getPerception()` without any null guard:

```js
// before
const perception = this._getPerception();
// …
current_perception: {
    tempo_bpm: perception.tempo_bpm,          // throws if null
    spectral_centroid_khz: perception.spectral_centroid,
    …
}
```

`_getPerception()` returns `null` before any track has been processed (at startup, before `hearTrack()` has been called). When `startPeriodicPublish()` fires its first tick (30 s after boot) while there are listeners, `publishFullState()` crashes with:

```
TypeError: Cannot read properties of null (reading 'tempo_bpm')
```

**Fix:** default to an empty object so every field access is safe, and add `?? null` to each field to keep the wire format consistent (explicit JSON `null` rather than missing keys) — matching the pattern already used in the static `_perceptionPayload()` helper in the same class:

```js
// after
const perception = this._getPerception() || {};
// …
current_perception: {
    tempo_bpm: perception.tempo_bpm ?? null,
    spectral_centroid_khz: perception.spectral_centroid ?? null,
    …
}
```

## Why it's safe

- No behaviour change when perception data is present: `|| {}` is only reached when `_getPerception()` is falsy.
- The `?? null` additions make `undefined` fields explicit `null` in JSON — the same output a consumer would get from a real `{ tempo_bpm: null, … }` object, so downstream is unchanged.
- The same class already handles the null case in `_perceptionFor()` (`const current = this._getPerception ? this._getPerception() : null`), confirming the function is known to return null.

## Verification

No dedicated `flux-publisher.test.js` exists. All 38 existing tests in the `npm test` suite pass and are unaffected — the periodic publish path is not exercised by any test, but the change is logically equivalent to the existing behaviour when perception is non-null.

Diff: 8 lines changed in 1 file (`server/flux-publisher.js`), well within the ≤150 line limit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgA4PV1RrBp5Wb1kQmWn8A)_