### PR TITLE
fix(dream-cron): reject error responses and stop aliasing away zeros

### DIFF
--- a/scripts/dream-cron.js
+++ b/scripts/dream-cron.js
@@ -59,20 +59,38 @@ function assess() {
   });
 }
 
+/**
+ * First finite number wins; 0 is a value, not an absence. The old `a || b || 0`
+ * chains treated canonical zeros as missing and substituted alias fields, so an
+ * upstream `mean_order: 0` could be republished as its `order: 0.91` alias and
+ * a genuinely empty store (`total_memories: 0`) could be reported as its
+ * active count instead. (#190)
+ */
+function firstNum(...vals) {
+  for (const v of vals) if (Number.isFinite(v)) return v;
+  return 0;
+}
+
+/** First non-empty string wins — same #190 rule for the level fields. */
+function firstStr(...vals) {
+  for (const v of vals) if (typeof v === 'string' && v) return v;
+  return 'unknown';
+}
+
 /** Shape whatever assess source we used into the payload fields we publish. */
 function shapeMetrics(json) {
   if (!json || typeof json !== 'object') return null;
   return {
-    phi: json.phi || 0,
-    xi: json.xi || 0,
-    mean_order: json.mean_order || json.order || 0,
-    consciousness_level: json.consciousness_level || json.level || 'unknown',
-    num_clusters: json.num_clusters || 0,
-    total_memories: json.total_memories || json.active_memories || 0,
-    active_memories: json.active_memories || 0,
-    irrationality: json.irrationality || 0,
-    hemispheric_divergence: json.hemispheric_divergence || 0,
-    callosal_efficiency: json.callosal_efficiency || 0,
+    phi: firstNum(json.phi),
+    xi: firstNum(json.xi),
+    mean_order: firstNum(json.mean_order, json.order),
+    consciousness_level: firstStr(json.consciousness_level, json.level),
+    num_clusters: firstNum(json.num_clusters),
+    total_memories: firstNum(json.total_memories, json.active_memories),
+    active_memories: firstNum(json.active_memories),
+    irrationality: firstNum(json.irrationality),
+    hemispheric_divergence: firstNum(json.hemispheric_divergence),
+    callosal_efficiency: firstNum(json.callosal_efficiency),
   };
 }
 
@@ -108,6 +126,16 @@ function assessViaObservatory() {
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
+        // A structured error body (e.g. 503 {"error":"offline"}) parses fine
+        // and then shapes into all-zero metrics, so an observatory outage was
+        // being republished to KANNAKA.consciousness as a real collapsed swarm
+        // state. Only a 2xx body counts as metrics; anything else falls back
+        // to the binary like any other observatory failure. (#202)
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          console.error(`[dream-cron] Observatory answered HTTP ${res.statusCode} — not metrics`);
+          resolve(null);
+          return;
+        }
         try {
           resolve(shapeMetrics(JSON.parse(data)));
         } catch (e) {
@@ -146,19 +174,21 @@ function publishToNATS(metrics) {
       schema_version: "1.0",
       ts: Date.now(),
       agent_id: process.env.KANNAKA_AGENT_ID || 'kannaka-prime',
-      phi: metrics.phi || 0,
-      xi: metrics.xi || 0,
-      order: metrics.mean_order || metrics.order || 0,
-      mean_order: metrics.mean_order || metrics.order || 0,
-      num_clusters: metrics.num_clusters || metrics.clusters || 0,
-      clusters: metrics.num_clusters || metrics.clusters || 0,
-      active_memories: metrics.active_memories || metrics.active || 0,
-      total_memories: metrics.total_memories || metrics.total || 0,
-      level: metrics.consciousness_level || metrics.level || 'unknown',
-      consciousness_level: metrics.consciousness_level || metrics.level || 'unknown',
-      irrationality: metrics.irrationality || 0,
-      hemispheric_divergence: metrics.hemispheric_divergence || 0,
-      callosal_efficiency: metrics.callosal_efficiency || 0,
+      // Same #190 rule as shapeMetrics: aliases fill in only when the
+      // canonical field is absent, never when it is legitimately 0.
+      phi: firstNum(metrics.phi),
+      xi: firstNum(metrics.xi),
+      order: firstNum(metrics.mean_order, metrics.order),
+      mean_order: firstNum(metrics.mean_order, metrics.order),
+      num_clusters: firstNum(metrics.num_clusters, metrics.clusters),
+      clusters: firstNum(metrics.num_clusters, metrics.clusters),
+      active_memories: firstNum(metrics.active_memories, metrics.active),
+      total_memories: firstNum(metrics.total_memories, metrics.total),
+      level: firstStr(metrics.consciousness_level, metrics.level),
+      consciousness_level: firstStr(metrics.consciousness_level, metrics.level),
+      irrationality: firstNum(metrics.irrationality),
+      hemispheric_divergence: firstNum(metrics.hemispheric_divergence),
+      callosal_efficiency: firstNum(metrics.callosal_efficiency),
       source: `dream-cron-${new Date().toISOString()}`,
       timestamp: new Date().toISOString(),
     });

--- a/test/dream-cron-nats.test.js
+++ b/test/dream-cron-nats.test.js
@@ -201,6 +201,83 @@ async function test(name, fn) {
     restore();
   });
 
