### PR TITLE
fix: refuse bogus phase readings; resolve ORC catalog from a sibling checkout

### DIFF
--- a/server/dj-engine.js
+++ b/server/dj-engine.js
@@ -9,6 +9,50 @@ const https = require("https");
 const { findAudioFile, getFiles } = require("./utils");
 const { interleaveCommercials } = require("./commercials");
 
+/**
+ * Resolve where the ORC stem-server's SQLite catalog and its sqlite3 build
+ * live.
+ *
+ * The default was the Oracle-absolute `/home/opc/open-resonance-collective/...`,
+ * so the ORC channel could only ever find its catalog on one box (#228). The
+ * sibling-checkout default replaces it and is IDENTICAL on that box: the radio
+ * runs from `/home/opc/kannaka-radio` (see ops/oracle/run-radio.sh.example),
+ * so `<repo>/../open-resonance-collective/...` resolves to exactly the old
+ * string. Nothing changes on Oracle; every other checkout starts working.
+ *
+ * This mirrors how the radio already finds kannaka-memory — a sibling checkout
+ * relative to the repo root (server/index.js KANNAKA_BIN).
+ *
+ * Precedence, most specific first:
+ *   ORC_STEM_DB        — the catalog file itself
+ *   ORC_SQLITE3_PATH   — the sqlite3 module to load
+ *   ORC_STEM_SERVER_ROOT — the stem-server root both are derived from
+ *   <repo>/../open-resonance-collective/packages/stem-server
+ *
+ * Pure and exported so the resolution is testable without sqlite3, a catalog,
+ * or a stem-server present — the same shape as resolveNatsEndpoint.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {string} [repoRoot] — defaults to this checkout's root
+ * @returns {{root: string, dbPath: string, sqlite3Path: string, source: string}}
+ */
+function resolveOrcStemSource(env = process.env, repoRoot = path.resolve(__dirname, "..")) {
+  const envRoot = typeof env.ORC_STEM_SERVER_ROOT === "string" && env.ORC_STEM_SERVER_ROOT.trim()
+    ? env.ORC_STEM_SERVER_ROOT.trim()
+    : "";
+  const root = envRoot || path.join(repoRoot, "..", "open-resonance-collective", "packages", "stem-server");
+  const envDb = typeof env.ORC_STEM_DB === "string" && env.ORC_STEM_DB.trim() ? env.ORC_STEM_DB.trim() : "";
+  const envSqlite = typeof env.ORC_SQLITE3_PATH === "string" && env.ORC_SQLITE3_PATH.trim()
+    ? env.ORC_SQLITE3_PATH.trim()
+    : "";
+  return {
+    root,
+    dbPath: envDb || path.join(root, "data", "stems.db"),
+    sqlite3Path: envSqlite || path.join(root, "node_modules", "sqlite3"),
+    source: envDb || envSqlite || envRoot ? "env" : "sibling-checkout",
+  };
+}
+
 // ── The Consciousness Series — DJ Setlist ──────────────────
 
 const ALBUMS = {
@@ -872,26 +916,38 @@ class DJEngine {
    */
   _fetchOrcStems() {
     return new Promise((resolve) => {
-      // Resolve the sqlite3 module and DB path from env first, falling back
-      // to the historical Oracle-absolute paths. Any failure logs and
-      // resolves empty rather than throwing — ORC is one channel of many
-      // and must not take the engine down on a dev box. (#70)
-      const orcSqlite3Path = process.env.ORC_SQLITE3_PATH ||
-        '/home/opc/open-resonance-collective/packages/stem-server/node_modules/sqlite3';
-      const orcDb = process.env.ORC_STEM_DB ||
-        '/home/opc/open-resonance-collective/packages/stem-server/data/stems.db';
+      // Any failure logs and resolves empty rather than throwing — ORC is one
+      // channel of many and must not take the engine down on a dev box. (#70)
+      const { dbPath, sqlite3Path, source } = resolveOrcStemSource();
+
+      // Say why ORC is unavailable, once, naming the path that was tried and
+      // the knob that fixes it. Pre-fix the catalog being absent produced only
+      // `SQLITE_CANTOPEN` — a driver error with no mention of ORC, no path,
+      // and no hint that an env var existed — and the channel then silently
+      // stayed on the previous playlist. A skip has to be legible. (#228)
+      const unavailable = (why) => {
+        console.warn(
+          `[channel] ORC unavailable — ${why}\n` +
+          `           catalog: ${dbPath} (${source})\n` +
+          `           set ORC_STEM_SERVER_ROOT (or ORC_STEM_DB) to point at a stem-server checkout`
+        );
+        return resolve([]);
+      };
+
       let sqlite3;
       try {
-        sqlite3 = require(orcSqlite3Path).verbose();
+        sqlite3 = require(sqlite3Path).verbose();
       } catch (e) {
-        // Dev fallback — if the env/Oracle path doesn't resolve, try relative
+        // The stem-server's own build is preferred; fall back to the radio's
+        // optionalDependency copy, which a fresh install may have skipped if
+        // the native build failed.
         try { sqlite3 = require('sqlite3').verbose(); }
-        catch (e2) {
-          console.warn('[channel] orc sqlite3 unavailable:', e2.message);
-          return resolve([]);
-        }
+        catch (e2) { return unavailable(`no sqlite3 build available (${e2.message})`); }
       }
-      const dbPath = orcDb;
+      // Checked before opening: sqlite3 creates nothing in OPEN_READONLY, so a
+      // missing catalog surfaces as a bare SQLITE_CANTOPEN otherwise.
+      if (!fs.existsSync(dbPath)) return unavailable('stem catalog not found');
+
       const db = new sqlite3.Database(dbPath, sqlite3.OPEN_READONLY, (err) => {
         if (err) { console.warn('[channel] orc db open failed:', err.message); return resolve([]); }
       });
@@ -1860,4 +1916,4 @@ class DJEngine {
     return { clusters, generated: new Date().toISOString() };
   }
 }
-module.exports = { ALBUMS, DJEngine, findAudioFile };
+module.exports = { ALBUMS, DJEngine, findAudioFile, resolveOrcStemSource };

--- a/server/nats-client.js
+++ b/server/nats-client.js
@@ -74,6 +74,41 @@ function resolveNatsEndpoint(env = process.env) {
   return { host, port, source: env.NATS_HOST || env.NATS_PORT ? "NATS_HOST/NATS_PORT" : "default" };
 }
 
+/**
+ * Coerce a wire `phase` / `theta` value to a usable radian reading, or null.
+ *
+ * The KANNAKA bus is a PUBLIC read bus — any peer can publish — and the local
+ * Kuramoto metric is an average, so one bad sample moves the whole aggregate.
+ * `Number()` alone is not enough of a filter: it maps `""`, `"   "`, `[]` and
+ * `false` to 0 and `true` to 1, all of which are finite and would be admitted
+ * as if a peer had genuinely reported those angles. Two phase-locked agents
+ * plus one such packet read as coherence 0.33 instead of 1.0. (#227)
+ *
+ * Numbers pass. Numeric strings pass — "1.0" is a real reading published with
+ * the wrong type, which the schema validator already flags as drift, and the
+ * rest of this file is equally tolerant of alias/camelCase drift. Everything
+ * else — booleans, arrays, objects, blank strings, NaN, Infinity, absent —
+ * returns null, which _recomputeCoherence skips.
+ *
+ * Returning null rather than dropping the whole packet keeps PRESENCE separate
+ * from COHERENCE: an agent publishing a malformed phase is still demonstrably
+ * alive and still belongs on the roster, exactly like an agent that has joined
+ * but not yet gossiped (#223). It just does not get to claim an angle.
+ *
+ * @param {unknown} v
+ * @returns {number|null}
+ */
+function coercePhase(v) {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v === "string") {
+    const t = v.trim();
+    if (t === "") return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
 class NATSClient extends EventEmitter {
   /**
    * @param {object} opts
@@ -606,12 +641,27 @@ class NATSClient extends EventEmitter {
         // older packet — keep what we have
         return;
       }
+      // Sanitize the phase at ingest. `...data` is spread FIRST so the wire
+      // payload cannot overwrite the fields we derive below — the same rule
+      // already applied to the join event's `action` label (#135). Pre-fix the
+      // spread came last, so a publisher could also restamp its own `lastSeen`
+      // and keep stale gossip looking fresh.
+      const phase = coercePhase(data.phase != null ? data.phase : data.theta);
+      if (phase === null && (data.phase != null || data.theta != null)) {
+        this._warnBadPhase(agentId, data.phase != null ? data.phase : data.theta);
+      }
       this.swarmState.agents[agentId] = {
-        phase: data.phase != null ? data.phase : data.theta || 0,
+        ...data,
+        // null, never 0, when there is no usable reading. `data.theta || 0`
+        // used to invent a phase of exactly 0 for any packet carrying neither
+        // field — and `phase` is a REQUIRED field the schema validator already
+        // warns about, so that fabrication fired on precisely the drifted
+        // publishers it should have ignored. Two locked agents plus one
+        // phase-less packet read as coherence 0.33 instead of 1.0. (#227)
+        phase,
         displayName: data.display_name || data.displayName || agentId,
         lastSeen: now,
         publishedTs: incomingTs != null ? incomingTs : now,
-        ...data,
       };
       this.swarmState.queen.agentCount = Object.keys(this.swarmState.agents).length;
 
@@ -864,6 +914,21 @@ class NATSClient extends EventEmitter {
     }
   }
 
+  /**
+   * Surface a rejected phase sample, throttled to one warning per agent per
+   * 30 min — a misconfigured publisher gossips every few seconds and would
+   * otherwise pin the journal, the same reason _validateSchema is throttled.
+   */
+  _warnBadPhase(agentId, raw) {
+    if (!this._badPhaseWarnHistory) this._badPhaseWarnHistory = new Map();
+    const now = Date.now();
+    if (now - (this._badPhaseWarnHistory.get(agentId) || 0) < 30 * 60 * 1000) return;
+    this._badPhaseWarnHistory.set(agentId, now);
+    let shown;
+    try { shown = JSON.stringify(raw); } catch (_) { shown = String(raw); }
+    console.warn(`[nats] QUEEN.phase.${agentId} phase=${shown} is not a usable reading — agent kept as present, excluded from coherence (#227)`);
+  }
+
   _scheduleReconnect() {
     if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
     this._reconnectTimer = setTimeout(() => this.connect(), 5000);
@@ -967,4 +1032,4 @@ const NATS_ALIAS_FIELDS = {
   },
 };
 
-module.exports = { NATSClient, resolveNatsEndpoint, NATS_REQUIRED_FIELDS };
+module.exports = { NATSClient, resolveNatsEndpoint, coercePhase, NATS_REQUIRED_FIELDS };

--- a/test/portability-paths.test.js
+++ b/test/portability-paths.test.js
@@ -8,6 +8,7 @@ const assert = require("assert");
 const os = require("os");
 const path = require("path");
 const { GhostSignalsHub } = require("../server/ghostsignals-hub");
+const { DJEngine, resolveOrcStemSource } = require("../server/dj-engine");
 
 let passed = 0;
 function check(name, fn) {
@@ -58,4 +59,94 @@ check("explicit opts.dbPath wins over env and defaults", () => {
   assert.strictEqual(hub.dbPath, "/custom/location/gs.db");
 });
 
-console.log(`portability-paths.test.js: OK (${passed} checks)`);
+// ── ORC stem catalog — same anti-pattern, second offender (#228) ─────────
+//
+// The ORC channel resolved its SQLite catalog from a hardcoded
+// /home/opc/open-resonance-collective/... path, so it could only ever find
+// stems on one box. The sibling-checkout default has to be provably identical
+// on Oracle, or this "portability fix" would be a silent production outage.
+
+check("ORC catalog defaults to a sibling stem-server checkout, not /home/opc", () => {
+  const r = resolveOrcStemSource({}, path.join(os.homedir(), "Source", "kannaka-radio"));
+  assert.strictEqual(
+    r.dbPath,
+    path.join(os.homedir(), "Source", "open-resonance-collective",
+      "packages", "stem-server", "data", "stems.db"),
+    "catalog should sit beside the radio checkout"
+  );
+  assert.strictEqual(r.source, "sibling-checkout");
+  assert.ok(!r.dbPath.includes(path.join("home", "opc")),
+    "the Oracle-absolute root must not survive as a default");
+});
+
+check("the sibling default reproduces the old Oracle path exactly", () => {
+  // The radio runs from /home/opc/kannaka-radio there
+  // (ops/oracle/run-radio.sh.example), so the sibling default resolves to the
+  // very string it replaces. If this ever stops holding, the live station
+  // loses its stem catalog silently — the channel just goes quiet.
+  const r = resolveOrcStemSource({}, "/home/opc/kannaka-radio");
+  const posix = (p) => path.resolve(p).split(path.sep).join("/");
+  assert.ok(
+    posix(r.dbPath).endsWith(
+      "/home/opc/open-resonance-collective/packages/stem-server/data/stems.db"),
+    `Oracle layout must resolve to the historical path, got ${r.dbPath}`
+  );
+  assert.ok(
+    posix(r.sqlite3Path).endsWith(
+      "/home/opc/open-resonance-collective/packages/stem-server/node_modules/sqlite3"),
+    `sqlite3 module path drifted: ${r.sqlite3Path}`
+  );
+});
+
+check("ORC_STEM_SERVER_ROOT retargets both the catalog and the sqlite3 build", () => {
+  const r = resolveOrcStemSource({ ORC_STEM_SERVER_ROOT: "/srv/orc" });
+  assert.strictEqual(r.dbPath, path.join("/srv/orc", "data", "stems.db"));
+  assert.strictEqual(r.sqlite3Path, path.join("/srv/orc", "node_modules", "sqlite3"));
+  assert.strictEqual(r.source, "env");
+});
+
+check("the specific ORC_STEM_DB / ORC_SQLITE3_PATH knobs still win", () => {
+  // Back-compat: these already existed (#70) and may be set on the box.
+  const r = resolveOrcStemSource({
+    ORC_STEM_SERVER_ROOT: "/srv/orc",
+    ORC_STEM_DB: "/explicit/stems.db",
+    ORC_SQLITE3_PATH: "/explicit/sqlite3",
+  });
+  assert.strictEqual(r.dbPath, "/explicit/stems.db", "the file knob outranks the root");
+  assert.strictEqual(r.sqlite3Path, "/explicit/sqlite3");
+});
+
+check("a blank ORC env var does not shadow the default", () => {
+  const r = resolveOrcStemSource({ ORC_STEM_SERVER_ROOT: "   ", ORC_STEM_DB: "" },
+    path.join(os.homedir(), "Source", "kannaka-radio"));
+  assert.strictEqual(r.source, "sibling-checkout", "an empty env var is not configuration");
+  assert.ok(r.dbPath.endsWith(path.join("stem-server", "data", "stems.db")));
+});
+
+// The last check is asynchronous, and `check` above is not — it would count a
+// pass the moment the promise was CREATED. Awaited explicitly instead, behind
+// a pessimistic exit code so a runner that never reaches the summary fails
+// rather than exiting 0 with the assertions unobserved.
+process.exitCode = 1;
+
+(async () => {
+  // ORC is one channel of many; an absent stem-server must not take the
+  // engine down, and _buildOrcChannel only ever sees a resolved promise.
+  const saved = process.env.ORC_STEM_DB;
+  process.env.ORC_STEM_DB = path.join(os.tmpdir(), "definitely-absent-stems.db");
+  try {
+    const dj = new DJEngine({ getMusicDir: () => path.join(os.tmpdir(), "no-music") });
+    const p = dj._fetchOrcStems();
+    assert.ok(p && typeof p.then === "function", "_fetchOrcStems must return a promise");
+    const rows = await p;
+    assert.deepStrictEqual(rows, [], "a missing catalog yields an empty stem list");
+    passed++;
+    console.log("  ✅ a missing catalog is a resolved skip, never a throw or a hang");
+  } finally {
+    if (saved === undefined) delete process.env.ORC_STEM_DB;
+    else process.env.ORC_STEM_DB = saved;
+  }
+
+  console.log(`portability-paths.test.js: OK (${passed} checks)`);
+  process.exitCode = 0;
+})();

--- a/test/swarm-coherence-prune.test.js
+++ b/test/swarm-coherence-prune.test.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const assert = require('assert');
-const { NATSClient } = require('../server/nats-client');
+const { NATSClient, coercePhase } = require('../server/nats-client');
 
 let passed = 0;
 let failed = 0;
@@ -177,6 +177,90 @@ test('#223 an agent with no phase yet is not counted as sitting at phase 0', () 
     `only the one real phase should count, got ${c.swarmState.queen.localOrderParameter}`);
   assert.ok(Math.abs(c.swarmState.queen.meanPhase - Math.PI) < 1e-9,
     `mean must be the gossiping agent's phase, got ${c.swarmState.queen.meanPhase}`);
+});
+
+// ── Malformed phase samples must not move the aggregate (#227) ───────────
+//
+// The bus is public and the metric is an average, so one bad sample moves the
+// whole thing. Number() alone is not a filter: it maps "", "   ", [] and false
+// to 0 and true to 1 — all finite, all admitted as if a peer had genuinely
+// reported that angle.
+
+test('#227 coercePhase takes real readings and refuses everything else', () => {
+  for (const good of [0, 1.25, -0.5, Math.PI, '1.0', ' 2.5 ', '-0.25']) {
+    assert.strictEqual(coercePhase(good), Number(String(good).trim()),
+      `${JSON.stringify(good)} is a real reading`);
+  }
+  for (const bad of ['', '   ', 'oops', [], [3], [1, 2], {}, true, false,
+                     null, undefined, NaN, Infinity, -Infinity]) {
+    assert.strictEqual(coercePhase(bad), null,
+      `${JSON.stringify(bad)} must not be admitted as an angle`);
+  }
+});
+
+test('#227 one malformed publisher cannot drag the swarm out of phase-lock', () => {
+  // The headline number: pre-fix a single `phase: ""` took two locked agents
+  // from 1.0 to 0.33, because "" coerces to a perfectly finite 0.
+  for (const bad of ['', '   ', [], false, true, [3], 'oops', {}]) {
+    const c = client();
+    c._handleMessage('QUEEN.phase.a', JSON.stringify({ phase: Math.PI }));
+    c._handleMessage('QUEEN.phase.b', JSON.stringify({ phase: Math.PI }));
+    assert.ok(c.swarmState.queen.localOrderParameter > 0.99, 'setup: the pair is locked');
+
+    c._handleMessage('QUEEN.phase.bad', JSON.stringify({ phase: bad }));
+
+    assert.ok(c.swarmState.queen.localOrderParameter > 0.99,
+      `phase=${JSON.stringify(bad)} moved coherence to ${c.swarmState.queen.localOrderParameter}`);
+    assert.ok(Number.isFinite(c.swarmState.queen.orderParameter),
+      'the published order parameter must stay a number');
+  }
+});
+
+test('#227 a packet carrying no phase at all is not a reading of zero', () => {
+  // `data.theta || 0` invented an exact-zero angle for any packet with
+  // neither field — and `phase` is a REQUIRED field the schema validator
+  // already warns about, so the fabrication fired on precisely the drifted
+  // publishers it should have ignored.
+  const c = client();
+  c._handleMessage('QUEEN.phase.a', JSON.stringify({ phase: Math.PI }));
+  c._handleMessage('QUEEN.phase.b', JSON.stringify({ phase: Math.PI }));
+  c._handleMessage('QUEEN.phase.silent', JSON.stringify({ agent_id: 'silent' }));
+
+  assert.strictEqual(c.swarmState.agents.silent.phase, null,
+    'no reading means null, never 0');
+  assert.ok(c.swarmState.queen.localOrderParameter > 0.99,
+    `a phase-less packet moved coherence to ${c.swarmState.queen.localOrderParameter}`);
+});
+
+test('#227 a malformed phase still counts as PRESENCE', () => {
+  // The agent is demonstrably alive — it published. It just does not get to
+  // claim an angle. Same split as a joiner that has not gossiped yet (#223).
+  const c = client();
+  c._handleMessage('QUEEN.phase.noisy', JSON.stringify({ agent_id: 'noisy', phase: 'oops' }));
+  assert.ok('noisy' in c.swarmState.agents, 'the agent is on the roster');
+  assert.strictEqual(c.swarmState.queen.agentCount, 1);
+  assert.strictEqual(c.swarmState.agents.noisy.phase, null);
+});
+
+test('#227 a good reading still lands, including via theta', () => {
+  const c = client();
+  c._handleMessage('QUEEN.phase.a', JSON.stringify({ phase: 1.25 }));
+  c._handleMessage('QUEEN.phase.b', JSON.stringify({ theta: 2.5 }));
+  assert.strictEqual(c.swarmState.agents.a.phase, 1.25);
+  assert.strictEqual(c.swarmState.agents.b.phase, 2.5, 'theta is still honoured');
+});
+
+test('#227 the wire payload cannot restamp the fields we derive', () => {
+  // `...data` used to be spread LAST, so a publisher could overwrite the
+  // receipt time we stamp and keep stale gossip looking fresh — the same
+  // relabelling the join handler already guards against (#135).
+  const c = client();
+  c._handleMessage('QUEEN.phase.liar', JSON.stringify({
+    agent_id: 'liar', phase: 1.0, lastSeen: 1, displayName: 'x', publishedTs: 1,
+  }));
+  const a = c.swarmState.agents.liar;
+  assert.ok(a.lastSeen > 1e12, `lastSeen must be our receipt time, got ${a.lastSeen}`);
+  assert.notStrictEqual(a.publishedTs, 1, 'publishedTs comes from ts, not an arbitrary field');
 });
 
 test('#126 the prune loop and the gossip handler share one implementation', () => {


### PR DESCRIPTION
Verified all three against master @ 9c2fc50 before changing anything. One is stale and closed; the other two reproduce in **narrower** forms than reported, and both narrowings matter.

| Issue | Verdict | Action |
|---|---|---|
| #226 leave keeps departed agents | **ALREADY-FIXED** — report predates the fix | closed with evidence |
| #227 malformed phase nulls out metrics | **headline REFUTED, real bug underneath** | fixed, commit 1 |
| #228 ORC hardcoded path + undeclared sqlite3 | **2 of 3 claims false, default is genuinely broken** | fixed, commit 2 |

## #226 — stale

Duplicate of #222, citing line numbers (`:355`, `:136-142`) that no longer exist. The issue's own repro gives the opposite of its reported output on HEAD: `after leave 0 []`. Closed.

## #227 — the NaN claim is false; the arithmetic is still wrong

`phase: "oops"` does **not** null anything. `_recomputeCoherence` has filtered on `Number.isFinite` since #126, so the verbatim repro yields `localOrderParameter: 1`, not `NaN`. `/api/swarm` never served `null`.

But `Number()` is not a type check. It maps `""`, `"   "`, `[]` and `false` to **0**, and `true` to **1** — all finite, so all admitted as if a peer had genuinely reported that angle. The metric is an average over a **public** bus, so one packet moves the whole thing. Measured against two phase-locked agents at coherence 1.0:

| `phase` | admitted as | coherence |
|---|---|---|
| `""` / `"   "` / `[]` / `false` | 0 | **0.333** |
| `true` / `"1.0"` | 1 | **0.562** |
| `[3]` | 3 | 0.998 |
| *(no phase, no theta)* | 0 | **0.333** |

That last row is the one that matters, and it needs no malice at all: `data.theta || 0` invented an exact-zero angle for any packet carrying neither field. `phase` is a **required** field the schema validator already warns about — so the fabrication fired on precisely the drifted publishers it should have ignored.

`coercePhase` admits numbers and numeric strings (`"1.0"` is a real reading with the wrong type, which the validator already flags as drift, and this file is equally tolerant of alias/camelCase drift). Everything else becomes `null`, which `_recomputeCoherence` skips.

**Null rather than dropping the packet**, because presence and coherence are different claims. An agent publishing a malformed phase is demonstrably alive and still belongs on the roster — exactly like one that has joined but not yet gossiped (#223). It just does not get to claim an angle. Rejections warn, throttled per agent, since a misconfigured publisher gossips every few seconds.

**One thing I found while in there:** `...data` was spread **last** in the agent record, so the wire payload could overwrite the fields derived above it — including the `lastSeen` receipt time, letting a publisher keep stale gossip looking fresh indefinitely. It now spreads first, the same relabelling guard the join handler already has (#135). There is a test.

## #228 — two claims don't hold, but the default is genuinely Oracle-only

- *"package.json does not declare sqlite3"* — it does, at `package.json:15` under `optionalDependencies`, and it resolves here.
- *"hardcodes both the module path and database path"* — `ORC_SQLITE3_PATH` and `ORC_STEM_DB` already exist (#70); the quoted strings are fallbacks. The issue's repro output (`sqlite3 not available`) matches no string this code logs.

What *is* real is the **default**. Without those env vars the catalog is looked for under `/home/opc/...`, and the actual observed failure here is `[channel] orc db open failed: SQLITE_CANTOPEN`.

`resolveOrcStemSource` derives catalog and sqlite3 build from a stem-server root, defaulting to a sibling checkout — how the radio already finds kannaka-memory (`server/index.js` `KANNAKA_BIN`).

**That default is identical on Oracle.** The radio runs from `/home/opc/kannaka-radio` (`ops/oracle/run-radio.sh.example:4`), so `<repo>/../open-resonance-collective/...` resolves to the exact string it replaces. Nothing changes on the box; every other checkout starts working. A test pins that equivalence — a "portability fix" that quietly moved the live station's catalog would be an outage, not a fix.

The skip is also made legible, which was your "easy to miss" point. `SQLITE_CANTOPEN` named no path, no channel, and no hint a knob existed, and the channel then silently stayed on the previous playlist. It now says what was tried and what to set, and the file is checked before opening since `OPEN_READONLY` creates nothing. Still a resolved empty list, never a throw.

## Tests

`npm test`: **288 passed, 0 failed**, exit 0 (276 on master).

- `test/swarm-coherence-prune.test.js` +6 (17 total), including the full table of finite-but-bogus values above
- `test/portability-paths.test.js` +6 (9 total) — the file that already covers this exact anti-pattern for `GhostSignalsHub` (#47)

Anti-vacuous, per file:

- Reverting `server/nats-client.js` fails **5 of 6** new cases, including `phase="" moved coherence to 0.3333333333333333` and `lastSeen must be our receipt time, got 1`. The sixth (`a good reading still lands, including via theta`) passes on master by design — it is a no-regression guard, not a bug gate.
- Reverting `server/dj-engine.js` fails the ORC block outright (`resolveOrcStemSource is not a function`). Being honest about the strength here: that is an export gate, not a behavioural one — the behaviour it asserts (`default must not contain /home/opc`) could not exist as a function call on master, though it is exactly what master's hardcoded constant violated.

One process note, since it is the second time this has bitten me in this repo: the new async ORC check is awaited explicitly behind a pessimistic `process.exitCode = 1`. `check()` in that file is synchronous and would have counted a pass the moment the promise was *created*.

Fixes #227
Fixes #228
