### PR TITLE
[auto-maintainer] refactor(inline-requires): hoist fs; remove redundant path in index.js + icecast-source.js

### DIFF
--- a/server/icecast-source.js
+++ b/server/icecast-source.js
@@ -134,7 +134,7 @@ class IcecastSource {
       return;
     }
     this._voiceQueue.push({ path: audioPath, meta, onDone: typeof onDone === "function" ? onDone : null });
-    console.log(`   \u{1F4FB} /stream voice queued: ${meta.label || require("path").basename(audioPath)} (${this._voiceQueue.length} pending)`);
+    console.log(`   \u{1F4FB} /stream voice queued: ${meta.label || path.basename(audioPath)} (${this._voiceQueue.length} pending)`);
   }
 
   start() {
@@ -378,12 +378,12 @@ class IcecastSource {
             expected = (cur && cur.file !== track.file) ? cur : this._djEngine.peekNextTrack();
           } catch (_) {}
           if (!expected || expected.file !== v.meta.introFor) {
-            console.log(`   \u{1F399} /stream VOICE dropped — stale intro (announced ${require("path").basename(v.meta.introFor)}, next is ${expected ? require("path").basename(expected.file) : "unknown"})`);
+            console.log(`   \u{1F399} /stream VOICE dropped — stale intro (announced ${path.basename(v.meta.introFor)}, next is ${expected ? path.basename(expected.file) : "unknown"})`);
             if (v.onDone) { try { v.onDone(new Error("stale intro")); } catch (_) {} }
             continue;
           }
         }
-        console.log(`   \u{1F399} /stream VOICE: ${v.meta.label || require("path").basename(v.path)}`);
+        console.log(`   \u{1F399} /stream VOICE: ${v.meta.label || path.basename(v.path)}`);
         let voiceErr = null;
         // Marks a one-shot performance as in flight so stop({drain:true}) can
         // wait for it instead of cutting mid-sentence (#54).

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@
  * Place your MP3/WAV/FLAC files there and they will be picked up automatically.
  */
 
+const fs = require("fs");
 const http = require("http");
 const path = require("path");
 const WebSocket = require("ws");
@@ -171,20 +172,20 @@ let _lastIcePreviewSeen = 0;
 
 (function loadListenerTotals() {
   try {
-    const raw = require("fs").readFileSync(LISTENER_STATE_PATH, "utf8");
+    const raw = fs.readFileSync(LISTENER_STATE_PATH, "utf8");
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed.unique === "number") {
       _listenerTotals = { unique: parsed.unique, started_at: parsed.started_at || Date.now() };
       console.log(`[listeners] loaded total=${_listenerTotals.unique} from ${LISTENER_STATE_PATH}`);
     }
   } catch (_) {
-    try { require("fs").mkdirSync(path.dirname(LISTENER_STATE_PATH), { recursive: true }); } catch {}
+    try { fs.mkdirSync(path.dirname(LISTENER_STATE_PATH), { recursive: true }); } catch {}
   }
 })();
 
 function _persistListenerTotals() {
   try {
-    require("fs").writeFileSync(LISTENER_STATE_PATH, JSON.stringify(_listenerTotals));
+    fs.writeFileSync(LISTENER_STATE_PATH, JSON.stringify(_listenerTotals));
   } catch (_) { /* best-effort */ }
 }
 setInterval(_persistListenerTotals, 10000);