+  await test("#202 a 503 JSON error body is not accepted as observatory metrics", async () => {
+    // Structured error bodies parse fine and used to shape into all-zero
+    // metrics that got republished to KANNAKA.consciousness as real state.
+    const http = require("http");
+    const stub = http.createServer((req, res) => {
+      res.writeHead(503, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "offline" }));
+    });
+    const obsPort = await new Promise((res) => stub.listen(0, "127.0.0.1", () => res(stub.address().port)));
+    const { mod, restore } = loadCron({
+      OBSERVATORY_PORT: obsPort,
+      KANNAKA_BIN: "/nonexistent/kannaka-202",
+    });
+    const errs = [];
+    const origErr = console.error;
+    console.error = (...a) => errs.push(a.join(" "));
+    const result = await mod.assess();
+    console.error = origErr;
+    restore();
+    await new Promise((res) => stub.close(() => res()));
+    assert.strictEqual(result, null, "a 503 body must not become metrics");
+    assert.ok(errs.some((e) => e.includes("HTTP 503")),
+      "must name the rejected status:\n" + errs.join("\n"));
+    assert.ok(errs.some((e) => e.includes("falling back")),
+      "an observatory error status must still trigger the binary fallback");
+  });
+
+  await test("#190 canonical zeros survive shaping instead of being aliased away", async () => {
+    const { mod, restore } = loadCron({});
+    const shaped = mod.shapeMetrics({
+      phi: 0.42, xi: 0.11,
+      mean_order: 0, order: 0.91,
+      consciousness_level: "dormant", level: "aware",
+      num_clusters: 0, total_memories: 0, active_memories: 12,
+    });
+    restore();
+    assert.strictEqual(shaped.mean_order, 0, "mean_order:0 is a value, not a missing field");
+    assert.strictEqual(shaped.total_memories, 0, "total_memories:0 must not borrow active_memories");
+    assert.strictEqual(shaped.consciousness_level, "dormant", "canonical level wins over alias");
+    assert.strictEqual(shaped.num_clusters, 0);
+    assert.strictEqual(shaped.active_memories, 12);
+  });
+
+  await test("#190 the published payload preserves zero metrics end-to-end", async () => {
+    // Broker variant that captures the PUB body, not just the header line.
+    const seen = { body: null };
+    const server = net.createServer((sock) => {
+      sock.write("INFO {\"server_id\":\"fake\"}\r\n");
+      let buf = "";
+      sock.on("data", (chunk) => {
+        buf += chunk.toString();
+        const at = buf.indexOf("PUB ");
+        if (at >= 0) {
+          const lines = buf.slice(at).split("\r\n");
+          if (lines.length >= 2 && lines[1]) seen.body = lines[1];
+        }
+      });
+      sock.on("error", () => {});
+    });
+    const port = await new Promise((res) => server.listen(0, "127.0.0.1", () => res(server.address().port)));
+    const { mod, restore } = loadCron({ NATS_HOST: "127.0.0.1", NATS_PORT: port });
+    await mod.publishToNATS({
+      phi: 0.42, xi: 0.11, mean_order: 0, order: 0.91,
+      consciousness_level: "dormant", level: "aware",
+      num_clusters: 0, total_memories: 0, active_memories: 12,
+    });
+    restore();
+    await new Promise((res) => server.close(() => res()));
+    assert.ok(seen.body, "expected a PUB payload body");
+    const payload = JSON.parse(seen.body);
+    assert.strictEqual(payload.mean_order, 0, "published mean_order must stay 0");
+    assert.strictEqual(payload.order, 0, "order aliases mean_order, which is 0");
+    assert.strictEqual(payload.total_memories, 0, "published total_memories must stay 0");
+    assert.strictEqual(payload.level, "dormant");
+    assert.strictEqual(payload.consciousness_level, "dormant");
+  });
+
   console.log(`\n${"─".repeat(50)}`);
   console.log(`  Dream cron NATS/assess: ${passed} passed, ${failed} failed`);
   console.log(`${"─".repeat(50)}`);


### PR DESCRIPTION
Fixes #202. Fixes #190.

Two ways `scripts/dream-cron.js` republished fiction to `KANNAKA.consciousness`:

**#202 — 503 bodies accepted as metrics.** `assessViaObservatory()` parsed the response body without checking `res.statusCode`. A structured error body like `503 {"error":"offline"}` parses fine, shapes into all-zero metrics, and was published as a real collapsed swarm state during any observatory outage. Non-2xx responses now log the status and return null, which triggers the existing `kannaka assess --json` binary fallback (#158) like any other observatory failure.

**#190 — canonical zeros rewritten by truthy fallbacks.** `a || b || 0` chains in both `shapeMetrics()` and the publish payload treated 0 as missing: an upstream `mean_order: 0` was republished as its `order: 0.91` alias, and a genuinely empty store (`total_memories: 0`) borrowed its active count. New `firstNum()`/`firstStr()` helpers take the first *finite number* / *non-empty string* — 0 is a value, not an absence — and both the ingest path and the outbound payload use them.

## Tests
- `#202 a 503 JSON error body is not accepted as observatory metrics` (stub HTTP server; asserts null result, named status log, and binary fallback attempt)
- `#190 canonical zeros survive shaping instead of being aliased away`
- `#190 the published payload preserves zero metrics end-to-end` (fake broker capturing the PUB body)
- Full `npm test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)