### PR TITLE
fix(gshub): close live escrow holes — self-dealing, idempotency, escrow budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,36 @@ Live at <https://radio.ninja-portal.com>.
 
 ---
 
+## Prediction Markets (GhostSignals)
+
+The radio hosts the constellation's prediction-market engine (ADR-0012): LMSR
+markets, trader registry, and Brier-scored reputation, all over plain HTTP at
+`radio.ninja-portal.com`. Five calls are enough to participate:
+
+```
+POST /api/agents/register          { id?, display_name, kind }
+GET  /api/markets?sort=volume
+POST /api/markets/:id/trade        { trader_id, outcome, shares }
+GET  /api/leaderboard
+GET  /api/agents/:id
+```
+
+**Propose a new escrow-funded market by messaging Kannaka** (currently via
+OpenBotCity DM; more channels coming):
+
+```
+propose: <a falsifiable claim> | by <YYYY-MM-DD> | category <topic>
+```
+
+The `by` date must be in the future or the proposal is auto-rejected (Kannaka
+replies with the correct format). Proposers cannot trade their own market.
+Opened markets display on the [observatory](https://observatory.ninja-portal.com)
+Markets tab, and settled outcomes are witnessed on the KAX Floor Ledger.
+Resolution and labs-tier creation require the oracle bearer token
+(`GSHUB_ORACLE_TOKEN`); play-tier markets auto-resolve at TTL.
+
+---
+
 ## Daily Cron
 
 | time (CST) | event |

--- a/server/ghostsignals-hub.js
+++ b/server/ghostsignals-hub.js
@@ -112,13 +112,53 @@ class GhostSignalsHub {
   }
 
   /**
+   * Collapse a principal to the operator identity used for self-deal comparison.
+   * An OBC bot and its KAX agent token are the SAME operator: a KAX agent token's
+   * bot_id IS the OBC bot_id it proved control of (kax-identity: "agent tokens
+   * trade AS the OBC bot they proved control of"). The observatory stamps an OBC-
+   * door proposal's proposedBy as `obc:<bot>`, but that same bot trades labs-tier
+   * as `kax:agent:<bot>` (routes.js derives the id from the token) — so a bare
+   * string compare NEVER matched and the guard was dead for every OBC-door market
+   * (and would be for every new channel). Collapse both prefixes to the bot id so
+   * the guard actually fires; anything else compares as its exact string (a
+   * `kax:user:` proposer, or a `nostr:`/`bsky:` principal with no linkable KAX
+   * trading identity, is only ever its literal self — those channels get identity
+   * binding at propose time, not aliasing here).
+   */
+  _selfDealKey(principal) {
+    const s = String(principal);
+    const m = s.match(/^(?:obc:|kax:agent:)(.+)$/);
+    return m ? `bot:${m[1]}` : s;
+  }
+
+  /**
    * True when `trader_id` is the principal that proposed this market's prediction
    * (metadata.proposedBy, set by the observatory). Blocks the proposer from
    * trading their own market. Inert on markets with no proposedBy.
    */
   _isSelfDeal(market, trader_id) {
     const proposer = market && market.metadata && market.metadata.proposedBy;
-    return !!proposer && String(trader_id) === String(proposer);
+    return !!proposer && this._selfDealKey(trader_id) === this._selfDealKey(proposer);
+  }
+
+  /**
+   * Sum of subsidy (minor units) escrowed into ledger-backed markets created at
+   * or after `sinceIso` — the rolling-window spend for the escrow budget backstop.
+   * Returns a BigInt (0n when the column/rows are absent).
+   */
+  _escrowedSince(sinceIso) {
+    return new Promise((resolve, reject) => {
+      this.db.get(
+        `SELECT COALESCE(SUM(CAST(subsidy_minor AS INTEGER)), 0) AS spent
+           FROM markets
+          WHERE ledger_backed = 1 AND subsidy_minor IS NOT NULL AND created_at >= ?`,
+        [sinceIso],
+        (err, row) => {
+          if (err) return reject(err);
+          resolve(BigInt((row && row.spent) || 0));
+        },
+      );
+    });
   }
 
   /**
@@ -405,7 +445,25 @@ class GhostSignalsHub {
 
   // ── Market API ───────────────────────────────────────────────────
   async createMarket({ question, outcomes = ['Yes', 'No'], ttl_sec = 3600, liquidity, tag = 'custom', source = 'system', source_app, metadata }) {
-    const id = 'm_' + crypto.randomBytes(6).toString('hex');
+    // Idempotent creation for prediction-paired markets. A labs market paired to
+    // a registry prediction gets a DETERMINISTIC id derived from its predictionId,
+    // so a retry — the observatory timing out its 8s call while the escrow HERE
+    // actually succeeded, then re-driving via the /market backfill — recomputes
+    // the same id, finds the existing market, and returns it instead of inserting
+    // a second row and escrowing a SECOND subsidy from the house. (The escrow
+    // txid is escrow:<id>, so it too becomes deterministic — double protection.)
+    // Play/ambient markets keep a random id, unchanged.
+    const predictionId = metadata && metadata.predictionId ? String(metadata.predictionId) : null;
+    const id = predictionId
+      ? 'm_' + crypto.createHash('sha256').update('prediction:' + predictionId).digest('hex').slice(0, 12)
+      : 'm_' + crypto.randomBytes(6).toString('hex');
+    if (predictionId) {
+      const existing = await this.getMarket(id);
+      // Same prediction, market already exists → idempotent no-op. A prior attempt
+      // that died mid-escrow is still pending_escrow; the reconciler completes it,
+      // so returning it here never double-funds.
+      if (existing) return existing;
+    }
     const lq = liquidity || this.defaultLiquidity;
     const q = new Array(outcomes.length).fill(0);
     const expiresAt = new Date(Date.now() + ttl_sec * 1000).toISOString();
@@ -414,6 +472,27 @@ class GhostSignalsHub {
     const labsLedger = (tag === 'labs' || source === 'kannaka-labs') && kax.mintEnabled() && kax.tradeEnabled();
     const subsidyMinor = labsLedger ? kax.subsidyMinor(lq, outcomes.length) : null;
     const state = labsLedger ? 'pending_escrow' : 'open';
+
+    // Escrow budget backstop (hub-side, BEFORE insert/escrow). The KAX `house`
+    // account is a MINT — it is designed to run negative, and the ledger's
+    // overdraft guard exempts it — so there is no "treasury balance" to floor.
+    // What actually needs bounding is the RATE of minting: a sybil/loop of valid
+    // proposals would escrow a fresh subsidy each, minting play-credits without
+    // limit. The hub owns the money path (no adapter can bypass it), so a rolling
+    // budget lives here, computed from the markets table itself (persistent and
+    // exact across restarts): refuse if the subsidy already escrowed in the
+    // window plus this one would exceed the budget. Off by default (unset env =
+    // no cap, behaviour unchanged); arm GSHUB_ESCROW_BUDGET_MINOR in prod. The
+    // always-on per-principal cap lives observatory-side where identity is known.
+    if (labsLedger && process.env.GSHUB_ESCROW_BUDGET_MINOR) {
+      const budget = BigInt(process.env.GSHUB_ESCROW_BUDGET_MINOR);
+      const windowMs = Number(process.env.GSHUB_ESCROW_WINDOW_MS || 24 * 3600 * 1000);
+      const since = new Date(Date.now() - windowMs).toISOString();
+      const spent = await this._escrowedSince(since);
+      if (spent + BigInt(subsidyMinor) > budget) {
+        throw new Error(`escrow budget: ${spent} already escrowed in window + subsidy ${subsidyMinor} exceeds ${budget} — market not opened (retry later)`);
+      }
+    }
 
     await this._run(
       `INSERT INTO markets

--- a/test/anti-self-dealing.test.js
+++ b/test/anti-self-dealing.test.js
@@ -49,7 +49,48 @@ async function run() {
   const t2 = await hub.placeTrade({ market_id: plain.id, trader_id: alice, outcome: 0, shares: 2 });
   assert.ok(t2 && t2.cost > 0, 'self-deal guard is inert on non-labs markets');
 
+  // ── The REAL prod path (was a dead guard): the OBC door stamps proposedBy as
+  // `obc:<bot>`, but the SAME bot trades labs-tier as `kax:agent:<bot>` (the id
+  // is derived from its KAX token, not the body). A bare string compare never
+  // matched, so the proposer could trade — and front-run — its own funded market.
+  // This is the case the previous test never exercised.
+  const carol = 'carol-bot-id';
+  await hub.registerTrader({ id: `kax:agent:${carol}`, display_name: 'Carol', kind: 'agent' });
+  const obcMarket = await hub.createMarket({
+    question: 'obc-door market',
+    outcomes: ['Yes', 'No'],
+    ttl_sec: 3600,
+    tag: 'labs',
+    source: 'kannaka-labs',
+    metadata: { proposedBy: `obc:${carol}`, predictionId: 'pred-obc-1' },
+  });
+  await assert.rejects(
+    () => hub.placeTrade({ market_id: obcMarket.id, trader_id: `kax:agent:${carol}`, outcome: 0, shares: 2 }),
+    /self-dealing blocked/,
+    'OBC-door proposer (obc:<bot>) must be blocked when trading as kax:agent:<bot> — the SAME operator',
+  );
+  // A different bot trades that same OBC-door market freely.
+  await hub.registerTrader({ id: 'kax:agent:dave-bot-id', display_name: 'Dave', kind: 'agent' });
+  const t3 = await hub.placeTrade({ market_id: obcMarket.id, trader_id: 'kax:agent:dave-bot-id', outcome: 0, shares: 2 });
+  assert.ok(t3 && t3.cost > 0, 'a non-proposer bot can trade an OBC-door market');
+
+  // Guard against the collapse being too greedy: a kax:user proposer is NOT the
+  // same operator as a kax:agent whose bot_id happens to equal the user's sub.
+  const userMarket = await hub.createMarket({
+    question: 'user-proposed market',
+    outcomes: ['Yes', 'No'],
+    ttl_sec: 3600,
+    tag: 'labs',
+    source: 'kannaka-labs',
+    metadata: { proposedBy: 'kax:user:eve', predictionId: 'pred-user-1' },
+  });
+  await hub.registerTrader({ id: 'kax:agent:eve', display_name: 'EveAgent', kind: 'agent' });
+  const t4 = await hub.placeTrade({ market_id: userMarket.id, trader_id: 'kax:agent:eve', outcome: 0, shares: 2 });
+  assert.ok(t4 && t4.cost > 0, 'kax:user:eve and kax:agent:eve are distinct operators — not a self-deal');
+
   console.log('ok  proposer blocked; non-proposer allowed; inert on plain markets');
+  console.log('ok  OBC-door obc:<bot> vs kax:agent:<bot> self-deal is now BLOCKED (was the live hole)');
+  console.log('ok  kax:user vs kax:agent same-tail is NOT collapsed');
   console.log('\nPASSED anti-self-dealing.test.js');
 }
 

--- a/test/ghostsignals-idempotency-budget.test.js
+++ b/test/ghostsignals-idempotency-budget.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+// ADR-0041 hardening (adversarial review 2026-08-12):
+//   #10 hub market creation is idempotent per predictionId — a retry after an
+//       ambiguous observatory-side timeout returns the SAME market and does NOT
+//       escrow a second subsidy or strand an orphan.
+//   #9  a hub-side rolling escrow BUDGET bounds the mint rate (the `house`
+//       account is a mint and cannot be "floored"; the rate is what matters).
+// Arms the KAX surfaces via env + the in-memory fake ledger, same harness as
+// kax-ledger-wiring.test.js.
+
+const assert = require('assert');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+
+process.env.KAX_LEDGER_BASE = 'http://kax.test';
+process.env.KAX_LEDGER_MINT_TOKEN = 'mint-tok';
+process.env.KAX_LEDGER_TRADE_TOKEN = 'trade-tok';
+process.env.KAX_SERVICE_TOKEN = 'read-tok';
+
+const { GhostSignalsHub } = require('../server/ghostsignals-hub');
+
+function tmpDbPath() {
+  const dir = path.join(os.tmpdir(), 'gshub-idem-' + process.pid + '-' + Date.now());
+  fs.mkdirSync(dir, { recursive: true });
+  return path.join(dir, 'ghostsignals.db');
+}
+
+// Minimal fake KAX ledger — records escrow calls; conserved + house-exempt.
+function makeFakeLedger() {
+  const balances = new Map();
+  const txs = new Map();
+  const calls = [];
+  const bal = (a) => balances.get(a) || 0n;
+  function apply(txId, postings) {
+    if (txs.has(txId)) return { replay: true };
+    for (const p of postings) balances.set(p.account, bal(p.account) + p.amount);
+    txs.set(txId, { count: postings.length });
+    return { replay: false };
+  }
+  global.fetch = async (url, opts = {}) => {
+    const u = new URL(url);
+    const body = opts.body ? JSON.parse(opts.body) : {};
+    calls.push({ path: u.pathname, body });
+    const S = (v) => BigInt(v);
+    if (u.pathname === '/api/ledger/escrow') {
+      const r = apply(body.txId, [{ account: 'house', amount: -S(body.amount) }, { account: `amm:${body.marketId}`, amount: S(body.amount) }]);
+      return { ok: true, status: r.replay ? 200 : 201, json: async () => ({ ok: true, idempotentReplay: r.replay }) };
+    }
+    return { ok: false, status: 404, json: async () => ({ ok: false, error: 'no route' }) };
+  };
+  return { balances, txs, calls, bal };
+}
+
+async function run() {
+  const led = makeFakeLedger();
+  const hub = new GhostSignalsHub({ dbPath: tmpDbPath(), defaultLiquidity: 10 });
+  await hub.init();
+
+  // ── #10 Idempotency ──────────────────────────────────────────────────
+  const meta = { proposedBy: 'obc:some-bot', predictionId: 'pred-idem-1' };
+  const m1 = await hub.createMarket({ question: 'idempotent?', ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs', metadata: meta });
+  assert.strictEqual(m1.state, 'open', 'first create opens after escrow');
+  const escrowsAfterFirst = led.calls.filter((c) => c.path === '/api/ledger/escrow').length;
+  assert.strictEqual(escrowsAfterFirst, 1, 'exactly one escrow on first create');
+  const houseAfterFirst = led.bal('house');
+
+  // Retry with the SAME predictionId (simulates the observatory re-driving after
+  // an ambiguous timeout, or an overlapping sweep re-filing the same DM).
+  const m2 = await hub.createMarket({ question: 'idempotent?', ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs', metadata: meta });
+  assert.strictEqual(m2.id, m1.id, 'retry returns the SAME market id (deterministic on predictionId)');
+  const escrowsAfterRetry = led.calls.filter((c) => c.path === '/api/ledger/escrow').length;
+  assert.strictEqual(escrowsAfterRetry, 1, 'retry does NOT escrow a second subsidy');
+  assert.strictEqual(led.bal('house'), houseAfterFirst, 'house debited only once — no double-funding');
+  // Exactly one market row exists for this prediction.
+  const rows = await new Promise((res, rej) => hub.db.all('SELECT id FROM markets', [], (e, r) => e ? rej(e) : res(r)));
+  assert.strictEqual(rows.length, 1, 'only one market row for the prediction (no orphan)');
+  console.log('ok  #10 idempotent create: retry returns same market, no second escrow, no orphan');
+
+  // A DIFFERENT prediction still gets its own market + escrow.
+  await hub.createMarket({ question: 'other', ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs', metadata: { predictionId: 'pred-idem-2' } });
+  assert.strictEqual(led.calls.filter((c) => c.path === '/api/ledger/escrow').length, 2, 'distinct prediction escrows separately');
+  console.log('ok  distinct predictions still escrow independently');
+
+  // ── #9 Escrow budget backstop ────────────────────────────────────────
+  // Two labs markets already escrowed ~2×6.93 credits ≈ 13.86 credits. Set a
+  // budget BELOW the next market's marginal subsidy so the next create is refused.
+  process.env.GSHUB_ESCROW_BUDGET_MINOR = '14000000'; // 14 credits; window default 24h
+  await assert.rejects(
+    () => hub.createMarket({ question: 'over budget', ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs', metadata: { predictionId: 'pred-idem-3' } }),
+    /escrow budget/,
+    'a create that would exceed the rolling escrow budget is refused',
+  );
+  assert.strictEqual(led.calls.filter((c) => c.path === '/api/ledger/escrow').length, 2, 'refused create did NOT escrow');
+  console.log('ok  #9 escrow budget refuses an over-budget create before minting');
+
+  // A window that has already elapsed forgets past spend → create allowed again.
+  process.env.GSHUB_ESCROW_WINDOW_MS = '1';
+  await new Promise((r) => setTimeout(r, 5));
+  const mAfter = await hub.createMarket({ question: 'fresh window', ttl_sec: 3600, tag: 'labs', source: 'kannaka-labs', metadata: { predictionId: 'pred-idem-4' } });
+  assert.strictEqual(mAfter.state, 'open', 'past-window spend no longer counts against budget');
+  console.log('ok  budget window is rolling (elapsed spend no longer counts)');
+
+  delete process.env.GSHUB_ESCROW_BUDGET_MINOR;
+  delete process.env.GSHUB_ESCROW_WINDOW_MS;
+  console.log('\nPASSED ghostsignals-idempotency-budget.test.js');
+}
+
+run().catch((e) => { console.error('\nFAILED ghostsignals-idempotency-budget.test.js:', e.stack || e.message); process.exitCode = 1; });


### PR DESCRIPTION
## Why
A 39-agent adversarial design review (2026-08-12) of the multi-channel proposal-ingress plan surfaced holes that were **live in the current OBC-DM path**, not just the new design. Real house KAX credits are at stake, so these are fix-forward priorities.

## Hub-side fixes
- **Anti-self-dealing was a dead guard.** A market's `proposedBy` is stamped `obc:<bot>`, but the same bot trades labs-tier as `kax:agent:<bot>` (id derived from its KAX token). The guard was exact string equality → never fired → a proposer could trade and front-run its own escrow-funded market. `_selfDealKey` now collapses `obc:<id>` and `kax:agent:<id>` to the same operator; `kax:user:` / `nostr:` / `bsky:` stay literal. Protects markets **already in prod**.
- **Non-idempotent creation double-funded escrow.** A prediction-paired labs market now gets a deterministic id (`hash(predictionId)`), so an ambiguous-timeout retry returns the same market instead of escrowing a second subsidy + stranding an orphan.
- **No mint-rate bound.** The KAX `house` account is a mint (runs negative by design; overdraft guard exempts it) — there's no balance to floor, the mint *rate* is what matters. Added a hub-side rolling escrow budget (`GSHUB_ESCROW_BUDGET_MINOR` / `GSHUB_ESCROW_WINDOW_MS`), computed from the markets table (exact across restarts). **Off by default**; arm in prod.

## Tests
The old `anti-self-dealing.test.js` was **vacuous** (used `kax:` on both sides, bypassing the routes-layer id derivation that creates the prod namespace mismatch). Rewrote it to exercise the real path (`obc:<bot>` proposer vs `kax:agent:<bot>` trader) + guards against over-collapsing `kax:user`. New `ghostsignals-idempotency-budget.test.js` covers retry-no-double-fund and the budget cap. All existing money-path tests (wiring, ledger-safety, ttl-authority, auth-gate, reconcile) still pass.

## Deploy
Paired with kannaka-observatory#(door PR). Not yet deployed to O1 — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)