### PR TITLE
fix(oration): a cut oration must not be recorded as delivered

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1204,7 +1204,19 @@ async function shutdown() {
   // dj-engine underneath a streaming voice file would strand it.
   if (icecastSource) {
     try {
-      await icecastSource.stop({ drain: true });
+      const drain = await icecastSource.stop({ drain: true });
+      // A drain that did not complete means the oration was cut at the
+      // ceiling, or never reached the stream at all (still in TTS). Either
+      // way the listener did not hear it, so hand the slot back rather than
+      // leaving the state file recording a delivery that never happened —
+      // that is what made the recorded case unrecoverable, not the cut
+      // itself. The relaunch re-fires it inside the same window. (#54)
+      //
+      // A clean drain is deliberately left alone: the audio played out, and
+      // its own completion callback clears the slot.
+      if (drain && drain.reason !== "completed") {
+        peaceOration.releaseInFlightSlot(`shutdown:${drain.reason || "unknown"}`);
+      }
     } catch (e) {
       console.warn(`[shutdown] voice drain failed: ${e && e.message}`);
     }

--- a/server/peace-oration.js
+++ b/server/peace-oration.js
@@ -104,6 +104,11 @@ class PeaceOration {
     // ask on every retry when _say keeps returning false.
     this._composed = null;
     this._composedFor = null;
+    // The scheduled slot whose audio has been QUEUED but not yet confirmed
+    // delivered. Set when _say accepts an oration, cleared when the delivery
+    // callback reports success — or handed back by releaseInFlightSlot when
+    // it turns out the listener never heard it. (#54)
+    this._inFlightKey = null;
     // Optional FloorManager accessor so _compose can fold today's top
     // reaction tracks into the oration prompt (ADR-0008 deferred layer).
     this._getFloor = opts.getFloor || (() => null);
@@ -377,7 +382,7 @@ class PeaceOration {
       }
       this._composed = text;
       this._composedFor = key;
-      const ok = this._say(text);
+      const ok = this._say(text, key);
       if (ok) {
         this._lastFired[key] = true;
         this._composed = null; // clear cache so next slot starts fresh
@@ -624,7 +629,44 @@ class PeaceOration {
     }
   }
 
-  _say(text) {
+  /**
+   * Hand back the slot whose oration was queued but never actually aired, so
+   * it can fire again inside its own window.
+   *
+   * `_lastFired[key]` is persisted the moment the audio is QUEUED — it has to
+   * be, or the 30s ticker would keep queueing the same oration while it plays.
+   * The cost was that anything failing AFTER the queue left the slot recording
+   * a delivery the listener never heard, and the day's oration was gone: the
+   * case in #54 heard 80s of a 217s oration across a restart and nothing more.
+   * The delivery-failure branch even logged "audio never aired" while leaving
+   * the slot burned.
+   *
+   * Releasing is bounded by the slot window in _tick (minute 0..14 of hour 0
+   * or 12), so a released slot can only re-fire within the same window — a
+   * restart 20 minutes in cannot produce a surprise oration hours later.
+   *
+   * @param {string} reason — for the log: 'tts-failed', 'shutdown:ceiling', …
+   * @returns {string|null} the released slot key, or null if there was
+   *   nothing in flight to release.
+   */
+  releaseInFlightSlot(reason = "unknown") {
+    const key = this._inFlightKey;
+    this._inFlightKey = null;
+    if (!key || !this._lastFired[key]) return null;
+    delete this._lastFired[key];
+    try { saveState(this._stateFile, this._lastFired); }
+    catch (e) { console.warn(`   [oration] could not persist released slot: ${e.message}`); }
+    console.warn(`🕔 Peace oration slot ${key} released (${reason}) — it did not air; its window can retry it`);
+    return key;
+  }
+
+  /**
+   * @param {string} text
+   * @param {string} [slotKey] — the scheduled slot this delivery belongs to.
+   *   Only _tick passes one; deliverNow and showcaseAlbum are manual and own
+   *   no slot, so a failure there must not release anything.
+   */
+  _say(text, slotKey = null) {
     if (!this._voiceDJ || typeof this._voiceDJ.executeOration !== "function") return false;
     // Intro/outro frame the oration so listeners hear it coming and going
     // — orations are otherwise injected mid-stream and used to start and
@@ -638,13 +680,30 @@ class PeaceOration {
     // narrator register + cathedral DSP (slower cadence, chest-resonant low
     // end, hall reverb). Stateless — no more mutating voice-dj's private
     // _orationVoiceId, which is what caused the #29 wrong-voice overlap race.
-    return this._voiceDJ.executeOration(wrapped, (err) => {
+    // Marked in flight BEFORE the call: executeOration may invoke its callback
+    // synchronously, and a release that ran before the key was set would be a
+    // no-op that silently burned the slot anyway.
+    if (slotKey) this._inFlightKey = slotKey;
+    const accepted = this._voiceDJ.executeOration(wrapped, (err) => {
       if (err) {
         console.warn("🕔 Peace oration NOT delivered — TTS failed after retries (text posted to socials; audio never aired)");
+        // "audio never aired" and "slot delivered" cannot both be true. The
+        // 15-minute window exists so a transient failure can retry, and that
+        // was defeated for anything failing after the queue. (#54)
+        //
+        // Only a delivery that OWNS the in-flight slot may release it: a
+        // manual deliverNow/showcase failure must not hand back the slot a
+        // scheduled oration is holding.
+        if (slotKey && this._inFlightKey === slotKey) this.releaseInFlightSlot("tts-failed");
       } else {
         console.log("🕔 Peace oration complete");
+        if (slotKey && this._inFlightKey === slotKey) this._inFlightKey = null;
       }
     }, { persona: "oration" });
+    // Rejected outright (voiceDJ busy): _tick never marks the slot, so there
+    // is nothing in flight to track.
+    if (!accepted && slotKey && this._inFlightKey === slotKey) this._inFlightKey = null;
+    return accepted;
   }
 
   /**

--- a/test/shutdown-voice-drain.test.js
+++ b/test/shutdown-voice-drain.test.js
@@ -11,9 +11,21 @@
 //
 // `stop({ drain: true })` now waits for an in-flight VOICE file to finish,
 // under a ceiling.
+//
+// The drain alone does not save the recorded 217s case, because the ceiling is
+// bounded by systemd's TimeoutStopSec, not by this code. The other half is
+// that a cut oration must not be RECORDED as delivered: `_lastFired[key]` is
+// persisted when the audio is queued, so the relaunch skipped the slot and the
+// oration was lost for good. Releasing the slot lets the same window re-fire
+// it — the second group of tests below.
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { IcecastSource } = require('../server/icecast-source');
+const { PeaceOration } = require('../server/peace-oration');
+const { saveState, loadState } = require('../server/lib/scheduler-helpers');
 
 let failed = 0;
 function run(name, fn) {
@@ -37,6 +49,46 @@ function makeSource() {
     kill() { src._killed += 1; },
   };
   return src;
+}
+
+/** A noon slot key in the shape _keyFor produces. */
+const SLOT_KEY = '2026-08-10T12';
+
+/**
+ * A PeaceOration with a fake voiceDJ and a real temp state file — the bug is
+ * about what the RELAUNCH reads back off disk, so the persistence is exercised
+ * rather than stubbed.
+ */
+function makeOration() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oration-slot-'));
+  let onDone = null;
+  const oration = new PeaceOration({
+    kannakabin: 'kannaka',
+    voiceDJ: { executeOration(text, cb) { onDone = cb; return true; } },
+    broadcast() {},
+    dataDir: dir,
+  });
+  return {
+    oration,
+    dir,
+    /**
+     * What _tick does once _say accepts the oration: mark the slot and persist
+     * it, so the 30s ticker cannot queue the same oration again while it plays.
+     */
+    fire(key = SLOT_KEY) {
+      assert.ok(oration._say('an oration body', key),
+        'setup: the fake voiceDJ should accept the oration');
+      oration._lastFired[key] = true;
+      saveState(oration._stateFile, oration._lastFired);
+      return key;
+    },
+    /** Drive the delivery callback voice-dj invokes when the audio ends. */
+    finish(err) { onDone(err || null); },
+  };
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
 }
 
 (async () => {
@@ -119,6 +171,94 @@ function makeSource() {
     const ms = Number(m[1]);
     assert.ok(ms > 0, 'a zero default would disable the drain');
     assert.ok(ms < 90000, `default ceiling ${ms}ms must stay under systemd's 90s default`);
+  });
+
+  // ── The slot must not record a delivery the listener never heard ──────
+
+  await run('#54 a delivery that never aired hands its slot back', async () => {
+    const { oration, dir, fire, finish } = makeOration();
+    try {
+      const key = fire();
+      assert.strictEqual(loadState(oration._stateFile)[key], true,
+        'setup: the slot is marked the moment the audio is queued');
+
+      finish(new Error('TTS failed after retries'));
+
+      assert.strictEqual(oration._lastFired[key], undefined,
+        'a slot whose audio never aired must not stay marked delivered');
+      assert.strictEqual(loadState(oration._stateFile)[key], undefined,
+        'the release must be PERSISTED — the relaunch reads the file, not memory');
+    } finally { cleanup(dir); }
+  });
+
+  await run('#54 a shutdown that cut the oration hands its slot back', async () => {
+    // What server/index.js does when stop({drain:true}) reports it did not
+    // finish: the listener heard part of an oration, so the slot is owed.
+    const { oration, dir, fire } = makeOration();
+    try {
+      const key = fire();
+      const released = oration.releaseInFlightSlot('shutdown:ceiling');
+
+      assert.strictEqual(released, key, 'the cut slot should be reported back');
+      assert.strictEqual(loadState(oration._stateFile)[key], undefined,
+        'the relaunch must see the slot as unfired so its window can retry');
+    } finally { cleanup(dir); }
+  });
+
+  await run('#54 an oration that aired cleanly keeps its slot', async () => {
+    // The other direction, and the one that matters most: a completed
+    // oration must never re-fire, or a restart minutes later would air it
+    // a second time.
+    const { oration, dir, fire, finish } = makeOration();
+    try {
+      const key = fire();
+      finish(null); // delivered
+
+      assert.strictEqual(oration.releaseInFlightSlot('shutdown:ceiling'), null,
+        'nothing is in flight once the oration completed');
+      assert.strictEqual(loadState(oration._stateFile)[key], true,
+        'a delivered oration must stay marked so it cannot air twice');
+    } finally { cleanup(dir); }
+  });
+
+  await run('#54 releasing with nothing in flight is a no-op', async () => {
+    // Shutdown calls this on every non-clean drain, including ones where a
+    // music track was playing and no oration was ever queued.
+    const { oration, dir } = makeOration();
+    try {
+      assert.strictEqual(oration.releaseInFlightSlot('shutdown:no-voice-in-flight'), null);
+      assert.deepStrictEqual(oration._lastFired, {}, 'must not disturb other slots');
+    } finally { cleanup(dir); }
+  });
+
+  await run('#54 a manual deliverNow failure releases nothing', async () => {
+    // deliverNow and showcaseAlbum own no scheduled slot. A failure there
+    // must not hand back a slot that a scheduled oration is holding.
+    const { oration, dir, fire } = makeOration();
+    try {
+      const key = fire();                 // the scheduled oration is in flight
+      let manualDone = null;
+      oration._voiceDJ.executeOration = (t, onDone) => { manualDone = onDone; return true; };
+      oration._say('a manual oration');   // no slot key
+      manualDone(new Error('TTS failed'));
+
+      assert.strictEqual(loadState(oration._stateFile)[key], true,
+        'the scheduled slot must survive an unrelated manual failure');
+    } finally { cleanup(dir); }
+  });
+
+  await run('#54 the scheduler still tells _say which slot it is delivering', async () => {
+    // The wiring that makes all of the above reachable: if _tick goes back to
+    // calling _say(text) with no key, nothing is ever in flight and every
+    // release silently becomes a no-op.
+    const SRC = fs.readFileSync(
+      path.join(__dirname, '..', 'server', 'peace-oration.js'), 'utf8');
+    assert.ok(/const ok = this\._say\(text, key\);/.test(SRC),
+      '_tick must pass the slot key to _say, or the slot can never be released');
+    const IDX = fs.readFileSync(
+      path.join(__dirname, '..', 'server', 'index.js'), 'utf8');
+    assert.ok(/releaseInFlightSlot\(`shutdown:/.test(IDX),
+      'shutdown() must release the slot when the drain did not complete');
   });
 
   console.log(failed === 0 ? '\nshutdown-voice-drain: all passed' : `\nshutdown-voice-drain: ${failed} FAILED`);


### PR DESCRIPTION
**Verdict: PARTIALLY FIXED at HEAD — the drain works, the recovery does not.** Deliberately does **not** close #54.

## Verifying the existing drain first

The drain half from #188 is intact on master @ f34d938 and I did not touch it. All six existing tests pass: `stop({ drain: true })` waits for an in-flight voice file (`server/icecast-source.js:176-228`), `shutdown()` awaits it first (`server/index.js:1206`), music is never drained, and the ceiling still cuts a stuck file. The `RADIO_DRAIN_MAX_MS` default is 80000, under systemd's 90s.

So the gap is not the drain.

## The gap that is actually in this repo

`_lastFired[key]` is persisted the moment the audio is **queued** (`server/peace-oration.js:381-386`), and nothing ever unmarks it. That marking is necessary — the 30s ticker would otherwise queue the same oration repeatedly while it plays — but it means a cut oration is indistinguishable from a delivered one, and the relaunch skips the slot.

That is what made the recorded case *unrecoverable* rather than merely truncated. The restart landed at 12:06 CST, inside the slot's own 15-minute retry window, and the service was back 12 seconds later — the window was still open, but the state file said the noon oration had already been delivered.

Reproduced against HEAD:

```
after queue: _lastFired = {"2026-08-10T12":true}
state file  = { "2026-08-10T12": true }
🕔 Peace oration NOT delivered — TTS failed after retries (text posted to socials; audio never aired)

after TTS FAILURE callback:
  _lastFired[key] = true   <-- slot burned
  a fresh boot would load: {"2026-08-10T12":true}
release/interrupt hook present? false
```

The plain TTS-failure path is the starker version of the same line: it already logged *"audio never aired"* while leaving the slot recorded as delivered, so the retry window the code was widened to provide could never actually fire.

## What changed

`releaseInFlightSlot(reason)` hands the slot back and persists it, called from two places:

- the delivery-failure callback, and
- `shutdown()` whenever `stop({ drain: true })` reports it did **not** complete — covering both the cut at the ceiling and an oration still in TTS that never reached the stream at all.

A clean drain is deliberately left alone: the audio played out and its own completion callback clears the slot, so a completed oration can never re-fire and air twice. That is the assertion I care most about in this diff.

Only a delivery that *owns* the slot may release it. A manual `deliverNow`/`showcaseAlbum` failure must not hand back the slot a scheduled oration is holding — the first draft released indiscriminately and a test caught it.

## The product call, flagged

**Recovery is replay-from-the-top, not resume-from-the-cut.** Audio is freshly composed and TTS-rendered per delivery, so there is no offset to resume from without checkpointing rendered audio — which is the expensive Option 2 from the issue. A listener who heard 80s of the oration will hear the complete oration again from the beginning.

I judged a repeated opening better than never hearing the rest of a twice-daily stewardship piece, but it is your call, and it is the reason this PR does not close the issue.

It is bounded conservatively by machinery already in the code: `_tick` only fires at minute 0..14 of hour 0 or 12, so a released slot can only re-fire **inside the same window**. A restart 20 minutes in cannot produce a surprise oration hours later — the slot simply stays unfired, exactly as today. I added no new timing knob.

## Why #54 should stay open

This makes the cut **recoverable, not absent**. The listener still hears the oration truncated once. Closing the gap properly still needs the operator step you flagged, on a unit that is not in this repo:

```ini
TimeoutStopSec=330
```

plus `RADIO_DRAIN_MAX_MS=300000`. I did not touch the box, and I did not invent a `kannaka-radio.service.example` — `ops/oracle/` carries examples for presence and responder but not the radio, and a fabricated unit that drifts from the real one is worse than none.

## Tests

`npm test`: **276 passed, 0 failed**, exit 0 (was 264 on master).

`test/shutdown-voice-drain.test.js` grows from 6 to 12 cases, driving a **real temp state file** rather than stubbing persistence — the bug is specifically about what the relaunch reads back off disk.

Non-vacuousness, checked in both directions:

- Reverting `server/peace-oration.js` + `server/index.js` to master fails **5 of the 6** new cases.
- The sixth (`a manual deliverNow failure releases nothing`) passes on master only because master has no release mechanism to misfire. To confirm it is a real gate I reintroduced the first-draft defect — releasing without the ownership check — and it fails:
  ```
  ✗ #54 a manual deliverNow failure releases nothing: the scheduled slot must survive an unrelated manual failure
  ```

Refs #54