@@ -478,7 +479,7 @@ const perception_ = new PerceptionEngine({
   kannakabin: KANNAKA_BIN,
   getMusicDir: () => MUSIC_DIR,
   getConsciousness: () => nats.getConsciousness(),
-  featuresFile: require("path").join(BASE_DIR, "workspace", "track-features.json"),
+  featuresFile: path.join(BASE_DIR, "workspace", "track-features.json"),
 });
 
 const nats = new NATSClient({
@@ -927,8 +928,8 @@ const programming = new ProgrammingSchedule({
   // peaceOration is constructed below; pass a getter so the showcase
   // trigger resolves it lazily at tick time (60s+ later).
   peaceOration: { composeAlbumNarration: (...args) => peaceOration.composeAlbumNarration(...args) },
-  dataDir: require("path").join(BASE_DIR, "workspace"),
-  showcaseStateFile: require("path").join(BASE_DIR, "workspace", "showcase-state.json"),
+  dataDir: path.join(BASE_DIR, "workspace"),
+  showcaseStateFile: path.join(BASE_DIR, "workspace", "showcase-state.json"),
 });
 
 // Wire programming into deps so routes can access it
@@ -952,7 +953,7 @@ const peaceOration = new PeaceOration({
   broadcast,
   getChannel: () => djEngine.state.channel,
   getFloor: () => floor, // ADR-0008 deferred layer: orations reference today's resonance
-  dataDir: require("path").join(BASE_DIR, "workspace"),
+  dataDir: path.join(BASE_DIR, "workspace"),
   rootDir: BASE_DIR,
   radioUrl: process.env.RADIO_PUBLIC_URL || "https://radio.ninja-portal.com",
 });
@@ -968,7 +969,7 @@ const newsBroadcast = new NewsBroadcast({
   voiceDJ,
   broadcast,
   gsHub, // LADDER world-state stream — opens + resolves markets per bulletin
-  dataDir: require("path").join(BASE_DIR, "workspace"),
+  dataDir: path.join(BASE_DIR, "workspace"),
 });
 newsBroadcast.start();
 deps.newsBroadcast = newsBroadcast;
@@ -982,7 +983,7 @@ const newsTeaser = new NewsTeaser({
   kannakabin: KANNAKA_BIN,
   voiceDJ,
   broadcast,
-  dataDir: require("path").join(BASE_DIR, "workspace"),
+  dataDir: path.join(BASE_DIR, "workspace"),
 });
 newsTeaser.start();
 deps.newsTeaser = newsTeaser;
@@ -995,7 +996,7 @@ const gossipBroadcast = new GossipBroadcast({
   kannakabin: KANNAKA_BIN,
   voiceDJ,
   broadcast,
-  dataDir: require("path").join(BASE_DIR, "workspace"),
+  dataDir: path.join(BASE_DIR, "workspace"),
 });
 gossipBroadcast.start();
 deps.gossipBroadcast = gossipBroadcast;


### PR DESCRIPTION
## What changed

Two files, 10 inline `require()` calls replaced with already-bound module-level identifiers. Net: +1 / -0 lines (the `fs` hoist) with 10 substitutions.

### `server/index.js`

**Added `const fs = require("fs")` to the top-level import block** (alphabetically between the comment block and `http`). Three call-sites re-declared `require("fs")` inline despite `fs` not previously being at module top:

| Site | Before | After |
|------|--------|-------|
| `loadListenerTotals()` IIFE (l.175) | `require("fs").readFileSync(...)` | `fs.readFileSync(...)` |
| catch block (l.181) | `require("fs").mkdirSync(...)` | `fs.mkdirSync(...)` |
| `_persistListenerTotals()` (l.187) | `require("fs").writeFileSync(...)` | `fs.writeFileSync(...)` |

**Seven call-sites used `require("path").join`** despite `path` already being bound at module top (line 21):

| Site | Module |
|------|--------|
| `featuresFile` on `PerceptionEngine` | `path.join` |
| `dataDir` + `showcaseStateFile` on `ProgrammingSchedule` | `path.join` (×2) |
| `dataDir` on `PeaceOration` | `path.join` |
| `dataDir` on `NewsBroadcast` | `path.join` |
| `dataDir` on `NewsTeaser` | `path.join` |
| `dataDir` on `GossipBroadcast` | `path.join` |

Note: the two `require("./icecast-metadata")` call-sites at lines 358 and 391 are **intentionally** left as inline requires — they are wrapped in `try/catch` as optional lazy-load guards and should not be hoisted.

### `server/icecast-source.js`

Three `console.log` call-sites used `require("path").basename` despite `path` already being bound at module top (line 30):

| Site | Before | After |
|------|--------|-------|
| Voice queued log (l.137) | `require("path").basename(audioPath)` | `path.basename(audioPath)` |
| Stale intro drop log (l.381) | `require("path").basename(v.meta.introFor)` / `require("path").basename(expected.file)` | `path.basename(...)` (×2) |
| Voice play log (l.386) | `require("path").basename(v.path)` | `path.basename(v.path)` |

## Why it's safe

Node.js caches every `require()` call — repeated calls for the same module path always return the same cached object. The inline re-requires returned the same value as (or, for `fs`, would return the same value as) the top-level binding; this is a pure deduplication with no semantic difference.

Same pattern as:
- PR #192 (inline-require hoisting in `dj-engine.js` + `routes.js`)
- PR #91 (inline-require hoisting in `scheduler-helpers.js`)
- kannaka-staff PR #35 (inline-require hoisting in `src/index.js`)

## Verification

```
node --check server/index.js       # → OK (no syntax errors)
node --check server/icecast-source.js  # → OK

npm test
# Results:              17 passed, 0 failed
# Perception:           10 passed, 0 failed
# DJ Engine:            23 passed, 0 failed
# NATS Metrics Sync:    11 passed, 0 failed
# NATS endpoint resolution: 9 passed, 0 failed
# VoiceDJ endpoints:    9 passed, 0 failed
# GhostSignals init failure: 0 passed, 1 failed  ← pre-existing
```

79 tests pass — identical baseline. The one pre-existing failure (`gshub-init-failure.test.js`) is caused by the missing `ws` native module in the dev container; fails identically on a clean `master` checkout.

## Runtime

~22 minutes wall-clock (including startup jitter, in-flight detection across all 6 repos, backlog checks, and work).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbhZDFvjARHTJNMHR6kLhv)_