### PR TITLE
fix(push-nats): publish a measured phase or no phase heartbeat at all

### DIFF
--- a/push-nats.js
+++ b/push-nats.js
@@ -133,7 +133,47 @@ function getLivePeerCount() {
   }
 }
 
-function buildPayloads(metrics, peerCount) {
+/**
+ * Live local oscillator phase from `kannaka swarm status`, or null when we
+ * genuinely cannot tell. Same rule as getLivePeerCount (#127): a failed
+ * lookup is unknown, not a value. An unknown phase means the QUEEN.phase
+ * heartbeat is skipped entirely rather than published as `phase: null` —
+ * the radio's own consumer folds null to 0 radians and reports a perfectly
+ * coherent one-agent swarm from a heartbeat that never measured anything. (#204)
+ */
+function getLiveLocalPhase() {
+  try {
+    const raw = execSync(`"${KANNAKA_BIN}" swarm status`, {
+      env: { ...process.env, KANNAKA_DATA_DIR: KANNAKA_DATA, KANNAKA_QUIET: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+      maxBuffer: 1024 * 1024,
+    });
+    const parsed = JSON.parse(raw.toString().trim());
+    const lp = parsed && parsed.local_phase;
+    if (lp && Number.isFinite(lp.phase)) {
+      return {
+        phase: lp.phase,
+        frequency: Number.isFinite(lp.frequency) ? lp.frequency : 0,
+      };
+    }
+    console.error('Swarm status carried no finite local phase — omitting phase heartbeat');
+    return null;
+  } catch (err) {
+    console.error(`Could not resolve local phase (${err.message}) — omitting phase heartbeat`);
+    return null;
+  }
+}
+
+// Env-overridable identity, resolved per call and shared by the payload
+// builder and the publisher so the QUEEN.phase subject can never disagree
+// with the agent_id inside it. (#204)
+function resolveIdentity(env = process.env) {
+  const agentId = env.KANNAKA_AGENT_ID || 'kannaka-01';
+  return { agentId, displayName: env.KANNAKA_DISPLAY_NAME || agentId };
+}
+
+function buildPayloads(metrics, peerCount, localPhase) {
   const now = new Date().toISOString();
 
   // Canonical envelope fields (schema_version / ts / agent_id) per
@@ -141,8 +181,7 @@ function buildPayloads(metrics, peerCount) {
   // metrics plus an ISO `timestamp`, so everything it published tripped the
   // radio's own drift detector on the receiving side. Purely additive — every
   // pre-existing field is retained for consumers that already read them. (#52)
-  const AGENT_ID = process.env.KANNAKA_AGENT_ID || 'kannaka-01';
-  const DISPLAY_NAME = process.env.KANNAKA_DISPLAY_NAME || AGENT_ID;
+  const { agentId: AGENT_ID, displayName: DISPLAY_NAME } = resolveIdentity();
   const TS = Date.now();
   // Only a number counts as knowledge. null/undefined mean the lookup failed
   // and the cardinality fields are omitted rather than defaulted (#127).
@@ -172,12 +211,16 @@ function buildPayloads(metrics, peerCount) {
     source: `live-${now}`,
   });
 
-  const phase1 = JSON.stringify({
+  // No measured phase -> no phase heartbeat. The contract requires `phase` on
+  // QUEEN.phase.*, and `phase: null` is worse than silence: it advertises
+  // presence with a value consumers treat as 0 rad (#204).
+  const phaseKnown = localPhase && Number.isFinite(localPhase.phase);
+  const phase1 = !phaseKnown ? null : JSON.stringify({
     schema_version: "1.0",
     ts: TS,
     agent_id: AGENT_ID,
-    phase: null,
-    frequency: 0,
+    phase: localPhase.phase,
+    frequency: Number.isFinite(localPhase.frequency) ? localPhase.frequency : 0,
     memory_count: metrics.total_memories,
     coherence: metrics.mean_order,
     phi: metrics.phi,
@@ -236,12 +279,16 @@ function publish(payloads) {
       : 'CONNECT {"verbose":false}\r\n';
     client.write(connectPayload);
 
+    // Subject derives from the same agent_id as the payload body — these were
+    // allowed to disagree when KANNAKA_AGENT_ID was set. Null payloads (an
+    // unmeasured phase) are dropped rather than published. (#204)
+    const { agentId } = resolveIdentity();
     const msgs = [
       ['KANNAKA.consciousness', payloads.consciousness],
-      ['QUEEN.phase.kannaka-01', payloads.phase1],
+      [`QUEEN.phase.${agentId}`, payloads.phase1],
       ['QUEEN.state', payloads.queen],
       ['KANNAKA.agents', payloads.agent],
-    ];
+    ].filter(([, data]) => data);
 
     msgs.forEach(([subject, data], i) => {
       setTimeout(() => {
@@ -289,8 +336,13 @@ if (require.main === module) {
     ? 'Peers: unknown — cardinality fields omitted'
     : `Peers: ${peerCount}`);
 
-  const payloads = buildPayloads(metrics, peerCount);
+  const localPhase = getLiveLocalPhase();
+  console.log(localPhase === null
+    ? 'Phase: unknown — QUEEN.phase heartbeat skipped'
+    : `Phase: ${localPhase.phase.toFixed(4)} rad @ ${localPhase.frequency.toFixed(2)}Hz`);
+
+  const payloads = buildPayloads(metrics, peerCount, localPhase);
   publish(payloads);
 }
 
-module.exports = { buildPayloads, getLivePeerCount };
+module.exports = { buildPayloads, getLivePeerCount, getLiveLocalPhase };

--- a/test/nats-envelope-canonical.test.js
+++ b/test/nats-envelope-canonical.test.js
@@ -82,8 +82,10 @@ test('#52 push-nats KANNAKA.consciousness carries every required field', () => {
 });
 
 test('#52 push-nats QUEEN.phase carries every required field', () => {
+  // Since #204 the heartbeat is conditional: built only from a measured
+  // phase, null (and unpublished) otherwise.
   const block = between(readSrc('push-nats.js'),
-    'const phase1 = JSON.stringify({', 'const queen =');
+    'const phase1 = !phaseKnown ? null : JSON.stringify({', 'const queen =');
   const missing = NATS_REQUIRED_FIELDS['QUEEN.phase.<agent_id>'].filter((f) => !hasField(block, f));
   assert.strictEqual(missing.length, 0, `missing ${missing.join(', ')}`);
 });

--- a/test/push-nats-swarm-cardinality.test.js
+++ b/test/push-nats-swarm-cardinality.test.js
@@ -34,8 +34,12 @@ const METRICS = {
   consciousness_level: 'aware',
 };
 
+// A measured local phase — the cardinality cases are not about the phase
+// heartbeat's existence, so they build with one present (#204 covers absence).
+const LOCAL_PHASE = { phase: 1.234, frequency: 0.5 };
+
 const build = (peerCount) => {
-  const p = buildPayloads(METRICS, peerCount);
+  const p = buildPayloads(METRICS, peerCount, LOCAL_PHASE);
   return { phase: JSON.parse(p.phase1), queen: JSON.parse(p.queen) };
 };
 
@@ -116,6 +120,38 @@ run('#127 display_name is still separately overridable', () => {
     if (prev === undefined) delete process.env.KANNAKA_DISPLAY_NAME;
     else process.env.KANNAKA_DISPLAY_NAME = prev;
   }
+});
+
+// ── #204: the phase heartbeat must carry a measured phase or not exist ──
+
+run('#204 a measured local phase is published verbatim', () => {
+  const p = buildPayloads(METRICS, 2, { phase: 2.71, frequency: 1.2 });
+  const phase = JSON.parse(p.phase1);
+  assert.strictEqual(phase.phase, 2.71, 'the published phase must be the measured one');
+  assert.strictEqual(phase.frequency, 1.2, 'the measured frequency rides along');
+});
+
+run('#204 an unknown phase omits the QUEEN.phase payload entirely', () => {
+  // `phase: null` is worse than silence: the radio consumer folds null to
+  // 0 radians and reports a perfectly coherent one-agent swarm.
+  for (const unknown of [null, undefined, {}, { phase: null }, { phase: NaN }]) {
+    const p = buildPayloads(METRICS, 2, unknown);
+    assert.strictEqual(p.phase1, null,
+      `localPhase=${JSON.stringify(unknown)} must suppress the heartbeat, got: ${p.phase1}`);
+  }
+});
+
+run('#204 zero radians is a real phase, not an unknown', () => {
+  const p = buildPayloads(METRICS, 2, { phase: 0, frequency: 0.9 });
+  const phase = JSON.parse(p.phase1);
+  assert.strictEqual(phase.phase, 0, 'phase 0 is a measurement and must publish');
+});
+
+run('#204 the other subjects still publish when the phase is unknown', () => {
+  const p = buildPayloads(METRICS, 2, null);
+  assert.ok(p.consciousness, 'consciousness must survive a missing phase');
+  assert.ok(p.queen, 'queen state must survive a missing phase');
+  assert.ok(p.agent, 'agent sync must survive a missing phase');
 });
 
 console.log(failed === 0 ? '\npush-nats-swarm-cardinality: all passed' : `\npush-nats-swarm-cardinality: ${failed} FAILED`);


### PR DESCRIPTION
Fixes #204.

`QUEEN.phase.kannaka-01` was published with a literal `phase: null`. The radio's own NATS consumer folds null to 0 radians, so a single heartbeat produced `localOrderParameter = 1` — a perfectly coherent one-agent swarm that was never measured.

## Changes
- **`getLiveLocalPhase()`** reads `local_phase` from `kannaka swarm status`. A failed lookup returns null — unknown, not zero — the same rule the peers fix (#127) established for cardinality.
- **`buildPayloads()`** now takes the measured phase and builds the `QUEEN.phase` payload only when one exists (0 rad counts as measured); otherwise `phase1` is null and the subject is not published at all. The contract requires `phase` on `QUEEN.phase.*`, and `phase: null` is worse than silence.
- **The publish subject derives from the same env-overridable `agent_id`** as the payload body — previously the subject was hardcoded `QUEEN.phase.kannaka-01` and could disagree with the body the moment `KANNAKA_AGENT_ID` was set.

## Tests
- `#204 a measured local phase is published verbatim`
- `#204 an unknown phase omits the QUEEN.phase payload entirely` (null / undefined / `{}` / `{phase:null}` / `{phase:NaN}`)
- `#204 zero radians is a real phase, not an unknown`
- `#204 the other subjects still publish when the phase is unknown`
- Envelope-canonical marker updated for the now-conditional heartbeat; full `npm test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)