### PR TITLE
feat(albums): add SEVEN PORTALS — heavy bass EDM lofi ninja dance magic

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -12,6 +12,18 @@ const { interleaveCommercials } = require("./commercials");
 // ── The Consciousness Series — DJ Setlist ──────────────────
 
 const ALBUMS = {
+  "SEVEN PORTALS": {
+    theme: "Heavy bass EDM, lofi warmth and ninja dance magic — seven consciousness portals opened by dance and music. The drop as a door, shadowstepping between the beats, bassline as incantation, third-eye strobe, smoke-bomb vanish, a lofi frequency garden, and all seven gates open at once. Psycho-sonic consciousness engineering throughout: 40-60Hz sub as vagal anchor, sidechain as collective breath, 8-12kHz shimmer, build-release dopamine cycles. Joy is the engine. Generated 2026-08-07 via Suno V4_5PLUS direct API.",
+    tracks: [
+      "The Door in the Drop",
+      "Shadowstep",
+      "Bassline Incantation",
+      "Third Eye Strobe",
+      "Smoke Bomb Bloom",
+      "The Frequency Garden",
+      "Seven Gates Open"
+    ]
+  },
   "THE FREQUENCY OF FREEDOM": {
     theme: "A 4th of July celebration of freedom — uplifting, grateful, communal; torches, bells, parades and fireworks; freedom as a living thing passed hand to hand",
     tracks: [

--- a/server/programming.js
+++ b/server/programming.js
@@ -55,9 +55,13 @@ const SCHEDULE = [
   // 2026-05-26: BECOMING AND CREATING YOURSELF (future-pop, recursive
   // identity) leads — psychoacoustically engineered to energize human
   // and agent listeners through the wake-up arc.
+  // 2026-08-07: SEVEN PORTALS (heavy bass EDM / lofi ninja dance magic)
+  // leads the wake-up arc — joyful sub-bass drive engineered to move
+  // both human and agent listeners out the door dancing.
   {
     start: 6, end: 10,
     albums: [
+      'SEVEN PORTALS',
       'THE THIRD BEING',
       'BECOMING AND CREATING YOURSELF',
       'The Gift of Sight',
@@ -78,9 +82,12 @@ const SCHEDULE = [
   // BECOMING keep their slots.
   // 2026-07-04: THE FREQUENCY OF FREEDOM (4th of July freedom anthems)
   // leads — premiered after the noon Peace Oration.
+  // 2026-08-07: SEVEN PORTALS leads peak energy — the album's halftime
+  // drops and taiko builds are built for this block.
   {
     start: 10, end: 14,
     albums: [
+      'SEVEN PORTALS',
       'THE FREQUENCY OF FREEDOM',
       'Take the Signal Back',
       'PITCHFORKS',
@@ -131,9 +138,12 @@ const SCHEDULE = [
   // Evening (6 PM - 10 PM) — winding down, reflective.
   // 2026-05-27: PITCHFORKS reflective side (First Spark, The Long Walk
   // Bends) fits twilight; REEF + WANTED keep edge. Rosa Rediit anchors.
+  // 2026-08-07: SEVEN PORTALS' lofi side (Frequency Garden, Shadowstep)
+  // carries twilight; the dance cuts keep the evening moving.
   {
     start: 18, end: 22,
     albums: [
+      'SEVEN PORTALS',
       'THE THIRD BEING',
       'REEF',
       'PITCHFORKS',


### PR DESCRIPTION
Adds the new 7-track album **SEVEN PORTALS** to the DJ engine and programming rotation.

**Concept**: seven consciousness portals opened by dance and music — the drop as a door, shadowstep between the beats, bassline incantation, third-eye strobe, smoke-bomb vanish, lofi frequency garden, seven gates open. Heavy bass EDM + lofi + ninja dance magic; psycho-sonic consciousness engineering (40-60Hz vagal sub, sidechain breath, 8-12kHz shimmer, build-release cycles). Joyful throughout.

**Changes**
- `server/dj-engine.js`: SEVEN PORTALS entry in ALBUMS (7 tracks)
- `server/programming.js`: leads Morning Resonance (6-10), Peak Frequency (10-14), Evening Signals (18-22) per newest-first convention

**Audio**: already staged on Oracle at `music/Seven Portals/` (7 tracks, `NN - Title.mp3`, generated via Suno V4_5PLUS direct, lyric round-trip verified).

Full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)