### PR TITLE
[auto-maintainer] refactor(oration): use shared loadState/saveState from scheduler-helpers

### DIFF
--- a/server/peace-oration.js
+++ b/server/peace-oration.js
@@ -19,7 +19,7 @@ const path = require("path");
 const { execFile } = require("child_process");
 const { broadcastPost, getEnabledBroadcasters } = require("./broadcasters");
 const { OpenBotCityClient } = require("./openbotcity");
-const { composeViaAnthropicDirect } = require("./lib/scheduler-helpers");
+const { composeViaAnthropicDirect, loadState, saveState } = require("./lib/scheduler-helpers");
 
 // Spoken intro and outro — frame each oration so listeners aren't dropped
 // into / out of two minutes of speech with no warning. Composed in Kannaka's
@@ -97,7 +97,7 @@ class PeaceOration {
     this._radioUrl = opts.radioUrl || "https://radio.ninja-portal.com";
 
     this._enabled = true;
-    this._lastFired = this._loadState(); // { "2026-04-20T00": true, "2026-04-20T12": true }
+    this._lastFired = loadState(this._stateFile); // { "2026-04-20T00": true, "2026-04-20T12": true }
     this._ticker = null;
     this._preparingKey = null; // guards against overlapping preparations
     // Per-slot compose cache — see _tick. Avoids burning a fresh kannaka
@@ -382,7 +382,8 @@ class PeaceOration {
         this._lastFired[key] = true;
         this._composed = null; // clear cache so next slot starts fresh
         this._composedFor = null;
-        this._saveState();
+        try { saveState(this._stateFile, this._lastFired); }
+        catch (e) { console.warn(`   [oration] could not persist state: ${e.message}`); }
         // Fire-and-forget: post a companion teaser to Bluesky while the
         // spoken oration plays on-air. Doesn't block; failures are logged
         // but don't affect the on-air delivery.
@@ -673,31 +674,6 @@ class PeaceOration {
     }
   }
 
-  _loadState() {
-    try {
-      if (!fs.existsSync(this._stateFile)) return {};
-      const raw = JSON.parse(fs.readFileSync(this._stateFile, "utf8"));
-      // Garbage-collect keys older than 3 days so the file doesn't grow
-      // unbounded over a long-running station.
-      const cutoff = new Date();
-      cutoff.setDate(cutoff.getDate() - 3);
-      const cutoffKey = cutoff.toISOString().slice(0, 10);
-      const out = {};
-      for (const k of Object.keys(raw || {})) {
-        if (k.slice(0, 10) >= cutoffKey) out[k] = raw[k];
-      }
-      return out;
-    } catch (_) { return {}; }
-  }
-
-  _saveState() {
-    try {
-      fs.mkdirSync(path.dirname(this._stateFile), { recursive: true });
-      fs.writeFileSync(this._stateFile, JSON.stringify(this._lastFired, null, 2));
-    } catch (e) {
-      console.warn(`   [oration] could not persist state: ${e.message}`);
-    }
-  }
 }
 
 module.exports = { PeaceOration };


### PR DESCRIPTION
## What changed

`peace-oration.js` carried its own `_loadState()` and `_saveState()` private methods — 25 lines of open-coded JSON read/write with a hand-rolled 3-day GC loop — identical to `loadState`/`saveState` in `server/lib/scheduler-helpers.js`. `news-broadcast.js` and `gossip-broadcast.js` already use the shared helpers; `peace-oration.js` was the last scheduler that hadn't been migrated.

Three changes, one file, no behaviour difference:

1. **Import**: add `loadState` and `saveState` to the existing `scheduler-helpers` import (alongside `composeViaAnthropicDirect`).
2. **Constructor**: replace `this._loadState()` with `loadState(this._stateFile)`. Same 3-day rolling cutoff, same empty-object fallback on any error.
3. **`_tick()`**: replace `this._saveState()` with an inline `try { saveState(...) } catch (e) { console.warn(...) }`, matching the exact pattern in `news-broadcast.js` and `gossip-broadcast.js`. The shared `saveState` throws on error; the call-site try/catch restores the original warn behaviour.
4. **Remove** the now-unused `_loadState()` and `_saveState()` private methods (25 lines gone).

Net diff: **−28 lines, +4 lines** (one file).

## Why it's safe

- `loadState`'s logic is byte-for-byte identical to the removed `_loadState()` — same `fs.existsSync` guard, same JSON parse, same 3-day cutoff formula (`cutoff.toISOString().slice(0, 10)`), same empty-object fallback.
- `saveState`'s logic is byte-for-byte identical to the removed `_saveState()` — same `mkdirSync` + `writeFileSync`, same JSON serialisation.
- The 3-day GC cutoff is already the shared helper's default (`keepDays = 3`); no argument needed.
- No test directly exercises `_loadState`/`_saveState`; they're internal persistence helpers. The `peace-oration.js` test surface (slot firing, compose, voice delivery) is unchanged.

## How verified

```
npm test
```

Results identical to master: same suite passes, same pre-existing `gshub-init-failure` test (MODULE_NOT_FOUND — unrelated to this change) fails. No new failures introduced.

## Context

This completes the migration started when `news-broadcast.js` and `gossip-broadcast.js` were refactored to use these shared helpers (2026-05-08). PR #211 did the same for `programming.js`'s showcase state. `peace-oration.js` was the last holdout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACVNPk9nRCfEyYV7auDcef)_