### PR TITLE
[auto-maintainer] refactor(programming): use shared loadState/saveState for showcase state

### DIFF
--- a/server/programming.js
+++ b/server/programming.js
@@ -10,6 +10,7 @@
  */
 
 const { ALBUMS } = require("./dj-engine");
+const { loadState, saveState } = require('./lib/scheduler-helpers');
 
 // ── Programming schedule (CST) ────────────────────────────
 
@@ -316,22 +317,12 @@ class ProgrammingSchedule {
   }
 
   _loadShowcaseState() {
-    try {
-      const fs = require("fs");
-      if (fs.existsSync(this._showcaseStateFile)) {
-        return JSON.parse(fs.readFileSync(this._showcaseStateFile, "utf8"));
-      }
-    } catch (_) { /* ignore */ }
-    return {};
+    return loadState(this._showcaseStateFile);
   }
 
   _saveShowcaseState() {
     try {
-      const fs = require("fs");
-      const path = require("path");
-      const dir = path.dirname(this._showcaseStateFile);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(this._showcaseStateFile, JSON.stringify(this._lastShowcaseFired, null, 2));
+      saveState(this._showcaseStateFile, this._lastShowcaseFired);
     } catch (e) {
       console.warn(`[programming] showcase state save: ${e && e.message}`);
     }
@@ -611,7 +602,6 @@ class ProgrammingSchedule {
       const key = `${dateKey}T${String(hour).padStart(2, "0")}-${showcase.album}`;
       if (this._lastShowcaseFired[key]) continue; // already fired today
 
-      const { ALBUMS } = require("./dj-engine");
       const album = ALBUMS[showcase.album];
       if (!album) {
         console.warn(`[programming] showcase album not found: ${showcase.album}`);


### PR DESCRIPTION
`_loadShowcaseState` and `_saveShowcaseState` each opened their own `fs`/`path` requires and hand-rolled JSON read/write — the exact same logic already lives in `server/lib/scheduler-helpers.js` (`loadState` / `saveState`), where `gossip-broadcast.js` and `news-broadcast.js` already use it.

## What changed

**`server/programming.js` — 3 changes, 1 file:**

1. **Import `loadState` + `saveState` at module scope** (top of file, beside the existing `ALBUMS` import from `dj-engine`).

2. **Simplify `_loadShowcaseState`** — replace the manual try/catch JSON read with a single `loadState()` call. Side-effect: showcase state is now auto-pruned to the last 3 days on each load (consistent with every other scheduler in the codebase — `gossip-broadcast`, `news-broadcast`, `peace-oration` all use the same 3-day window). Without pruning the file accumulated one entry per showcase slot per day (~1 825 entries/year with no bound).

3. **Simplify `_saveShowcaseState`** — replace the manual `mkdirSync` + `writeFileSync` with `saveState()` inside the existing try/catch. `saveState` already creates the parent directory.

4. **Remove the redundant inner `const { ALBUMS } = require('./dj-engine')` inside `_checkShowcaseTrigger`** — `ALBUMS` is already imported at module scope on line 1; the inner `require` was a no-op (Node caches it) but read like a missing import.

## Why it's safe

- No behaviour change on the happy path: `loadState` and `saveState` do exactly what `_loadShowcaseState`/`_saveShowcaseState` did, plus the 3-day prune.
- The 3-day prune is safe: showcase keys are `YYYY-MM-DDTHH-<album>`. The only key that matters at runtime is today's; 3-day-old keys cannot re-trigger since the check uses the current date.
- The redundant inner `require` removal is a no-op: Node's module cache means both the outer and inner require returned the same object; removing the inner one changes nothing at runtime.
- No new dependencies introduced — `scheduler-helpers` is already a first-party file in the same `server/lib/` directory.

## Verification

`npm test` run locally before and after the change.

- **Before (master):** 1 pre-existing failure — `gshub-init-failure.test.js` (#155) fails due to a `MODULE_NOT_FOUND` in `server/index.js:22` unrelated to `programming.js`.
- **After (this branch):** Identical result — same 1 pre-existing failure, zero new failures.

All 39 other test files pass including `programming-override-validation.test.js`, which exercises the public `setOverride`/`clearOverride` API and the route handler that calls them.

Runtime: ~25 minutes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxrBPUgTvzwViptMYt5zQG)_